### PR TITLE
⬆️ bump napi-rs to v3 with full migration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: integration-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   changes:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,9 +442,9 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "convert_case"
-version = "0.6.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -579,13 +579,19 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.2.9"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
+checksum = "424e0138278faeb2b401f174ad17e715c829512d74f3d1e81eb43365c2e0590e"
 dependencies = [
- "quote",
- "syn",
+ "ctor-proc-macro",
+ "dtor",
 ]
+
+[[package]]
+name = "ctor-proc-macro"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "darling"
@@ -716,6 +722,21 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "dtor"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "404d02eeb088a82cfd873006cb713fe411306c7d182c344905e101fb1167d301"
+dependencies = [
+ "dtor-proc-macro",
+]
+
+[[package]]
+name = "dtor-proc-macro"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 
 [[package]]
 name = "dyn-clone"
@@ -1480,9 +1501,9 @@ checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
 name = "libloading"
-version = "0.8.9"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
 dependencies = [
  "cfg-if",
  "windows-link",
@@ -1603,15 +1624,17 @@ dependencies = [
 
 [[package]]
 name = "napi"
-version = "2.16.17"
+version = "3.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55740c4ae1d8696773c78fdafd5d0e5fe9bc9f1b071c7ba493ba5c413a9184f3"
+checksum = "e6944d0bf100571cd6e1a98a316cdca262deb6fccf8d93f5ae1502ca3fc88bd3"
 dependencies = [
  "bitflags",
  "ctor",
- "napi-derive",
+ "futures",
+ "napi-build",
  "napi-sys",
- "once_cell",
+ "nohash-hasher",
+ "rustc-hash",
  "serde",
  "serde_json",
  "tokio",
@@ -1625,12 +1648,12 @@ checksum = "d376940fd5b723c6893cd1ee3f33abbfd86acb1cd1ec079f3ab04a2a3bc4d3b1"
 
 [[package]]
 name = "napi-derive"
-version = "2.16.13"
+version = "3.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cbe2585d8ac223f7d34f13701434b9d5f4eb9c332cccce8dee57ea18ab8ab0c"
+checksum = "2c914b5e420182bfb73504e0607592cdb8e2e21437d450883077669fb72a114d"
 dependencies = [
- "cfg-if",
  "convert_case",
+ "ctor",
  "napi-derive-backend",
  "proc-macro2",
  "quote",
@@ -1639,27 +1662,31 @@ dependencies = [
 
 [[package]]
 name = "napi-derive-backend"
-version = "1.0.75"
+version = "5.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1639aaa9eeb76e91c6ae66da8ce3e89e921cd3885e99ec85f4abacae72fc91bf"
+checksum = "f0864cf6a82e2cfb69067374b64c9253d7e910e5b34db833ed7495dda56ccb18"
 dependencies = [
  "convert_case",
- "once_cell",
  "proc-macro2",
  "quote",
- "regex",
  "semver",
  "syn",
 ]
 
 [[package]]
 name = "napi-sys"
-version = "2.4.0"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "427802e8ec3a734331fec1035594a210ce1ff4dc5bc1950530920ab717964ea3"
+checksum = "8eb602b84d7c1edae45e50bbf1374696548f36ae179dfa667f577e384bb90c2b"
 dependencies = [
  "libloading",
 ]
+
+[[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "num"
@@ -2477,7 +2504,7 @@ dependencies = [
 
 [[package]]
 name = "sayiir-core"
-version = "0.1.0-alpha.8"
+version = "0.1.0-alpha.9"
 dependencies = [
  "bytes",
  "chrono",
@@ -2492,7 +2519,7 @@ dependencies = [
 
 [[package]]
 name = "sayiir-integration-tests"
-version = "0.1.0-alpha.8"
+version = "0.1.0-alpha.9"
 dependencies = [
  "bytes",
  "sayiir-core",
@@ -2510,7 +2537,7 @@ dependencies = [
 
 [[package]]
 name = "sayiir-macros"
-version = "0.1.0-alpha.8"
+version = "0.1.0-alpha.9"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -2521,7 +2548,7 @@ dependencies = [
 
 [[package]]
 name = "sayiir-node"
-version = "0.1.0-alpha.8"
+version = "0.1.0-alpha.9"
 dependencies = [
  "bytes",
  "chrono",
@@ -2539,7 +2566,7 @@ dependencies = [
 
 [[package]]
 name = "sayiir-persistence"
-version = "0.1.0-alpha.8"
+version = "0.1.0-alpha.9"
 dependencies = [
  "bytes",
  "chrono",
@@ -2550,7 +2577,7 @@ dependencies = [
 
 [[package]]
 name = "sayiir-postgres"
-version = "0.1.0-alpha.8"
+version = "0.1.0-alpha.9"
 dependencies = [
  "bytes",
  "chrono",
@@ -2569,7 +2596,7 @@ dependencies = [
 
 [[package]]
 name = "sayiir-py"
-version = "0.1.0-alpha.8"
+version = "0.1.0-alpha.9"
 dependencies = [
  "bytes",
  "chrono",
@@ -2586,7 +2613,7 @@ dependencies = [
 
 [[package]]
 name = "sayiir-runtime"
-version = "0.1.0-alpha.8"
+version = "0.1.0-alpha.9"
 dependencies = [
  "backon",
  "bytecheck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ resolver = "2"
 exclude = ["examples/hello-world-rs", "examples/background-jobs-rs"]
 
 [workspace.package]
-version = "0.1.0-alpha.8"
+version = "0.1.0-alpha.9"
 authors = ["Yacine Bouraoui <ybsoft2011@live.com>"]
 edition = "2024"
 license = "MIT"
@@ -29,14 +29,18 @@ lto = true
 codegen-units = 1
 
 [workspace.dependencies]
-sayiir-core = { version = "0.1.0-alpha.8", path = "sayiir-core", default-features = false }
-sayiir-persistence = { version = "0.1.0-alpha.8", path = "sayiir-persistence" }
-sayiir-runtime = { version = "0.1.0-alpha.8", path = "sayiir-runtime", default-features = false }
-sayiir-postgres = { version = "0.1.0-alpha.8", path = "sayiir-postgres" }
-sayiir-macros = { version = "0.1.0-alpha.8", path = "sayiir-macros" }
+sayiir-core = { version = "0.1.0-alpha.9", path = "sayiir-core", default-features = false }
+sayiir-persistence = { version = "0.1.0-alpha.9", path = "sayiir-persistence" }
+sayiir-runtime = { version = "0.1.0-alpha.9", path = "sayiir-runtime", default-features = false }
+sayiir-postgres = { version = "0.1.0-alpha.9", path = "sayiir-postgres" }
+sayiir-macros = { version = "0.1.0-alpha.9", path = "sayiir-macros" }
 tracing = "0.1"
 bytes = { version = "1", features = ["serde"] }
-chrono = { version = "0.4", default-features = false, features = ["std", "serde", "clock"] }
+chrono = { version = "0.4", default-features = false, features = [
+    "std",
+    "serde",
+    "clock",
+] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 rkyv = { version = "0.8", features = ["std", "bytecheck"] }

--- a/README.md
+++ b/README.md
@@ -54,12 +54,8 @@ async fn send_email(user: User) -> Result<(), BoxError> {
     email_service.send_welcome(&user).await
 }
 
-// Register and compose
-let mut registry = TaskRegistry::new();
-FetchUser::register(&mut registry, codec.clone(), FetchUser::new());
-SendEmail::register(&mut registry, codec.clone(), SendEmail::new());
-
-let workflow = workflow!("welcome", JsonCodec, registry,
+// Compose — workflow! auto-registers all tasks
+let workflow = workflow!("welcome", JsonCodec, TaskRegistry::new(),
     fetch_user => send_email
 ).unwrap();
 

--- a/sayiir-node/Cargo.toml
+++ b/sayiir-node/Cargo.toml
@@ -11,8 +11,8 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-napi = { version = "2", features = ["napi9", "async", "tokio_rt", "serde-json"] }
-napi-derive = "2"
+napi = { version = "3", features = ["napi9", "async", "tokio_rt", "serde-json"] }
+napi-derive = "3"
 bytes = { workspace = true }
 chrono = { workspace = true }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread"] }

--- a/sayiir-node/src/codec.rs
+++ b/sayiir-node/src/codec.rs
@@ -16,20 +16,16 @@
 //! object where each value is individually JSON-decoded.
 
 use bytes::Bytes;
+use napi::Env;
 use napi::bindgen_prelude::*;
-use napi::{Env, JsFunction, JsObject, JsUnknown};
 use sayiir_core::branch_results::NamedBranchResults;
 
-/// Encodes a JavaScript value to JSON bytes via `JSON.stringify`.
-pub fn encode_js_value(env: &Env, value: &JsUnknown) -> Result<Bytes> {
-    let global = env.get_global()?;
-    let json: JsObject = global.get_named_property("JSON")?;
-    let stringify_fn: JsFunction = json.get_named_property("stringify")?;
-    let stringify_result = stringify_fn
-        .call(Some(&json), &[value])?
-        .coerce_to_string()?;
-    let json_str = stringify_result.into_utf8()?.into_owned()?;
-    Ok(Bytes::from(json_str))
+/// Encodes a JavaScript value to JSON bytes via N-API serde bridge.
+pub fn encode_js_value(env: &Env, value: Unknown) -> Result<Bytes> {
+    let serde_val: serde_json::Value = env.from_js_value(value)?;
+    let json_bytes = serde_json::to_vec(&serde_val)
+        .map_err(|e| Error::new(Status::GenericFailure, e.to_string()))?;
+    Ok(Bytes::from(json_bytes))
 }
 
 /// Decodes JSON bytes to a JavaScript value.
@@ -37,41 +33,35 @@ pub fn encode_js_value(env: &Env, value: &JsUnknown) -> Result<Bytes> {
 /// Branch results (fork/join) are checked first because `serialize_branch_results`
 /// produces serde-JSON that `JSON.parse` would parse as an array-of-arrays
 /// instead of the object that JS join tasks expect.
-pub fn decode_to_js_value(env: &Env, bytes: &Bytes) -> Result<JsUnknown> {
+pub fn decode_to_js_value<'env>(env: &'env Env, bytes: &Bytes) -> Result<Unknown<'env>> {
     // Try branch results first
     if let Ok(named) = serde_json::from_slice::<NamedBranchResults>(bytes)
         && !named.is_empty()
     {
-        return decode_branch_results_to_js_object(env, &named);
+        return decode_branch_results(env, &named);
     }
 
     // Regular JSON path for normal task inputs
-    let json_str =
-        std::str::from_utf8(bytes).map_err(|e| Error::new(Status::InvalidArg, e.to_string()))?;
-    json_parse(env, json_str)
-}
-
-/// Call `JSON.parse(str)` and return the result.
-fn json_parse(env: &Env, s: &str) -> Result<JsUnknown> {
-    let global = env.get_global()?;
-    let json: JsObject = global.get_named_property("JSON")?;
-    let parse_fn: JsFunction = json.get_named_property("parse")?;
-    let js_str = env.create_string(s)?;
-    parse_fn.call(Some(&json), &[js_str])
+    let serde_val: serde_json::Value =
+        serde_json::from_slice(bytes).map_err(|e| Error::new(Status::InvalidArg, e.to_string()))?;
+    env.to_js_value(&serde_val)
 }
 
 /// Converts deserialized `NamedBranchResults` into a JS object.
 ///
 /// Each branch value is individually JSON-decoded.
-fn decode_branch_results_to_js_object(env: &Env, named: &NamedBranchResults) -> Result<JsUnknown> {
-    let mut obj = env.create_object()?;
+fn decode_branch_results<'env>(
+    env: &'env Env,
+    named: &NamedBranchResults,
+) -> Result<Unknown<'env>> {
+    let mut obj = Object::new(env)?;
 
     for (name, data) in named.as_slice() {
-        let json_str =
-            std::str::from_utf8(data).map_err(|e| Error::new(Status::InvalidArg, e.to_string()))?;
-        let val = json_parse(env, json_str)?;
-        obj.set_named_property(name, val)?;
+        let serde_val: serde_json::Value = serde_json::from_slice(data)
+            .map_err(|e| Error::new(Status::InvalidArg, e.to_string()))?;
+        let js_val: Unknown = env.to_js_value(&serde_val)?;
+        obj.set(name.as_str(), js_val)?;
     }
 
-    Ok(obj.into_unknown())
+    obj.into_unknown(env)
 }

--- a/sayiir-node/src/durable_engine.rs
+++ b/sayiir-node/src/durable_engine.rs
@@ -4,8 +4,8 @@
 //! to the Rust checkpointing runtime. Supports run, resume, cancel, pause, and signals.
 
 use bytes::Bytes;
+use napi::Env;
 use napi::bindgen_prelude::*;
-use napi::{Env, JsObject, JsUnknown};
 use napi_derive::napi;
 use std::sync::Arc;
 
@@ -161,10 +161,10 @@ impl NapiDurableEngine {
         env: Env,
         workflow: &NapiWorkflow,
         instance_id: String,
-        input: JsUnknown,
-        task_registry: JsObject,
+        input: Unknown,
+        task_registry: Object,
     ) -> Result<NapiWorkflowStatus> {
-        let input_bytes = encode_js_value(&env, &input)?;
+        let input_bytes = encode_js_value(&env, input)?;
         let continuation = Arc::clone(&workflow.continuation);
         let definition_hash = workflow.definition_hash.clone();
         let first_task_id = continuation.first_task_id().to_string();
@@ -218,7 +218,7 @@ impl NapiDurableEngine {
         env: Env,
         workflow: &NapiWorkflow,
         instance_id: String,
-        task_registry: JsObject,
+        task_registry: Object,
     ) -> Result<NapiWorkflowStatus> {
         let continuation = Arc::clone(&workflow.continuation);
         let definition_hash = workflow.definition_hash.clone();
@@ -325,9 +325,9 @@ impl NapiDurableEngine {
         env: Env,
         instance_id: String,
         signal_name: String,
-        payload: JsUnknown,
+        payload: Unknown,
     ) -> Result<()> {
-        let payload_bytes = encode_js_value(&env, &payload)?;
+        let payload_bytes = encode_js_value(&env, payload)?;
         tracing::info!(%instance_id, %signal_name, "sending external signal");
         with_backend!(self, |backend| {
             self.runtime
@@ -370,15 +370,28 @@ struct SendEnv(napi::sys::napi_env);
 unsafe impl Send for SendEnv {}
 unsafe impl Sync for SendEnv {}
 
+/// Wrapper around `ObjectRef` that we assert is `Send`+`Sync`.
+///
+/// SAFETY: Same invariant as `SendEnv` — only safe when execution stays on the
+/// main JS thread via `current_thread` tokio runtime with `block_on`.
+///
+/// `LEAK_CHECK = false` because this ref is intentionally held for the duration
+/// of the engine call and cleaned up by the GC when the closure is dropped.
+struct SendObjectRef(ObjectRef<false>);
+unsafe impl Send for SendObjectRef {}
+unsafe impl Sync for SendObjectRef {}
+
 /// Build the task executor callback for `execute_continuation_with_checkpointing`.
 ///
 /// Since we use `current_thread` runtime with `block_on`, the executor never
 /// crosses threads. We wrap the raw env pointer in a `SendEnv` to satisfy
 /// the Send+Sync bounds.
+///
+/// We use `ObjectRef` to hold the task registry across async boundaries.
 #[allow(clippy::type_complexity)]
 fn make_task_executor(
     env: &Env,
-    task_registry: &JsObject,
+    task_registry: &Object,
 ) -> impl Fn(
     &str,
     Bytes,
@@ -390,10 +403,10 @@ fn make_task_executor(
 > + Send
 + Sync {
     let send_env = Arc::new(SendEnv(env.raw()));
-    let registry_ref = env
-        .create_reference(task_registry)
+    let registry_ref = task_registry
+        .create_ref()
         .unwrap_or_else(|_| panic!("Failed to create reference to task registry"));
-    let registry_ref = Arc::new(registry_ref);
+    let registry_ref = Arc::new(SendObjectRef(registry_ref));
 
     move |task_id: &str,
           task_input: Bytes|
@@ -411,12 +424,14 @@ fn make_task_executor(
         Box::pin(async move {
             // SAFETY: We know we're on the main JS thread because we use
             // current_thread runtime with block_on.
-            let env = unsafe { Env::from_raw(send_env.0) };
-            let registry: JsObject = env.get_reference_value(&registry_ref).map_err(
-                |e| -> sayiir_core::error::BoxError {
-                    format!("Failed to get registry reference: {e}").into()
-                },
-            )?;
+            let env = Env::from_raw(send_env.0);
+            let registry: Object =
+                registry_ref
+                    .0
+                    .get_value(&env)
+                    .map_err(|e| -> sayiir_core::error::BoxError {
+                        format!("Failed to get registry reference: {e}").into()
+                    })?;
 
             crate::engine::execute_js_task(&env, &task_id, &task_input, &registry)
                 .map_err(|e| -> sayiir_core::error::BoxError { e.to_string().into() })

--- a/sayiir-node/src/engine.rs
+++ b/sayiir-node/src/engine.rs
@@ -15,8 +15,8 @@
 //! naturally between steps.
 
 use bytes::Bytes;
+use napi::Env;
 use napi::bindgen_prelude::*;
-use napi::{Env, JsFunction, JsObject, JsUnknown};
 use napi_derive::napi;
 use std::sync::Arc;
 
@@ -44,20 +44,20 @@ impl NapiWorkflowEngine {
     /// All tasks must return plain values (not Promises). For async tasks,
     /// use the stepper-based `runWorkflow()` from TypeScript instead.
     #[napi]
-    pub fn run(
+    pub fn run<'env>(
         &self,
-        env: Env,
+        env: &'env Env,
         workflow: &NapiWorkflow,
-        input: JsUnknown,
-        task_registry: JsObject,
-    ) -> Result<JsUnknown> {
-        let input_bytes = encode_js_value(&env, &input)?;
+        input: Unknown,
+        task_registry: Object,
+    ) -> Result<Unknown<'env>> {
+        let input_bytes = encode_js_value(env, input)?;
         let continuation = Arc::clone(&workflow.continuation);
 
         tracing::info!(workflow_id = %workflow.workflow_id, "starting workflow execution");
 
         let result = execute_continuation_sync(&continuation, input_bytes, &|task_id, input| {
-            execute_js_task(&env, task_id, &input, &task_registry).map_err(|e| {
+            execute_js_task(env, task_id, &input, &task_registry).map_err(|e| {
                 let msg: sayiir_core::error::BoxError = e.to_string().into();
                 msg
             })
@@ -66,7 +66,7 @@ impl NapiWorkflowEngine {
 
         tracing::info!(workflow_id = %workflow.workflow_id, "workflow execution completed");
 
-        decode_to_js_value(&env, &result)
+        decode_to_js_value(env, &result)
     }
 }
 
@@ -78,21 +78,22 @@ pub(crate) fn execute_js_task(
     env: &Env,
     task_id: &str,
     input: &Bytes,
-    registry: &JsObject,
+    registry: &Object,
 ) -> Result<Bytes> {
-    let callable: JsFunction = registry.get_named_property(task_id).map_err(|_| {
-        Error::new(
-            Status::GenericFailure,
-            format!("Task '{task_id}' not found in registry"),
-        )
-    })?;
+    let callable: Function<Unknown, Unknown> =
+        registry.get_named_property(task_id).map_err(|_| {
+            Error::new(
+                Status::GenericFailure,
+                format!("Task '{task_id}' not found in registry"),
+            )
+        })?;
 
     tracing::debug!(task_id, input_bytes = input.len(), "executing js task");
 
     let input_obj = decode_to_js_value(env, input)?;
-    let result: JsUnknown = callable.call(None, &[input_obj])?;
+    let result: Unknown = callable.call(input_obj)?;
 
-    if is_promise(&result)? {
+    if is_promise(env, &result)? {
         return Err(Error::new(
             Status::GenericFailure,
             format!(
@@ -104,19 +105,20 @@ pub(crate) fn execute_js_task(
     }
 
     tracing::debug!(task_id, "js task completed");
-    encode_js_value(env, &result)
+    encode_js_value(env, result)
 }
 
 /// Check if a JS value is a Promise (has a `.then` property that is a function).
-fn is_promise(value: &JsUnknown) -> Result<bool> {
+fn is_promise(_env: &Env, value: &Unknown) -> Result<bool> {
     let value_type = value.get_type()?;
     if value_type != ValueType::Object {
         return Ok(false);
     }
-    let obj = unsafe { value.cast::<JsObject>() };
-    match obj.get_named_property::<JsUnknown>("then") {
-        Ok(then_val) => Ok(then_val.get_type()? == ValueType::Function),
-        Err(_) => Ok(false),
+    // SAFETY: We just checked the value type is Object.
+    let obj: Object = unsafe { value.cast() }?;
+    match obj.get::<Unknown>("then") {
+        Ok(Some(then_val)) => Ok(then_val.get_type()? == ValueType::Function),
+        _ => Ok(false),
     }
 }
 
@@ -194,8 +196,8 @@ pub struct NapiContinuationStepper {
 impl NapiContinuationStepper {
     /// Create a new stepper from a workflow and input.
     #[napi(constructor)]
-    pub fn new(env: Env, workflow: &NapiWorkflow, input: JsUnknown) -> Result<Self> {
-        let input_bytes = encode_js_value(&env, &input)?;
+    pub fn new(env: Env, workflow: &NapiWorkflow, input: Unknown) -> Result<Self> {
+        let input_bytes = encode_js_value(&env, input)?;
 
         let mut steps = Vec::new();
         Self::flatten(&workflow.continuation, &mut steps)?;
@@ -229,8 +231,8 @@ impl NapiContinuationStepper {
 
     /// Submit a task result and advance to the next step.
     #[napi]
-    pub fn submit_result(&mut self, env: Env, output: JsUnknown) -> Result<NapiStepResult> {
-        let output_bytes = encode_js_value(&env, &output)?;
+    pub fn submit_result(&mut self, env: Env, output: Unknown) -> Result<NapiStepResult> {
+        let output_bytes = encode_js_value(&env, output)?;
         self.current_input = output_bytes;
 
         // Move past the just-completed task.

--- a/sayiir-node/src/lib.rs
+++ b/sayiir-node/src/lib.rs
@@ -13,7 +13,7 @@
     // napi-derive generates these
     clippy::module_name_repetitions,
     clippy::cast_possible_truncation,
-    // &Env is idiomatic in napi-rs even though Env is Copy
+    // napi-rs generated code may trigger this
     clippy::trivially_copy_pass_by_ref,
 )]
 

--- a/sayiir-node/src/worker.rs
+++ b/sayiir-node/src/worker.rs
@@ -6,7 +6,7 @@
 
 use bytes::Bytes;
 use napi::bindgen_prelude::*;
-use napi::threadsafe_function::{ErrorStrategy, ThreadsafeFunction};
+use napi::threadsafe_function::ThreadsafeFunction;
 use napi_derive::napi;
 use std::sync::Arc;
 use std::time::Duration;
@@ -101,7 +101,10 @@ impl NapiWorker {
     pub fn start(
         &self,
         workflows: Vec<&NapiWorkflow>,
-        #[napi(ts_arg_type = "(payload: string) => Promise<string>")] task_executor: JsFunction,
+        #[napi(ts_arg_type = "(payload: string) => Promise<string>")] task_executor: Function<
+            String,
+            Promise<String>,
+        >,
     ) -> Result<NapiWorkerHandle> {
         let external_workflows: WorkflowIndex = workflows
             .iter()
@@ -115,21 +118,16 @@ impl NapiWorker {
             })
             .collect();
 
-        // Create a ThreadsafeFunction from the JS executor.
-        // We pass a single JSON string containing both task_id and input.
-        // The JS function signature: (payload: string) => Promise<string>
-        let tsfn: ThreadsafeFunction<String, ErrorStrategy::CalleeHandled> = task_executor
-            .create_threadsafe_function(
-                0,
-                |ctx: napi::threadsafe_function::ThreadSafeCallContext<String>| {
-                    Ok(vec![ctx.env.create_string(&ctx.value)?.into_unknown()])
-                },
-            )?;
+        // Build a ThreadsafeFunction from the JS executor.
+        let tsfn: ThreadsafeFunction<String, Promise<String>, _, _, true> = task_executor
+            .build_threadsafe_function()
+            .callee_handled::<true>()
+            .build()?;
 
         let tsfn = Arc::new(tsfn);
 
         let executor: ExternalTaskExecutor = Arc::new(move |task_id: &str, input: Bytes| {
-            let tsfn: Arc<ThreadsafeFunction<String, ErrorStrategy::CalleeHandled>> =
+            let tsfn: Arc<ThreadsafeFunction<String, Promise<String>, _, _, true>> =
                 Arc::clone(&tsfn);
             let task_id = task_id.to_string();
             let input_json = String::from_utf8_lossy(&input).into_owned();
@@ -141,13 +139,12 @@ impl NapiWorker {
                         .unwrap_or(serde_json::Value::Null),
                 })
                 .to_string();
-                let promise: Promise<String> = tsfn
+                let output_json: String = tsfn
                     .call_async(Ok(payload))
                     .await
-                    .map_err(|e| -> sayiir_core::error::BoxError { e.to_string().into() })?;
-                let output_json: String = promise
+                    .map_err(|e| -> sayiir_core::error::BoxError { e.to_string().into() })?
                     .await
-                    .map_err(|e: Error| -> sayiir_core::error::BoxError { e.to_string().into() })?;
+                    .map_err(|e| -> sayiir_core::error::BoxError { e.to_string().into() })?;
                 Ok(Bytes::from(output_json.into_bytes()))
             })
         });

--- a/sayiir-nodejs/npm/darwin-arm64/package.json
+++ b/sayiir-nodejs/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sayiir/node-darwin-arm64",
-  "version": "0.1.0-alpha.8",
+  "version": "0.1.0-alpha.9",
   "os": [
     "darwin"
   ],

--- a/sayiir-nodejs/npm/darwin-x64/package.json
+++ b/sayiir-nodejs/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sayiir/node-darwin-x64",
-  "version": "0.1.0-alpha.8",
+  "version": "0.1.0-alpha.9",
   "os": [
     "darwin"
   ],

--- a/sayiir-nodejs/npm/linux-arm64-gnu/package.json
+++ b/sayiir-nodejs/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sayiir/node-linux-arm64-gnu",
-  "version": "0.1.0-alpha.8",
+  "version": "0.1.0-alpha.9",
   "os": [
     "linux"
   ],

--- a/sayiir-nodejs/npm/linux-x64-gnu/package.json
+++ b/sayiir-nodejs/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sayiir/node-linux-x64-gnu",
-  "version": "0.1.0-alpha.8",
+  "version": "0.1.0-alpha.9",
   "os": [
     "linux"
   ],

--- a/sayiir-nodejs/npm/win32-x64-msvc/package.json
+++ b/sayiir-nodejs/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sayiir/node-win32-x64-msvc",
-  "version": "0.1.0-alpha.8",
+  "version": "0.1.0-alpha.9",
   "os": [
     "win32"
   ],

--- a/sayiir-nodejs/package.json
+++ b/sayiir-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sayiir",
-  "version": "0.1.0-alpha.8",
+  "version": "0.1.0-alpha.9",
   "description": "Durable workflow engine for Node.js — type-safe, fault-tolerant task orchestration",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/sayiir-python/pyproject.toml
+++ b/sayiir-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "sayiir"
-version = "0.1.0-alpha.8"
+version = "0.1.0-alpha.9"
 description = "Durable workflow engine with Rust core and Python bindings — checkpointing, fork/join, distributed workers"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sayiir-python/sayiir/__init__.py
+++ b/sayiir-python/sayiir/__init__.py
@@ -51,4 +51,4 @@ __all__ = [
     "WorkerHandle",
 ]
 
-__version__ = "0.1.0-alpha.8"
+__version__ = "0.1.0-alpha.9"

--- a/tests/integration/Cargo.toml
+++ b/tests/integration/Cargo.toml
@@ -14,7 +14,7 @@ bytes.workspace = true
 tokio = { workspace = true, features = ["rt", "macros", "time"] }
 serde_json = { workspace = true }
 sqlx = { workspace = true }
-testcontainers = "0.26"
+testcontainers = "0.26"                                                      # TODO: update to 0.27
 testcontainers-modules = { version = "0.14", features = ["postgres"] }
 sayiir-macros = { workspace = true }
 serde = { workspace = true }


### PR DESCRIPTION
- napi 2 → 3, napi-derive 2 → 3
- codec.rs: replace JSON.stringify/parse via JsObject/JsFunction with env.from_js_value/to_js_value serde bridge
- engine.rs: JsUnknown → Unknown, JsObject → Object, JsFunction → Function<Unknown, Unknown>
- durable_engine.rs: ObjectRef<false> replaces deprecated Ref<JsObject>, Env::from_raw no longer unsafe
- worker.rs: ThreadsafeFunction built via typed Function<String, Promise<String>> builder API, drops ErrorStrategy/ThreadSafeCallContext

#71 