### PR TITLE
✨ type-safe fork/join in builder

### DIFF
--- a/workflow-core/src/task.rs
+++ b/workflow-core/src/task.rs
@@ -1,21 +1,24 @@
 use crate::codec::{Codec, sealed};
 use anyhow::Result;
 use bytes::Bytes;
+use std::collections::HashMap;
 use std::future::Future;
 use std::io::Read;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
-/// Deserialize branch results from length-prefixed format.
+/// Deserialize named branch results from length-prefixed format.
 ///
 /// Format:
 /// - 4 bytes: number of branches (u32, little-endian)
 /// - For each branch:
-///   - 4 bytes: length of branch result (u32, little-endian)
-///   - N bytes: branch result data
-pub fn deserialize_branch_results(bytes: Bytes) -> Result<Vec<Bytes>> {
+///   - 4 bytes: name length (u32, little-endian)
+///   - N bytes: name (UTF-8)
+///   - 4 bytes: data length (u32, little-endian)
+///   - M bytes: data
+pub fn deserialize_named_branch_results(bytes: Bytes) -> Result<HashMap<String, Bytes>> {
     let mut reader = bytes.as_ref();
-    let mut results = Vec::new();
+    let mut results = HashMap::new();
 
     // Read number of branches
     let mut branch_count_bytes = [0u8; 4];
@@ -24,18 +27,92 @@ pub fn deserialize_branch_results(bytes: Bytes) -> Result<Vec<Bytes>> {
 
     // Read each branch result
     for _ in 0..branch_count {
-        // Read length
-        let mut length_bytes = [0u8; 4];
-        reader.read_exact(&mut length_bytes)?;
-        let length = u32::from_le_bytes(length_bytes) as usize;
+        // Read name length
+        let mut name_len_bytes = [0u8; 4];
+        reader.read_exact(&mut name_len_bytes)?;
+        let name_len = u32::from_le_bytes(name_len_bytes) as usize;
+
+        // Read name
+        let mut name_bytes = vec![0u8; name_len];
+        reader.read_exact(&mut name_bytes)?;
+        let name = String::from_utf8(name_bytes)?;
+
+        // Read data length
+        let mut data_len_bytes = [0u8; 4];
+        reader.read_exact(&mut data_len_bytes)?;
+        let data_len = u32::from_le_bytes(data_len_bytes) as usize;
 
         // Read data
-        let mut data = vec![0u8; length];
+        let mut data = vec![0u8; data_len];
         reader.read_exact(&mut data)?;
-        results.push(Bytes::from(data));
+        results.insert(name, Bytes::from(data));
     }
 
     Ok(results)
+}
+
+/// A type-safe map of branch outputs for heterogeneous fork-join.
+///
+/// Each branch can return a different type. Use `get::<T>(name)` to retrieve
+/// a branch's output with the correct type.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// .join("combine", |outputs: BranchOutputs<MyCodec>| async move {
+///     let count: u32 = outputs.get("counter")?;
+///     let name: String = outputs.get("fetch_name")?;
+///     let items: Vec<Item> = outputs.get("load_items")?;
+///     Ok(format!("{}: {} items for {}", count, items.len(), name))
+/// })
+/// ```
+pub struct BranchOutputs<C> {
+    outputs: HashMap<String, Bytes>,
+    codec: Arc<C>,
+}
+
+impl<C> BranchOutputs<C> {
+    /// Create a new BranchOutputs from raw data.
+    pub fn new(outputs: HashMap<String, Bytes>, codec: Arc<C>) -> Self {
+        Self { outputs, codec }
+    }
+
+    /// Get the names of all branches.
+    pub fn branch_names(&self) -> impl Iterator<Item = &str> {
+        self.outputs.keys().map(|s| s.as_str())
+    }
+
+    /// Check if a branch exists.
+    pub fn contains(&self, name: &str) -> bool {
+        self.outputs.contains_key(name)
+    }
+
+    /// Get the number of branches.
+    pub fn len(&self) -> usize {
+        self.outputs.len()
+    }
+
+    /// Check if there are no branches.
+    pub fn is_empty(&self) -> bool {
+        self.outputs.is_empty()
+    }
+}
+
+impl<C: Codec> BranchOutputs<C> {
+    /// Get a branch output by name, deserializing to the requested type.
+    ///
+    /// Returns an error if the branch doesn't exist or deserialization fails.
+    pub fn get<T>(&self, name: &str) -> Result<T>
+    where
+        C: sealed::DecodeValue<T>,
+    {
+        let bytes = self
+            .outputs
+            .get(name)
+            .ok_or_else(|| anyhow::anyhow!("Branch '{}' not found", name))?;
+
+        self.codec.decode(bytes.clone())
+    }
 }
 
 /// A core task is a task that can be run by the workflow runtime.
@@ -109,39 +186,18 @@ where
     })
 }
 
-/// A boxed async function for use in fork branches.
-///
-/// This type alias enables heterogeneous branch closures in `fork()`.
-pub type BoxedBranchFn<I, O> = Box<
-    dyn Fn(I) -> std::pin::Pin<Box<dyn Future<Output = Result<O>> + Send>> + Send + Sync,
->;
+/// A boxed async function for use in fork branches (internal).
+type BoxedBranchFn<I, O> =
+    Box<dyn Fn(I) -> std::pin::Pin<Box<dyn Future<Output = Result<O>> + Send>> + Send + Sync>;
 
-/// A named branch for use with `fork()`.
-pub struct Branch<I, O> {
-    /// The name of the branch.
-    pub name: String,
-    /// The boxed async function to execute.
-    pub func: BoxedBranchFn<I, O>,
+/// A named branch for use with `fork()` (internal).
+pub(crate) struct Branch<I, O> {
+    name: String,
+    func: BoxedBranchFn<I, O>,
 }
 
-/// Create a named branch for use with `fork()`.
-///
-/// This helper boxes the closure to allow different closures in the same fork.
-///
-/// # Example
-///
-/// ```rust,ignore
-/// workflow
-///     .fork(vec![
-///         branch("double", |i: i32| async move { Ok(i * 2) }),
-///         branch("triple", |i: i32| async move { Ok(i * 3) }),
-///         branch("square", |i: i32| async move { Ok(i * i) }),
-///     ])
-///     .join("combine", |results: Vec<i32>| async move {
-///         Ok(results.into_iter().sum())
-///     })
-/// ```
-pub fn branch<F, Fut, I, O>(name: &str, f: F) -> Branch<I, O>
+/// Create a named branch (internal helper used by ForkBuilder).
+pub(crate) fn branch<F, Fut, I, O>(name: &str, f: F) -> Branch<I, O>
 where
     F: Fn(I) -> Fut + Send + Sync + 'static,
     Fut: Future<Output = Result<O>> + Send + 'static,
@@ -154,8 +210,31 @@ where
     }
 }
 
-/// Convert a Branch to an UntypedCoreTask.
-pub fn branch_to_core_task<I, O, C>(branch: Branch<I, O>, codec: Arc<C>) -> UntypedCoreTask
+/// A type-erased branch for heterogeneous fork operations (internal).
+pub(crate) struct ErasedBranch {
+    pub(crate) name: String,
+    pub(crate) task: UntypedCoreTask,
+}
+
+impl<I, O> Branch<I, O> {
+    /// Convert this branch to a type-erased branch.
+    ///
+    /// This is used internally by `fork()` to allow heterogeneous output types.
+    pub fn erase<C>(self, codec: Arc<C>) -> ErasedBranch
+    where
+        I: Send + 'static,
+        O: Send + 'static,
+        C: Codec + sealed::DecodeValue<I> + sealed::EncodeValue<O>,
+    {
+        ErasedBranch {
+            name: self.name.clone(),
+            task: branch_to_core_task(self, codec),
+        }
+    }
+}
+
+/// Convert a Branch to an UntypedCoreTask (internal).
+pub(crate) fn branch_to_core_task<I, O, C>(branch: Branch<I, O>, codec: Arc<C>) -> UntypedCoreTask
 where
     I: Send + 'static,
     O: Send + 'static,
@@ -198,28 +277,23 @@ where
     })
 }
 
-/// Typed join wrapper that deserializes branch results automatically.
+/// Join task wrapper for heterogeneous branch outputs.
 ///
-/// This wrapper receives serialized branch results, deserializes each to the
-/// expected `BranchOutput` type, and passes a `Vec<BranchOutput>` to the user function.
-// Type alias to reduce complexity for clippy
-type TypedJoinPhantom<BranchOutput, JoinOutput, Fut> =
-    PhantomData<fn(Vec<BranchOutput>) -> (JoinOutput, Fut)>;
-
-struct TypedJoinTaskWrapper<F, BranchOutput, JoinOutput, Fut, C> {
+/// This wrapper receives serialized named branch results and passes a
+/// `BranchOutputs` map to the user function for type-safe access.
+#[allow(clippy::type_complexity)]
+struct HeterogeneousJoinTaskWrapper<F, JoinOutput, Fut, C> {
     func: Arc<F>,
     codec: Arc<C>,
-    _phantom: TypedJoinPhantom<BranchOutput, JoinOutput, Fut>,
+    _phantom: PhantomData<fn(BranchOutputs<C>) -> (JoinOutput, Fut)>,
 }
 
-impl<F, BranchOutput, JoinOutput, Fut, C> CoreTask
-    for TypedJoinTaskWrapper<F, BranchOutput, JoinOutput, Fut, C>
+impl<F, JoinOutput, Fut, C> CoreTask for HeterogeneousJoinTaskWrapper<F, JoinOutput, Fut, C>
 where
-    F: Fn(Vec<BranchOutput>) -> Fut + Send + Sync + 'static,
-    BranchOutput: Send + 'static,
+    F: Fn(BranchOutputs<C>) -> Fut + Send + Sync + 'static,
     JoinOutput: Send + 'static,
     Fut: Future<Output = Result<JoinOutput>> + Send + 'static,
-    C: Codec + sealed::DecodeValue<BranchOutput> + sealed::EncodeValue<JoinOutput>,
+    C: Codec + sealed::EncodeValue<JoinOutput> + Send + Sync + 'static,
 {
     type Input = Bytes;
     type Output = Bytes;
@@ -229,36 +303,37 @@ where
         let func = Arc::clone(&self.func);
         let codec = Arc::clone(&self.codec);
         Box::pin(async move {
-            let branch_bytes = deserialize_branch_results(input)?;
+            let named_results = deserialize_named_branch_results(input)?;
+            let branch_outputs = BranchOutputs::new(named_results, codec.clone());
 
-            // Decode each branch result to typed value
-            let typed_results: Vec<BranchOutput> = branch_bytes
-                .into_iter()
-                .map(|b| codec.decode::<BranchOutput>(b))
-                .collect::<Result<Vec<_>>>()?;
-
-            let output = func(typed_results).await?;
+            let output = func(branch_outputs).await?;
             codec.encode(&output)
         })
     }
 }
 
-/// Create a typed join task that automatically deserializes branch results.
+/// Create a join task for heterogeneous branch outputs.
 ///
-/// The join function receives `Vec<BranchOutput>` instead of raw `Bytes`,
-/// providing type safety at the fork-join boundary.
-pub fn to_typed_join_task<F, BranchOutput, JoinOutput, Fut, C>(
-    func: F,
-    codec: Arc<C>,
-) -> UntypedCoreTask
+/// The join function receives `BranchOutputs<C>` which allows type-safe
+/// retrieval of each branch's output by name.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// .join("combine", |outputs: BranchOutputs<MyCodec>| async move {
+///     let count: u32 = outputs.get("counter")?;
+///     let name: String = outputs.get("fetch_name")?;
+///     Ok(format!("{} - {}", name, count))
+/// })
+/// ```
+pub fn to_heterogeneous_join_task<F, JoinOutput, Fut, C>(func: F, codec: Arc<C>) -> UntypedCoreTask
 where
-    F: Fn(Vec<BranchOutput>) -> Fut + Send + Sync + 'static,
-    BranchOutput: Send + 'static,
+    F: Fn(BranchOutputs<C>) -> Fut + Send + Sync + 'static,
     JoinOutput: Send + 'static,
     Fut: Future<Output = Result<JoinOutput>> + Send + 'static,
-    C: Codec + sealed::DecodeValue<BranchOutput> + sealed::EncodeValue<JoinOutput>,
+    C: Codec + sealed::EncodeValue<JoinOutput> + Send + Sync + 'static,
 {
-    Box::new(TypedJoinTaskWrapper {
+    Box::new(HeterogeneousJoinTaskWrapper {
         func: Arc::new(func),
         codec,
         _phantom: PhantomData,


### PR DESCRIPTION
#8 

Compile-time safe workflow build:
  - prevent misuse of `branch()` , `branches`, `join`, `build`
  - Guarantees input-output types soundness

The typestate pattern enforces correct usage at compile time:
  | Method     | Available on      | Returns           |
  |------------|-------------------|-------------------|
  | `then`     | `WorkflowBuilder` | `WorkflowBuilder` |
  | `branches` | `WorkflowBuilder` | `ForkBuilder`     |
  | `build`    | `WorkflowBuilder` | `Workflow`        |
  | `branch`   | `ForkBuilder`     | `ForkBuilder`     |
  | `join`     | `ForkBuilder`     | `WorkflowBuilder` |
  

## Compile-time guarantees:
  - Can't build without joining first (no build on ForkBuilder)
  - Can't then after fork without joining (no then on ForkBuilder)
  - Can't join without forking first (no join on WorkflowBuilder)
  - Must complete fork-join before continuing the chain