### PR TITLE
⚡️ Improve tasks polling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,6 +164,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
 dependencies = [
  "fastrand",
+ "gloo-timers",
  "tokio",
 ]
 
@@ -210,6 +211,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -454,6 +464,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "convert_case"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -600,6 +616,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "ctor"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -645,7 +670,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -666,10 +691,21 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.1",
 ]
 
 [[package]]
@@ -768,6 +804,9 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "ferroid"
@@ -802,6 +841,18 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
 dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
+
+[[package]]
+name = "flume"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
+dependencies = [
+ "fastrand",
  "futures-core",
  "futures-sink",
  "spin",
@@ -955,9 +1006,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -979,6 +1032,18 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "h2"
@@ -1075,7 +1140,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1142,6 +1207,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -1576,7 +1650,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1631,6 +1705,21 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "nanoserde"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a36fb3a748a4c9736ed7aeb5f2dfc99665247f1ce306abbddb2bf0ba2ac530a4"
+dependencies = [
+ "nanoserde-derive",
+]
+
+[[package]]
+name = "nanoserde-derive"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a846cbc04412cf509efcd8f3694b114fc700a035fb5a37f21517f9fb019f1ebc"
 
 [[package]]
 name = "napi"
@@ -2532,8 +2621,8 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid",
- "digest",
+ "const-oid 0.9.6",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
@@ -2671,11 +2760,12 @@ dependencies = [
  "bytecheck",
  "bytes",
  "chrono",
+ "hex",
  "proptest",
  "rkyv",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "strum 0.28.0",
  "thiserror",
  "tokio",
@@ -2747,8 +2837,10 @@ dependencies = [
 name = "sayiir-persistence"
 version = "0.5.0"
 dependencies = [
+ "base64",
  "bytes",
  "chrono",
+ "nanoserde",
  "sayiir-core",
  "thiserror",
  "tokio",
@@ -2758,9 +2850,11 @@ dependencies = [
 name = "sayiir-postgres"
 version = "0.5.0"
 dependencies = [
+ "backon",
  "bytes",
  "chrono",
  "criterion",
+ "flume 0.12.0",
  "sayiir-core",
  "sayiir-persistence",
  "sayiir-runtime",
@@ -2770,6 +2864,7 @@ dependencies = [
  "testcontainers-modules",
  "thiserror",
  "tokio",
+ "tokio-util",
  "tracing",
 ]
 
@@ -3011,7 +3106,7 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3022,7 +3117,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3056,7 +3162,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -3149,7 +3255,7 @@ dependencies = [
  "percent-encoding",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "thiserror",
  "tokio",
@@ -3211,7 +3317,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sqlx-core",
  "sqlx-mysql",
  "sqlx-postgres",
@@ -3234,7 +3340,7 @@ dependencies = [
  "bytes",
  "chrono",
  "crc",
- "digest",
+ "digest 0.10.7",
  "dotenvy",
  "either",
  "futures-channel",
@@ -3255,7 +3361,7 @@ dependencies = [
  "rsa",
  "serde",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -3293,7 +3399,7 @@ dependencies = [
  "rand 0.8.6",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -3310,7 +3416,7 @@ checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
 dependencies = [
  "atoi",
  "chrono",
- "flume",
+ "flume 0.11.1",
  "futures-channel",
  "futures-core",
  "futures-executor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,9 +59,13 @@ serde_json = "1"
 rkyv = { version = "0.8", features = ["std", "bytecheck", "bytes-1"] }
 bytecheck = "0.8"
 tokio = { version = "1", features = ["rt"] }
-sha2 = "0.10"
+sha2 = "0.11"
+hex = "0.4"
 strum = { version = "0.28", features = ["derive"] }
 thiserror = "2"
 base64 = "0.22"
 sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "chrono"] }
 proptest = "1"
+backon = "1"
+nanoserde = "0.2"
+flume = "0.12"

--- a/sayiir-core/Cargo.toml
+++ b/sayiir-core/Cargo.toml
@@ -27,6 +27,7 @@ chrono = { workspace = true }
 tokio = { workspace = true, optional = true }
 serde = { workspace = true }
 sha2 = { workspace = true }
+hex = { workspace = true }
 strum = { workspace = true }
 thiserror = { workspace = true }
 rkyv = { workspace = true, optional = true }

--- a/sayiir-core/src/workflow.rs
+++ b/sayiir-core/src/workflow.rs
@@ -1344,8 +1344,7 @@ impl SerializableContinuation {
 
         let mut hasher = Sha256::new();
         hash_continuation(self, &mut hasher);
-        let result = hasher.finalize();
-        format!("{result:x}")
+        hex::encode(hasher.finalize())
     }
 }
 

--- a/sayiir-core/src/workflow.rs
+++ b/sayiir-core/src/workflow.rs
@@ -2371,7 +2371,7 @@ mod tests {
         let wf2: SerializableWorkflow<_, u32> = WorkflowBuilder::new(ctx2)
             .with_registry()
             .then("step1", |i: u32| async move { Ok(i + 1) })
-            .delay("wait", Duration::from_secs(60))
+            .delay("wait", Duration::from_mins(1))
             .build()
             .unwrap();
 

--- a/sayiir-core/src/workflow.rs
+++ b/sayiir-core/src/workflow.rs
@@ -2415,7 +2415,7 @@ mod tests {
         let ctx = WorkflowContext::new("test-workflow", Arc::new(DummyCodec), Arc::new(()));
         let workflow = WorkflowBuilder::new(ctx)
             .then("fetch", |i: u32| async move { Ok(i) })
-            .delay("wait_24h", Duration::from_secs(86400))
+            .delay("wait_24h", Duration::from_hours(24))
             .then("process", |i: u32| async move { Ok(i + 1) })
             .build()
             .unwrap();
@@ -2467,7 +2467,7 @@ mod tests {
                 id, duration, next, ..
             } => {
                 assert_eq!(id, "wait");
-                assert_eq!(duration, std::time::Duration::from_millis(5000));
+                assert_eq!(duration, std::time::Duration::from_secs(5));
                 assert!(next.is_none());
             }
             _ => panic!("Expected Delay variant"),

--- a/sayiir-macros/src/task/codegen.rs
+++ b/sayiir-macros/src/task/codegen.rs
@@ -122,7 +122,7 @@ fn gen_metadata_body(parsed: &ParsedTask) -> TokenStream {
             .backoff
             .as_ref()
             .map(|d| d.to_tokens())
-            .unwrap_or_else(|| quote! { ::std::time::Duration::from_millis(1000) });
+            .unwrap_or_else(|| quote! { ::std::time::Duration::from_secs(1) });
         let multiplier = attrs.backoff_multiplier.unwrap_or(2.0_f32);
 
         Some(quote! {

--- a/sayiir-node/src/worker.rs
+++ b/sayiir-node/src/worker.rs
@@ -51,7 +51,7 @@ impl NapiWorker {
             poll_interval: Duration::from_millis(
                 #[allow(clippy::cast_sign_loss)]
                 {
-                    poll_interval_ms.unwrap_or(5000.0) as u64
+                    poll_interval_ms.unwrap_or(30000.0) as u64
                 },
             ),
             claim_ttl: Duration::from_millis(
@@ -80,7 +80,7 @@ impl NapiWorker {
             poll_interval: Duration::from_millis(
                 #[allow(clippy::cast_sign_loss)]
                 {
-                    poll_interval_ms.unwrap_or(5000.0) as u64
+                    poll_interval_ms.unwrap_or(30000.0) as u64
                 },
             ),
             claim_ttl: Duration::from_millis(

--- a/sayiir-persistence/Cargo.toml
+++ b/sayiir-persistence/Cargo.toml
@@ -21,6 +21,9 @@ sayiir-core = { workspace = true }
 thiserror = "2"
 bytes = { workspace = true }
 chrono = { workspace = true }
+# `TaskWakeupHint::encode/decode` use nanoserde for the binary wire format.
+nanoserde = { workspace = true }
+base64 = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt", "macros"] }

--- a/sayiir-persistence/src/backend.rs
+++ b/sayiir-persistence/src/backend.rs
@@ -17,6 +17,124 @@ use sayiir_core::snapshot::{
 };
 use sayiir_core::task_claim::{AvailableTask, TaskClaim};
 
+/// Routing-and-eligibility hint a producer attaches to a "task ready"
+/// wakeup. Workers consume it to:
+///
+/// * **Filter** — drop the wake without polling if the worker's tags don't
+///   match, or if the worker doesn't have the workflow registered. Cuts
+///   PG load proportional to NOTIFY volume × fleet-tag-fragmentation.
+/// * **Direct-claim** — call [`TaskClaimStore::find_hinted_task`] to skip
+///   the full `find_available_tasks` scan on the happy path; the producer
+///   already named the task that just became ready.
+///
+#[derive(Debug, Clone, PartialEq, Eq, nanoserde::SerBin, nanoserde::DeBin)]
+pub struct TaskWakeupHint {
+    /// Workflow instance the task belongs to.
+    pub instance_id: String,
+    /// Task id that's claimable as of the producer's commit.
+    pub task_id: String,
+    /// `definition_hash` of the workflow — workers without this hash
+    /// registered can drop the wake without touching the DB.
+    pub definition_hash: String,
+    /// Task tags. A worker can handle the task only if its tag set is a
+    /// superset of `tags` (untagged tasks are claimable by anyone).
+    pub tags: Vec<String>,
+}
+
+/// Wire-format version byte prepended to the nanoserde blob. Bump on
+/// any breaking change to [`TaskWakeupHint`]'s field layout so decoders
+/// reject payloads they don't understand instead of silently
+/// misparsing them.
+const HINT_WIRE_VERSION: u8 = 1;
+
+impl TaskWakeupHint {
+    /// Encode to a base64-wrapped binary blob, suitable for any text-only
+    /// transport (e.g. PG's `pg_notify` payload).
+    ///
+    /// Wire layout: `[version u8][nanoserde SerBin bytes]`. nanoserde
+    /// uses length-prefixed (u64 LE) encoding for strings and `Vec`,
+    /// little-endian for primitives. Typical hint encodes to ~70–100
+    /// bytes raw and ~95–135 bytes base64 — comfortably under PG's
+    /// 8 kB `NOTIFY` payload cap.
+    #[must_use]
+    pub fn encode(&self) -> String {
+        use base64::Engine;
+        use nanoserde::SerBin;
+
+        let mut buf = Vec::with_capacity(96);
+        buf.push(HINT_WIRE_VERSION);
+        self.ser_bin(&mut buf);
+        base64::engine::general_purpose::STANDARD_NO_PAD.encode(&buf)
+    }
+
+    /// Decode from the wire format produced by [`Self::encode`].
+    ///
+    /// Returns `Err` with a human-readable reason for any corrupt,
+    /// truncated, or version-mismatched payload. The caller should log
+    /// and treat the failure as a missed wakeup — the fallback poll
+    /// will catch up.
+    pub fn decode(payload: &str) -> Result<Self, String> {
+        use base64::Engine;
+        use nanoserde::DeBin;
+
+        let bytes = base64::engine::general_purpose::STANDARD_NO_PAD
+            .decode(payload)
+            .map_err(|e| format!("base64: {e}"))?;
+        let Some((&version, body)) = bytes.split_first() else {
+            return Err("empty payload".into());
+        };
+        if version != HINT_WIRE_VERSION {
+            return Err(format!("unsupported wire version: {version}"));
+        }
+        Self::deserialize_bin(body).map_err(|e| format!("nanoserde: {e}"))
+    }
+}
+
+#[cfg(test)]
+mod hint_tests {
+    use super::TaskWakeupHint;
+
+    fn sample() -> TaskWakeupHint {
+        TaskWakeupHint {
+            instance_id: "wf-abc-123".to_string(),
+            task_id: "step-1".to_string(),
+            definition_hash: "hash-xyz".to_string(),
+            tags: vec!["gpu".to_string(), "cuda-12".to_string()],
+        }
+    }
+
+    #[test]
+    fn roundtrip() {
+        let hint = sample();
+        let encoded = hint.encode();
+        let decoded = TaskWakeupHint::decode(&encoded).expect("roundtrip");
+        assert_eq!(hint, decoded);
+    }
+
+    #[test]
+    fn roundtrip_empty_tags() {
+        let mut hint = sample();
+        hint.tags.clear();
+        let decoded = TaskWakeupHint::decode(&hint.encode()).unwrap();
+        assert_eq!(hint, decoded);
+    }
+
+    #[test]
+    fn rejects_garbage_payload() {
+        assert!(TaskWakeupHint::decode("not base64!@#").is_err());
+        assert!(TaskWakeupHint::decode("").is_err());
+    }
+
+    #[test]
+    fn rejects_unknown_version() {
+        use base64::Engine;
+        let buf = vec![99u8, 0, 0, 0, 0, 0, 0, 0, 0];
+        let payload = base64::engine::general_purpose::STANDARD_NO_PAD.encode(&buf);
+        let err = TaskWakeupHint::decode(&payload).unwrap_err();
+        assert!(err.contains("unsupported wire version"));
+    }
+}
+
 /// Error type for backend operations.
 #[derive(Debug, thiserror::Error)]
 pub enum BackendError {
@@ -271,6 +389,35 @@ pub trait TaskClaimStore: Send + Sync {
         aging_interval: Duration,
         worker_tags: &[String],
     ) -> impl Future<Output = Result<Vec<AvailableTask>, BackendError>> + Send;
+
+    /// Block until a wakeup arrives or `timeout` elapses. `Some(hint)`
+    /// when a producer attached one; `None` for hint-less wakeups,
+    /// timeout, or backends without a notification channel.
+    ///
+    /// Default returns a future that never resolves (`std::future::pending`)
+    /// — the worker's `interval.tick()` arm provides the cadence, so
+    /// non-overriding backends keep their fixed-interval poll. Keeps
+    /// `sayiir-persistence` runtime-agnostic.
+    fn wait_for_wakeup(
+        &self,
+        _timeout: std::time::Duration,
+    ) -> impl Future<Output = Result<Option<TaskWakeupHint>, BackendError>> + Send {
+        async move {
+            std::future::pending::<Option<TaskWakeupHint>>().await;
+            Ok(None)
+        }
+    }
+
+    /// Resolve a wakeup hint into a claimable [`AvailableTask`], or
+    /// `None` if the snapshot moved on / is claim-blocked / signal-blocked.
+    /// Does NOT claim — the caller runs the normal claim+execute pipeline.
+    /// Default returns `None`; backends opt in for the targeted lookup.
+    fn find_hinted_task(
+        &self,
+        _hint: &TaskWakeupHint,
+    ) -> impl Future<Output = Result<Option<AvailableTask>, BackendError>> + Send {
+        async move { Ok(None) }
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/sayiir-persistence/src/lib.rs
+++ b/sayiir-persistence/src/lib.rs
@@ -46,6 +46,7 @@ pub mod validation;
 
 pub use backend::{
     BackendError, PersistentBackend, SignalStore, SnapshotStore, TaskClaimStore, TaskResultStore,
+    TaskWakeupHint,
 };
 pub use in_memory::InMemoryBackend;
 pub use lifecycle::{PrepareRunOutcome, RunConflict, prepare_run};

--- a/sayiir-postgres/Cargo.toml
+++ b/sayiir-postgres/Cargo.toml
@@ -24,6 +24,12 @@ bytes = { workspace = true }
 chrono = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
+tokio = { workspace = true, features = ["rt", "time"] }
+tokio-util = { version = "0.7", default-features = false }
+backon = { workspace = true }
+# `Receiver: Clone` + `recv_async(&self)` means we can hand a shared
+# receiver to every backend clone without wrapping in a mutex.
+flume = { workspace = true }
 
 [[bench]]
 name = "postgres"

--- a/sayiir-postgres/src/backend.rs
+++ b/sayiir-postgres/src/backend.rs
@@ -1,11 +1,14 @@
 //! `PostgresBackend` struct and constructors.
 
+use std::sync::Arc;
+
 use sayiir_core::codec::{self, Decoder, Encoder};
 use sayiir_core::snapshot::WorkflowSnapshot;
 use sayiir_persistence::BackendError;
 use sqlx::{PgPool, Row};
 
 use crate::error::PgError;
+use crate::wakeup::WakeupListener;
 
 /// Minimum supported PostgreSQL major version.
 const MIN_PG_MAJOR_VERSION: u32 = 13;
@@ -32,6 +35,7 @@ const MIN_PG_MAJOR_VERSION: u32 = 13;
 pub struct PostgresBackend<C> {
     pub(crate) pool: PgPool,
     pub(crate) codec: C,
+    pub(crate) wakeup: Arc<WakeupListener>,
 }
 
 impl<C> PostgresBackend<C>
@@ -65,10 +69,14 @@ where
             .run(&pool)
             .await
             .map_err(|e| BackendError::Backend(format!("migration failed: {e}")))?;
+
+        let wakeup = WakeupListener::spawn(pool.clone());
+
         tracing::info!("postgres backend ready");
         Ok(Self {
             pool,
             codec: C::default(),
+            wakeup,
         })
     }
 }

--- a/sayiir-postgres/src/backend.rs
+++ b/sayiir-postgres/src/backend.rs
@@ -1,5 +1,6 @@
 //! `PostgresBackend` struct and constructors.
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use sayiir_core::codec::{self, Decoder, Encoder};
@@ -9,6 +10,7 @@ use sqlx::postgres::PgPoolOptions;
 use sqlx::{PgPool, Row};
 
 use crate::error::PgError;
+use crate::wakeup::WakeupListener;
 
 /// Minimum supported PostgreSQL major version.
 const MIN_PG_MAJOR_VERSION: u32 = 13;
@@ -77,6 +79,7 @@ pub struct PoolOptions {
 pub struct PostgresBackend<C> {
     pub(crate) pool: PgPool,
     pub(crate) codec: C,
+    pub(crate) wakeup: Arc<WakeupListener>,
 }
 
 impl<C> PostgresBackend<C>
@@ -187,10 +190,14 @@ where
             .run(&pool)
             .await
             .map_err(|e| BackendError::Backend(format!("migration failed: {e}")))?;
+
+        let wakeup = WakeupListener::spawn(pool.clone());
+
         tracing::info!("postgres backend ready");
         Ok(Self {
             pool,
             codec: C::default(),
+            wakeup,
         })
     }
 }

--- a/sayiir-postgres/src/lib.rs
+++ b/sayiir-postgres/src/lib.rs
@@ -69,5 +69,6 @@ mod signal_store;
 mod snapshot_store;
 mod task_claim_store;
 mod task_result_store;
+mod wakeup;
 
 pub use backend::PostgresBackend;

--- a/sayiir-postgres/src/lib.rs
+++ b/sayiir-postgres/src/lib.rs
@@ -69,5 +69,6 @@ mod signal_store;
 mod snapshot_store;
 mod task_claim_store;
 mod task_result_store;
+mod wakeup;
 
 pub use backend::{PoolOptions, PostgresBackend};

--- a/sayiir-postgres/src/snapshot_store.rs
+++ b/sayiir-postgres/src/snapshot_store.rs
@@ -7,6 +7,7 @@ use sqlx::Row;
 
 use crate::backend::PostgresBackend;
 use crate::error::PgError;
+use crate::wakeup::emit_task_ready;
 
 impl<C> SnapshotStore for PostgresBackend<C>
 where
@@ -145,6 +146,8 @@ where
             .map_err(PgError)?;
         }
 
+        emit_task_ready(&mut tx, snapshot).await.map_err(PgError)?;
+
         tx.commit().await.map_err(PgError)?;
         Ok(())
     }
@@ -210,6 +213,8 @@ where
         .execute(&mut *tx)
         .await
         .map_err(PgError)?;
+
+        emit_task_ready(&mut tx, &snapshot).await.map_err(PgError)?;
 
         tx.commit().await.map_err(PgError)?;
         Ok(())

--- a/sayiir-postgres/src/snapshot_store.rs
+++ b/sayiir-postgres/src/snapshot_store.rs
@@ -7,6 +7,7 @@ use sqlx::Row;
 
 use crate::backend::PostgresBackend;
 use crate::error::PgError;
+use crate::wakeup::emit_task_ready;
 
 impl<C> SnapshotStore for PostgresBackend<C>
 where
@@ -154,6 +155,8 @@ where
             .map_err(PgError)?;
         }
 
+        emit_task_ready(&mut tx, snapshot).await.map_err(PgError)?;
+
         tx.commit().await.map_err(PgError)?;
         Ok(())
     }
@@ -219,6 +222,8 @@ where
         .execute(&mut *tx)
         .await
         .map_err(PgError)?;
+
+        emit_task_ready(&mut tx, &snapshot).await.map_err(PgError)?;
 
         tx.commit().await.map_err(PgError)?;
         Ok(())

--- a/sayiir-postgres/src/task_claim_store.rs
+++ b/sayiir-postgres/src/task_claim_store.rs
@@ -10,6 +10,28 @@ use sqlx::Row;
 use crate::backend::PostgresBackend;
 use crate::error::PgError;
 
+/// SQL fragment that gates a snapshot row to "claimable right now":
+/// no active claim on the named task, and no signal pending on the
+/// instance. Shared between `find_available_tasks` (polling scan,
+/// `claim_task_id_expr = s.current_task_id`) and `find_hinted_task`
+/// (single-row lookup, `claim_task_id_expr = $N` bind parameter) so a
+/// future change to the eligibility rules can't silently desynchronise
+/// the two paths.
+fn eligibility_predicate(claim_task_id_expr: &str) -> String {
+    format!(
+        "NOT EXISTS (
+            SELECT 1 FROM sayiir_task_claims c
+            WHERE c.instance_id = s.instance_id
+              AND c.task_id = {claim_task_id_expr}
+              AND (c.expires_at IS NULL OR c.expires_at > now())
+        )
+        AND NOT EXISTS (
+            SELECT 1 FROM sayiir_workflow_signals sig
+            WHERE sig.instance_id = s.instance_id
+        )"
+    )
+}
+
 impl<C> TaskClaimStore for PostgresBackend<C>
 where
     C: Encoder
@@ -217,9 +239,8 @@ where
         // scope dedup: two pollers issuing this SELECT at the exact same
         // instant will tend to receive disjoint row sets instead of fully
         // overlapping ones, reducing wasted snapshot decodes when fleet
-        // size is high. If real cross-statement dedup is ever needed, the
-        // SELECT and the conflict-resolving INSERT have to share a
-        // transaction — see the audit for the trade-offs.
+        // size is high.
+        let eligibility = eligibility_predicate("s.current_task_id");
         let query = format!(
             "SELECT s.instance_id, s.data, s.trace_parent
              FROM sayiir_workflow_snapshots s
@@ -230,16 +251,7 @@ where
                        AND s.delay_wake_at IS NOT NULL
                        AND s.delay_wake_at <= now())
                )
-               AND NOT EXISTS (
-                   SELECT 1 FROM sayiir_task_claims c
-                   WHERE c.instance_id = s.instance_id
-                     AND c.task_id = s.current_task_id
-                     AND (c.expires_at IS NULL OR c.expires_at > now())
-               )
-               AND NOT EXISTS (
-                   SELECT 1 FROM sayiir_workflow_signals sig
-                   WHERE sig.instance_id = s.instance_id
-               )
+               AND {eligibility}
                {tag_filter}
              ORDER BY
                (s.task_priority - EXTRACT(EPOCH FROM (now() - s.updated_at)) / $2) ASC,
@@ -287,7 +299,7 @@ where
                             ..
                         } = &snapshot.state
                             && let Some(task) =
-                                build_available_task(&snapshot, task_id, completed_tasks, worker_id)
+                                build_available_task(&snapshot, task_id, completed_tasks)
                         {
                             let bias = snapshot.has_failed_on_worker(task_id, worker_id);
                             available.push((bias, task));
@@ -318,9 +330,7 @@ where
                         continue;
                     }
 
-                    if let Some(task) =
-                        build_available_task(&snapshot, task_id, completed_tasks, worker_id)
-                    {
+                    if let Some(task) = build_available_task(&snapshot, task_id, completed_tasks) {
                         let bias = snapshot.has_failed_on_worker(task_id, worker_id);
                         available.push((bias, task));
                     }
@@ -342,6 +352,76 @@ where
         tracing::debug!(count = available.len(), "available tasks found");
         Ok(available.into_iter().map(|(_, task)| task).collect())
     }
+
+    async fn wait_for_wakeup(
+        &self,
+        timeout: std::time::Duration,
+    ) -> Result<Option<sayiir_persistence::TaskWakeupHint>, BackendError> {
+        Ok(self.wakeup.wait(timeout).await)
+    }
+
+    #[tracing::instrument(
+        name = "db.find_hinted_task",
+        skip(self, hint),
+        fields(
+            db.system = "postgresql",
+            instance_id = %hint.instance_id,
+            task_id = %hint.task_id,
+        ),
+        err(level = tracing::Level::ERROR),
+    )]
+    async fn find_hinted_task(
+        &self,
+        hint: &sayiir_persistence::TaskWakeupHint,
+    ) -> Result<Option<AvailableTask>, BackendError> {
+        // Single-row eligibility check: skip the priority-ordered scan
+        // in find_available_tasks and verify just the hinted row. No
+        // claim happens here — the caller runs the AvailableTask
+        // through the normal execute pipeline (which claims atomically
+        // against the race). On any negative outcome — claim held,
+        // signal blocking, snapshot advanced, no row — return None so
+        // the caller falls back to the full poll.
+        let query = format!(
+            "SELECT s.data, s.trace_parent
+             FROM sayiir_workflow_snapshots s
+             WHERE s.instance_id = $1
+               AND s.status = 'InProgress'
+               AND {eligibility}",
+            eligibility = eligibility_predicate("$2"),
+        );
+        let row = sqlx::query(&query)
+            .bind(&hint.instance_id)
+            .bind(&hint.task_id)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(PgError)?;
+
+        let Some(row) = row else { return Ok(None) };
+
+        let raw: &[u8] = row.get("data");
+        let mut snapshot = self.decode(raw)?;
+        snapshot.trace_parent = row.get("trace_parent");
+
+        // The snapshot must still be at the hinted task — otherwise the
+        // hint is stale (workflow moved on between NOTIFY and our read).
+        let WorkflowSnapshotState::InProgress {
+            position: ExecutionPosition::AtTask { task_id },
+            completed_tasks,
+            ..
+        } = &snapshot.state
+        else {
+            return Ok(None);
+        };
+        if task_id != &hint.task_id || completed_tasks.contains_key(task_id) {
+            return Ok(None);
+        }
+
+        Ok(build_available_task(
+            &snapshot,
+            &hint.task_id,
+            completed_tasks,
+        ))
+    }
 }
 
 /// Build an [`AvailableTask`] from a snapshot at a task position.
@@ -349,7 +429,6 @@ fn build_available_task(
     snapshot: &WorkflowSnapshot,
     task_id: &str,
     completed_tasks: &std::collections::HashMap<String, sayiir_core::snapshot::TaskResult>,
-    _worker_id: &str,
 ) -> Option<AvailableTask> {
     let input = if completed_tasks.is_empty() {
         snapshot.initial_input_bytes()

--- a/sayiir-postgres/src/task_claim_store.rs
+++ b/sayiir-postgres/src/task_claim_store.rs
@@ -10,6 +10,28 @@ use sqlx::Row;
 use crate::backend::PostgresBackend;
 use crate::error::PgError;
 
+/// SQL fragment that gates a snapshot row to "claimable right now":
+/// no active claim on the named task, and no signal pending on the
+/// instance. Shared between `find_available_tasks` (polling scan,
+/// `claim_task_id_expr = s.current_task_id`) and `find_hinted_task`
+/// (single-row lookup, `claim_task_id_expr = $N` bind parameter) so a
+/// future change to the eligibility rules can't silently desynchronise
+/// the two paths.
+fn eligibility_predicate(claim_task_id_expr: &str) -> String {
+    format!(
+        "NOT EXISTS (
+            SELECT 1 FROM sayiir_task_claims c
+            WHERE c.instance_id = s.instance_id
+              AND c.task_id = {claim_task_id_expr}
+              AND (c.expires_at IS NULL OR c.expires_at > now())
+        )
+        AND NOT EXISTS (
+            SELECT 1 FROM sayiir_workflow_signals sig
+            WHERE sig.instance_id = s.instance_id
+        )"
+    )
+}
+
 impl<C> TaskClaimStore for PostgresBackend<C>
 where
     C: Encoder
@@ -199,20 +221,12 @@ where
             "AND s.task_tags <@ $3"
         };
 
+        let eligibility = eligibility_predicate("s.current_task_id");
         let query = format!(
             "SELECT s.instance_id, s.data, s.trace_parent
              FROM sayiir_workflow_snapshots s
              WHERE s.status = 'InProgress'
-               AND NOT EXISTS (
-                   SELECT 1 FROM sayiir_task_claims c
-                   WHERE c.instance_id = s.instance_id
-                     AND c.task_id = s.current_task_id
-                     AND (c.expires_at IS NULL OR c.expires_at > now())
-               )
-               AND NOT EXISTS (
-                   SELECT 1 FROM sayiir_workflow_signals sig
-                   WHERE sig.instance_id = s.instance_id
-               )
+               AND {eligibility}
                {tag_filter}
              ORDER BY
                (s.task_priority - EXTRACT(EPOCH FROM (now() - s.updated_at)) / $2) ASC,
@@ -259,7 +273,7 @@ where
                             ..
                         } = &snapshot.state
                             && let Some(task) =
-                                build_available_task(&snapshot, task_id, completed_tasks, worker_id)
+                                build_available_task(&snapshot, task_id, completed_tasks)
                         {
                             let bias = snapshot.has_failed_on_worker(task_id, worker_id);
                             available.push((bias, task));
@@ -290,9 +304,7 @@ where
                         continue;
                     }
 
-                    if let Some(task) =
-                        build_available_task(&snapshot, task_id, completed_tasks, worker_id)
-                    {
+                    if let Some(task) = build_available_task(&snapshot, task_id, completed_tasks) {
                         let bias = snapshot.has_failed_on_worker(task_id, worker_id);
                         available.push((bias, task));
                     }
@@ -314,6 +326,76 @@ where
         tracing::debug!(count = available.len(), "available tasks found");
         Ok(available.into_iter().map(|(_, task)| task).collect())
     }
+
+    async fn wait_for_wakeup(
+        &self,
+        timeout: std::time::Duration,
+    ) -> Result<Option<sayiir_persistence::TaskWakeupHint>, BackendError> {
+        Ok(self.wakeup.wait(timeout).await)
+    }
+
+    #[tracing::instrument(
+        name = "db.find_hinted_task",
+        skip(self, hint),
+        fields(
+            db.system = "postgresql",
+            instance_id = %hint.instance_id,
+            task_id = %hint.task_id,
+        ),
+        err(level = tracing::Level::ERROR),
+    )]
+    async fn find_hinted_task(
+        &self,
+        hint: &sayiir_persistence::TaskWakeupHint,
+    ) -> Result<Option<AvailableTask>, BackendError> {
+        // Single-row eligibility check: skip the priority-ordered scan
+        // in find_available_tasks and verify just the hinted row. No
+        // claim happens here — the caller runs the AvailableTask
+        // through the normal execute pipeline (which claims atomically
+        // against the race). On any negative outcome — claim held,
+        // signal blocking, snapshot advanced, no row — return None so
+        // the caller falls back to the full poll.
+        let query = format!(
+            "SELECT s.data, s.trace_parent
+             FROM sayiir_workflow_snapshots s
+             WHERE s.instance_id = $1
+               AND s.status = 'InProgress'
+               AND {eligibility}",
+            eligibility = eligibility_predicate("$2"),
+        );
+        let row = sqlx::query(&query)
+            .bind(&hint.instance_id)
+            .bind(&hint.task_id)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(PgError)?;
+
+        let Some(row) = row else { return Ok(None) };
+
+        let raw: &[u8] = row.get("data");
+        let mut snapshot = self.decode(raw)?;
+        snapshot.trace_parent = row.get("trace_parent");
+
+        // The snapshot must still be at the hinted task — otherwise the
+        // hint is stale (workflow moved on between NOTIFY and our read).
+        let WorkflowSnapshotState::InProgress {
+            position: ExecutionPosition::AtTask { task_id },
+            completed_tasks,
+            ..
+        } = &snapshot.state
+        else {
+            return Ok(None);
+        };
+        if task_id != &hint.task_id || completed_tasks.contains_key(task_id) {
+            return Ok(None);
+        }
+
+        Ok(build_available_task(
+            &snapshot,
+            &hint.task_id,
+            completed_tasks,
+        ))
+    }
 }
 
 /// Build an [`AvailableTask`] from a snapshot at a task position.
@@ -321,7 +403,6 @@ fn build_available_task(
     snapshot: &WorkflowSnapshot,
     task_id: &str,
     completed_tasks: &std::collections::HashMap<String, sayiir_core::snapshot::TaskResult>,
-    _worker_id: &str,
 ) -> Option<AvailableTask> {
     let input = if completed_tasks.is_empty() {
         snapshot.initial_input_bytes()

--- a/sayiir-postgres/src/wakeup.rs
+++ b/sayiir-postgres/src/wakeup.rs
@@ -192,7 +192,7 @@ async fn connect_and_listen(
     }
 }
 
-/// Drain `recv()` into the broadcast channel until cancellation or
+/// Drain `recv()` into the mpmc wakeup queue until cancellation or
 /// non-recoverable error. sqlx auto-reconnects internally on transient
 /// socket failures and replays the LISTEN; `Err` here means recovery is
 /// exhausted. `Break` = exit; `Continue` = caller should reconnect.

--- a/sayiir-postgres/src/wakeup.rs
+++ b/sayiir-postgres/src/wakeup.rs
@@ -1,0 +1,256 @@
+//! LISTEN/NOTIFY plumbing for the polling wakeup path.
+//!
+//! Producers ([`emit_task_ready`]) fire `pg_notify` inside whatever
+//! transaction wrote the snapshot — PG defers delivery to commit time, so
+//! readers never see a wakeup without an underlying row change. The
+//! payload is a nanoserde-encoded [`TaskWakeupHint`] wrapped in base64
+//! (PG `NOTIFY` payloads must be valid text). The hint lets the worker
+//! filter at receive time and target the named task with a one-row
+//! eligibility check, skipping the full `find_available_tasks` scan.
+//!
+//! The consumer is one long-lived tokio task spawned in `init`. It runs
+//! `LISTEN sayiir_task_ready` over a `PgListener` (sqlx auto-reconnects
+//! internally; the outer loop here handles the case where reconnect
+//! eventually gives up) and `try_send`s each parsed hint into a `flume`
+//! mpmc channel.
+
+use std::ops::ControlFlow;
+use std::time::Duration;
+
+use backon::{BackoffBuilder, ExponentialBuilder};
+use sayiir_persistence::TaskWakeupHint;
+use sqlx::PgPool;
+use sqlx::postgres::PgListener;
+use tokio_util::sync::CancellationToken;
+
+/// PG channel name for "a task is ready" wakeups. Listener and producers
+/// share this single source of truth.
+pub(crate) const TASK_READY_CHANNEL: &str = "sayiir_task_ready";
+
+/// Wakeup channel capacity. When full, the listener drops the incoming
+/// hint with a warn log; the worker recovers via the timer-tick poll.
+/// Sized so that ~256 saves can stack up before drops kick in — at
+/// the typical 30 s fallback interval, the worker would need to be
+/// processing fewer than ~8.5 hints/s sustained for drops to matter,
+/// which is well below normal load.
+const WAKEUP_CHANNEL_CAPACITY: usize = 256;
+
+/// First reconnect delay after a listener failure. The exponential policy
+/// grows from here so a flapping PG doesn't get hammered, and the jitter
+/// spreads reconnect attempts across a fleet to avoid a thundering herd
+/// when (e.g.) PG restarts and every backend wakes up at the same instant.
+const RECONNECT_MIN_DELAY: Duration = Duration::from_secs(5);
+
+/// Ceiling on the reconnect delay — even after many failures the listener
+/// retries at least this often, so a recovered PG is picked up promptly.
+const RECONNECT_MAX_DELAY: Duration = Duration::from_secs(60);
+
+/// Fire `pg_notify(sayiir_task_ready, <hint bytes>)` on the given connection.
+///
+/// Call unconditionally from any save site — the eligibility predicate is
+/// evaluated here. Only `InProgress AtTask` produces a wake; everything
+/// else (terminal, paused, AtDelay, AtJoin, …) returns without touching
+/// the connection.
+///
+/// Call from inside the transaction that wrote the snapshot (pass
+/// `&mut *tx`) — NOTIFY is deferred to commit, so a rollback correctly
+/// drops the wake. Uses the function form of NOTIFY because it accepts
+/// bind parameters, keeping the channel name and payload out of SQL
+/// string interpolation.
+pub(crate) async fn emit_task_ready(
+    conn: &mut sqlx::PgConnection,
+    snapshot: &sayiir_core::snapshot::WorkflowSnapshot,
+) -> Result<(), sqlx::Error> {
+    let Some(hint) = build_hint(snapshot) else {
+        return Ok(());
+    };
+    sqlx::query("SELECT pg_notify($1, $2)")
+        .bind(TASK_READY_CHANNEL)
+        .bind(hint.encode())
+        .execute(conn)
+        .await?;
+    Ok(())
+}
+
+/// Build a wakeup hint from a snapshot if a save should wake workers.
+/// Only `InProgress AtTask` qualifies — `find_hinted_task` targets a
+/// concrete task, and every other in-progress position relies on the
+/// timer-tick fallback poll.
+fn build_hint(snapshot: &sayiir_core::snapshot::WorkflowSnapshot) -> Option<TaskWakeupHint> {
+    let task_id = snapshot.current_task_id()?;
+    Some(TaskWakeupHint {
+        instance_id: snapshot.instance_id.clone(),
+        task_id: task_id.to_string(),
+        definition_hash: snapshot.definition_hash.clone(),
+        tags: snapshot.current_task_tags().to_vec(),
+    })
+}
+
+pub(crate) struct WakeupListener {
+    rx: flume::Receiver<TaskWakeupHint>,
+    shutdown: CancellationToken,
+}
+
+impl WakeupListener {
+    /// Spawn the listener task and return a shared handle. Must be called
+    /// from a tokio runtime.
+    pub(crate) fn spawn(pool: PgPool) -> std::sync::Arc<Self> {
+        let (tx, rx) = flume::bounded(WAKEUP_CHANNEL_CAPACITY);
+        let shutdown = CancellationToken::new();
+        tokio::spawn(run_listener(pool, tx, shutdown.clone()));
+        std::sync::Arc::new(Self { rx, shutdown })
+    }
+
+    /// Wait for the next wakeup or until `timeout` elapses.
+    ///
+    /// `Some(hint)` on delivery; `None` on timeout or after the listener
+    /// task exited (e.g. process shutdown). `flume::Receiver::recv_async`
+    /// takes `&self`, so multiple `wait` callers share this single
+    /// receiver without any mutex — fan-in is mpmc.
+    pub(crate) async fn wait(&self, timeout: std::time::Duration) -> Option<TaskWakeupHint> {
+        match tokio::time::timeout(timeout, self.rx.recv_async()).await {
+            Ok(Ok(hint)) => Some(hint),
+            Ok(Err(flume::RecvError::Disconnected)) | Err(_) => None,
+        }
+    }
+}
+
+impl Drop for WakeupListener {
+    fn drop(&mut self) {
+        self.shutdown.cancel();
+    }
+}
+
+async fn run_listener(
+    pool: PgPool,
+    tx: flume::Sender<TaskWakeupHint>,
+    shutdown: CancellationToken,
+) {
+    loop {
+        let listener = match connect_and_listen(&pool, &shutdown).await {
+            ControlFlow::Break(()) => break,
+            ControlFlow::Continue(l) => l,
+        };
+        match recv_until_error(listener, &tx, &shutdown).await {
+            ControlFlow::Break(()) => break,
+            ControlFlow::Continue(()) => {}
+        }
+    }
+    tracing::debug!("wakeup listener: exiting");
+}
+
+/// Open a `PgListener` and subscribe to [`TASK_READY_CHANNEL`].
+///
+/// `Break(())` on shutdown / `PoolClosed`; `Continue(listener)` with a
+/// live subscription. The `backon` iterator is local to each call so
+/// exponential growth resets across reconnect cycles — a recovered PG
+/// isn't penalized for an earlier outage.
+async fn connect_and_listen(
+    pool: &PgPool,
+    shutdown: &CancellationToken,
+) -> ControlFlow<(), PgListener> {
+    let mut backoff = ExponentialBuilder::default()
+        .with_min_delay(RECONNECT_MIN_DELAY)
+        .with_max_delay(RECONNECT_MAX_DELAY)
+        .with_factor(2.0)
+        .with_jitter()
+        .without_max_times()
+        .build();
+
+    loop {
+        if shutdown.is_cancelled() || pool.is_closed() {
+            return ControlFlow::Break(());
+        }
+
+        let mut listener = match shutdown
+            .run_until_cancelled(PgListener::connect_with(pool))
+            .await
+        {
+            None | Some(Err(sqlx::Error::PoolClosed)) => return ControlFlow::Break(()),
+            Some(Ok(l)) => l,
+            Some(Err(e)) => {
+                tracing::warn!(error = %e, "wakeup listener: connect failed, retrying");
+                sleep_or_break(shutdown, &mut backoff).await?;
+                continue;
+            }
+        };
+
+        match shutdown
+            .run_until_cancelled(listener.listen(TASK_READY_CHANNEL))
+            .await
+        {
+            None => return ControlFlow::Break(()),
+            Some(Ok(())) => {
+                tracing::debug!(channel = TASK_READY_CHANNEL, "wakeup listener subscribed");
+                return ControlFlow::Continue(listener);
+            }
+            Some(Err(e)) => {
+                tracing::warn!(error = %e, "wakeup listener: LISTEN failed, retrying");
+                sleep_or_break(shutdown, &mut backoff).await?;
+            }
+        }
+    }
+}
+
+/// Drain `recv()` into the broadcast channel until cancellation or
+/// non-recoverable error. sqlx auto-reconnects internally on transient
+/// socket failures and replays the LISTEN; `Err` here means recovery is
+/// exhausted. `Break` = exit; `Continue` = caller should reconnect.
+///
+/// Malformed payloads (base64 decode failure, nanoserde decode failure)
+/// are logged at WARN and skipped — a producer with a mismatched wire
+/// format shouldn't crash the listener.
+async fn recv_until_error(
+    mut listener: PgListener,
+    tx: &flume::Sender<TaskWakeupHint>,
+    shutdown: &CancellationToken,
+) -> ControlFlow<(), ()> {
+    loop {
+        match shutdown.run_until_cancelled(listener.recv()).await {
+            None | Some(Err(sqlx::Error::PoolClosed)) => return ControlFlow::Break(()),
+            Some(Ok(notification)) => match TaskWakeupHint::decode(notification.payload()) {
+                Ok(hint) => match tx.try_send(hint) {
+                    // `Disconnected` only happens if every Receiver was
+                    // dropped — i.e. every PostgresBackend clone is
+                    // gone. At that point the shutdown CancellationToken
+                    // has also fired, so the outer loop will exit on
+                    // the next `run_until_cancelled` poll. Drop the
+                    // hint silently in either case.
+                    Ok(()) | Err(flume::TrySendError::Disconnected(_)) => {}
+                    Err(flume::TrySendError::Full(_)) => {
+                        tracing::warn!(
+                            "wakeup channel full, dropping hint; worker falls back to poll",
+                        );
+                    }
+                },
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        payload = notification.payload(),
+                        "wakeup listener: dropping unparseable hint",
+                    );
+                }
+            },
+            Some(Err(e)) => {
+                tracing::warn!(error = %e, "wakeup listener: recv failed, reconnecting");
+                return ControlFlow::Continue(());
+            }
+        }
+    }
+}
+
+/// Sleep the next delay from `backoff`, or bail with `Break` on shutdown.
+/// Returns `ControlFlow` so callers can `?`-propagate the break.
+async fn sleep_or_break<B: Iterator<Item = Duration>>(
+    shutdown: &CancellationToken,
+    backoff: &mut B,
+) -> ControlFlow<()> {
+    let delay = backoff.next().unwrap_or(RECONNECT_MAX_DELAY);
+    match shutdown
+        .run_until_cancelled(tokio::time::sleep(delay))
+        .await
+    {
+        None => ControlFlow::Break(()),
+        Some(()) => ControlFlow::Continue(()),
+    }
+}

--- a/sayiir-postgres/src/wakeup.rs
+++ b/sayiir-postgres/src/wakeup.rs
@@ -43,7 +43,7 @@ const RECONNECT_MIN_DELAY: Duration = Duration::from_secs(5);
 
 /// Ceiling on the reconnect delay — even after many failures the listener
 /// retries at least this often, so a recovered PG is picked up promptly.
-const RECONNECT_MAX_DELAY: Duration = Duration::from_secs(60);
+const RECONNECT_MAX_DELAY: Duration = Duration::from_mins(1);
 
 /// Fire `pg_notify(sayiir_task_ready, <hint bytes>)` on the given connection.
 ///

--- a/sayiir-postgres/tests/integration.rs
+++ b/sayiir-postgres/tests/integration.rs
@@ -848,6 +848,260 @@ async fn works_on_minimum_pg_version() {
     assert!(claim.is_some());
 }
 
+// ─── LISTEN/NOTIFY ──────────────────────────────────────────────────────────
+
+/// `save_snapshot` must wake listening workers iff the new state is
+/// `InProgress AtTask` — the only position `find_hinted_task` can
+/// target. Terminal, paused, not-yet-started, or any non-AtTask
+/// in-progress position must not fire (those rely on the worker's
+/// timer-tick fallback poll).
+#[tokio::test]
+async fn save_snapshot_emits_notify_only_when_poll_eligible() {
+    use sqlx::postgres::PgListener;
+    use std::time::Duration;
+
+    let container = Postgres::default()
+        .with_tag(DEFAULT_PG_VERSION)
+        .start()
+        .await
+        .unwrap();
+    let port = container.get_host_port_ipv4(5432).await.unwrap();
+    let url = format!("postgresql://postgres:postgres@127.0.0.1:{port}/postgres");
+    let pool = PgPool::connect(&url).await.unwrap();
+    let backend = PostgresBackend::<JsonCodec>::connect_with(pool)
+        .await
+        .unwrap();
+
+    let mut listener = PgListener::connect(&url).await.unwrap();
+    listener.listen("sayiir_task_ready").await.unwrap();
+
+    // 1) Fresh NotStarted snapshot — must not notify.
+    let snapshot = WorkflowSnapshot::new("wf-notify".into(), "h".into());
+    backend.save_snapshot(&snapshot).await.unwrap();
+    let no_notify = tokio::time::timeout(Duration::from_millis(150), listener.recv()).await;
+    assert!(
+        no_notify.is_err(),
+        "NotStarted save should not emit a NOTIFY; got {:?}",
+        no_notify.ok()
+    );
+
+    // 2) Transition to AtTask — must notify with a base64-wrapped
+    //    nanoserde-encoded TaskWakeupHint carrying instance_id + task_id +
+    //    definition_hash.
+    let mut snapshot = backend.load_snapshot("wf-notify").await.unwrap();
+    snapshot.update_position(ExecutionPosition::AtTask {
+        task_id: "step-1".into(),
+    });
+    backend.save_snapshot(&snapshot).await.unwrap();
+    let notif = tokio::time::timeout(Duration::from_secs(1), listener.recv())
+        .await
+        .expect("AtTask save should emit a NOTIFY within 1s")
+        .expect("listener recv failed");
+    assert_eq!(notif.channel(), "sayiir_task_ready");
+    let hint = sayiir_persistence::TaskWakeupHint::decode(notif.payload())
+        .expect("payload must decode to a TaskWakeupHint");
+    assert_eq!(hint.instance_id, "wf-notify");
+    assert_eq!(hint.task_id, "step-1");
+    assert_eq!(hint.definition_hash, "h");
+
+    // 3) Terminal completion — must not notify.
+    let mut snapshot = backend.load_snapshot("wf-notify").await.unwrap();
+    snapshot.mark_completed(Bytes::from("done"));
+    backend.save_snapshot(&snapshot).await.unwrap();
+    let no_notify = tokio::time::timeout(Duration::from_millis(150), listener.recv()).await;
+    assert!(
+        no_notify.is_err(),
+        "Completed save should not emit a NOTIFY; got {:?}",
+        no_notify.ok()
+    );
+}
+
+/// `wait_for_wakeup` must return promptly once a `NOTIFY` is emitted by a
+/// concurrent `save_snapshot`. The timeout is a ceiling; under normal
+/// operation the listener delivers in <100 ms.
+#[tokio::test]
+async fn wait_for_wakeup_returns_on_notify() {
+    use std::time::{Duration, Instant};
+    use tokio::time::sleep;
+
+    let (_c, backend) = setup().await;
+    let backend2 = backend.clone();
+
+    // Give the LISTEN task a brief moment to actually subscribe before we
+    // race a NOTIFY against it. The listener spawns in `init` but the
+    // socket-level LISTEN registration is racy without this nudge.
+    sleep(Duration::from_millis(100)).await;
+
+    let producer = tokio::spawn(async move {
+        sleep(Duration::from_millis(150)).await;
+        let mut snapshot = WorkflowSnapshot::new("wf-wake".into(), "h".into());
+        snapshot.update_position(ExecutionPosition::AtTask {
+            task_id: "step-1".into(),
+        });
+        backend2.save_snapshot(&snapshot).await.unwrap();
+    });
+
+    let started = Instant::now();
+    backend
+        .wait_for_wakeup(Duration::from_secs(5))
+        .await
+        .unwrap();
+    let elapsed = started.elapsed();
+
+    producer.await.unwrap();
+
+    assert!(
+        elapsed < Duration::from_secs(2),
+        "expected NOTIFY-driven wakeup within 2s, took {elapsed:?}",
+    );
+}
+
+/// With no NOTIFY traffic, `wait_for_wakeup` must respect its timeout and
+/// return at the deadline — this is the fallback poll guarantee.
+#[tokio::test]
+async fn wait_for_wakeup_respects_timeout() {
+    use std::time::{Duration, Instant};
+
+    let (_c, backend) = setup().await;
+    // Let the listener subscribe so a real Notify is in place — the
+    // timeout path must hold even when the channel is actively listened.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let started = Instant::now();
+    backend
+        .wait_for_wakeup(Duration::from_millis(300))
+        .await
+        .unwrap();
+    let elapsed = started.elapsed();
+
+    assert!(
+        elapsed >= Duration::from_millis(280),
+        "expected ~300ms timeout, returned in {elapsed:?}",
+    );
+    assert!(
+        elapsed < Duration::from_secs(1),
+        "expected timeout near 300ms, got {elapsed:?}",
+    );
+}
+
+/// `wait_for_wakeup` must return the parsed `TaskWakeupHint` when a
+/// NOTIFY arrives, not just signal that something happened.
+#[tokio::test]
+async fn wait_for_wakeup_delivers_parsed_hint() {
+    use std::time::Duration;
+    use tokio::time::sleep;
+
+    let (_c, backend) = setup().await;
+    let backend2 = backend.clone();
+    sleep(Duration::from_millis(100)).await;
+
+    let producer = tokio::spawn(async move {
+        sleep(Duration::from_millis(100)).await;
+        let mut snapshot = WorkflowSnapshot::new("wf-hinted".into(), "h-xyz".into());
+        snapshot.update_position(ExecutionPosition::AtTask {
+            task_id: "task-a".into(),
+        });
+        backend2.save_snapshot(&snapshot).await.unwrap();
+    });
+
+    let hint = backend
+        .wait_for_wakeup(Duration::from_secs(2))
+        .await
+        .unwrap()
+        .expect("expected a hint from the NOTIFY");
+    producer.await.unwrap();
+
+    assert_eq!(hint.instance_id, "wf-hinted");
+    assert_eq!(hint.task_id, "task-a");
+    assert_eq!(hint.definition_hash, "h-xyz");
+}
+
+/// `find_hinted_task` must return an `AvailableTask` when the snapshot
+/// is still at the hinted task with no claim or signal block.
+#[tokio::test]
+async fn find_hinted_task_returns_available_task() {
+    use sayiir_persistence::TaskWakeupHint;
+
+    let (_c, backend) = setup().await;
+    let mut snapshot = WorkflowSnapshot::with_initial_input(
+        "wf-hint-found".into(),
+        "h".into(),
+        Bytes::from_static(b"\"input\""),
+    );
+    snapshot.update_position(ExecutionPosition::AtTask {
+        task_id: "first".into(),
+    });
+    backend.save_snapshot(&snapshot).await.unwrap();
+
+    let hint = TaskWakeupHint {
+        instance_id: "wf-hint-found".into(),
+        task_id: "first".into(),
+        definition_hash: "h".into(),
+        tags: vec![],
+    };
+    let task = backend
+        .find_hinted_task(&hint)
+        .await
+        .unwrap()
+        .expect("hinted task should still be eligible");
+    assert_eq!(task.instance_id, "wf-hint-found");
+    assert_eq!(task.task_id, "first");
+    assert_eq!(task.workflow_definition_hash, "h");
+}
+
+/// `find_hinted_task` must return `None` when the snapshot already
+/// moved past the hinted task (stale hint) — caller falls back to
+/// the full poll, no claim happens.
+#[tokio::test]
+async fn find_hinted_task_returns_none_when_stale() {
+    use sayiir_persistence::TaskWakeupHint;
+
+    let (_c, backend) = setup().await;
+    let mut snapshot = WorkflowSnapshot::new("wf-stale".into(), "h".into());
+    snapshot.update_position(ExecutionPosition::AtTask {
+        task_id: "second".into(),
+    });
+    backend.save_snapshot(&snapshot).await.unwrap();
+
+    // Hint targets a task the workflow is no longer at — should be skipped.
+    let hint = TaskWakeupHint {
+        instance_id: "wf-stale".into(),
+        task_id: "first".into(),
+        definition_hash: "h".into(),
+        tags: vec![],
+    };
+    assert!(backend.find_hinted_task(&hint).await.unwrap().is_none());
+}
+
+/// `find_hinted_task` must return `None` when an active claim already
+/// holds the task — preserving the find_available_tasks invariant that
+/// claimed work is never re-handed-out.
+#[tokio::test]
+async fn find_hinted_task_returns_none_when_claimed() {
+    use sayiir_persistence::TaskWakeupHint;
+
+    let (_c, backend) = setup().await;
+    let mut snapshot = WorkflowSnapshot::new("wf-claimed".into(), "h".into());
+    snapshot.update_position(ExecutionPosition::AtTask {
+        task_id: "first".into(),
+    });
+    backend.save_snapshot(&snapshot).await.unwrap();
+
+    backend
+        .claim_task("wf-claimed", "first", "other-worker", None)
+        .await
+        .unwrap()
+        .expect("first claim should succeed");
+
+    let hint = TaskWakeupHint {
+        instance_id: "wf-claimed".into(),
+        task_id: "first".into(),
+        definition_hash: "h".into(),
+        tags: vec![],
+    };
+    assert!(backend.find_hinted_task(&hint).await.unwrap().is_none());
+}
+
 /// `connect_with` must reject PostgreSQL versions below the minimum (13).
 #[tokio::test]
 async fn rejects_unsupported_pg_version() {

--- a/sayiir-py/src/worker.rs
+++ b/sayiir-py/src/worker.rs
@@ -30,7 +30,11 @@ use crate::flow::PyWorkflow;
 /// Args:
 ///     `worker_id`: Unique identifier for this worker node
 ///     backend: Either `InMemoryBackend()` or `PostgresBackend(url)`
-///     `poll_interval_secs`: Seconds between polls (default: 5.0)
+///     `poll_interval_secs`: Seconds between fallback polls (default: 30.0).
+///         For PG backends, LISTEN/NOTIFY wakes the worker within ms of
+///         a task transitioning to claimable, so this only bounds the
+///         worst-case latency for events NOTIFY can't cover (delay
+///         expiry, expired claims, lost LISTEN connections).
 ///     `claim_ttl_secs`: Task claim TTL in seconds (default: 300.0)
 #[pyclass]
 pub struct PyWorker {
@@ -45,7 +49,7 @@ pub struct PyWorker {
 #[pymethods]
 impl PyWorker {
     #[new]
-    #[pyo3(signature = (worker_id, backend, poll_interval_secs=5.0, claim_ttl_secs=300.0, tags=None))]
+    #[pyo3(signature = (worker_id, backend, poll_interval_secs=30.0, claim_ttl_secs=300.0, tags=None))]
     fn new(
         worker_id: String,
         backend: &Bound<'_, PyAny>,

--- a/sayiir-python/sayiir/_sayiir.pyi
+++ b/sayiir-python/sayiir/_sayiir.pyi
@@ -200,7 +200,7 @@ class PyWorker:
         self,
         worker_id: str,
         backend: PyInMemoryBackend | PyPostgresBackend,
-        poll_interval_secs: float = 5.0,
+        poll_interval_secs: float = 30.0,
         claim_ttl_secs: float = 300.0,
         tags: list[str] | None = None,
     ) -> None: ...

--- a/sayiir-python/sayiir/_sayiir.pyi
+++ b/sayiir-python/sayiir/_sayiir.pyi
@@ -189,7 +189,7 @@ class PyWorker:
         self,
         worker_id: str,
         backend: PyInMemoryBackend | PyPostgresBackend,
-        poll_interval_secs: float = 5.0,
+        poll_interval_secs: float = 30.0,
         claim_ttl_secs: float = 300.0,
         tags: list[str] | None = None,
     ) -> None: ...

--- a/sayiir-runtime/src/execution/tests.rs
+++ b/sayiir-runtime/src/execution/tests.rs
@@ -1172,7 +1172,7 @@ async fn test_checkpointing_delay_returns_waiting() {
     let next_task = stub_node("process", None);
     let delay = WorkflowContinuation::Delay {
         id: "wait_1h".into(),
-        duration: std::time::Duration::from_secs(3600),
+        duration: std::time::Duration::from_hours(1),
         next: Some(Box::new(next_task)),
     };
 
@@ -1232,7 +1232,7 @@ async fn test_checkpointing_delay_skip_on_resume() {
     let process = stub_node("process", None);
     let delay = WorkflowContinuation::Delay {
         id: "wait".into(),
-        duration: std::time::Duration::from_secs(3600),
+        duration: std::time::Duration::from_hours(1),
         next: Some(Box::new(process)),
     };
 
@@ -1286,7 +1286,7 @@ async fn test_checkpointing_delay_cancellation() {
 
     let delay = WorkflowContinuation::Delay {
         id: "wait".into(),
-        duration: std::time::Duration::from_secs(3600),
+        duration: std::time::Duration::from_hours(1),
         next: None,
     };
 
@@ -1364,7 +1364,7 @@ fn fork_with_delay_in_branch() -> WorkflowContinuation {
     let after_delay = stub_node("after_delay", None);
     let delay = WorkflowContinuation::Delay {
         id: "branch_delay".into(),
-        duration: std::time::Duration::from_secs(3600),
+        duration: std::time::Duration::from_hours(1),
         next: Some(Box::new(after_delay)),
     };
     let branch_b = Arc::new(stub_node("before_delay", Some(Box::new(delay))));
@@ -1623,7 +1623,7 @@ async fn test_fork_normal_branch_completes_delayed_branch_parks() {
     let branch_a = Arc::new(stub_node("branch_a", None));
     let delay = WorkflowContinuation::Delay {
         id: "branch_delay".into(),
-        duration: std::time::Duration::from_secs(3600),
+        duration: std::time::Duration::from_hours(1),
         next: None,
     };
     let branch_b = Arc::new(delay);
@@ -2331,7 +2331,7 @@ async fn test_checkpointing_delay_terminal_parks() {
 
     let delay = WorkflowContinuation::Delay {
         id: "final_wait".into(),
-        duration: std::time::Duration::from_secs(3600),
+        duration: std::time::Duration::from_hours(1),
         next: None,
     };
 

--- a/sayiir-runtime/src/runner/distributed.rs
+++ b/sayiir-runtime/src/runner/distributed.rs
@@ -1382,7 +1382,7 @@ mod tests {
 
         let workflow = WorkflowBuilder::new(ctx())
             .then("step1", |i: u32| async move { Ok(i + 1) })
-            .delay("wait_1h", std::time::Duration::from_secs(3600))
+            .delay("wait_1h", std::time::Duration::from_hours(1))
             .then("step2", |i: u32| async move { Ok(i * 2) })
             .build()
             .unwrap();
@@ -1428,7 +1428,7 @@ mod tests {
 
         let workflow = WorkflowBuilder::new(ctx())
             .then("step1", |i: u32| async move { Ok(i + 1) })
-            .delay("wait_1h", std::time::Duration::from_secs(3600))
+            .delay("wait_1h", std::time::Duration::from_hours(1))
             .then("step2", |i: u32| async move { Ok(i * 2) })
             .build()
             .unwrap();
@@ -1486,7 +1486,7 @@ mod tests {
 
         let workflow = WorkflowBuilder::new(ctx())
             .then("step1", |i: u32| async move { Ok(i + 1) })
-            .delay("wait_1h", std::time::Duration::from_secs(3600))
+            .delay("wait_1h", std::time::Duration::from_hours(1))
             .then("step2", |i: u32| async move { Ok(i * 2) })
             .build()
             .unwrap();

--- a/sayiir-runtime/src/worker.rs
+++ b/sayiir-runtime/src/worker.rs
@@ -2248,12 +2248,12 @@ mod tests {
         let registry = TaskRegistry::new();
         let worker = PooledWorker::builder(backend, registry)
             .worker_id("w1")
-            .claim_ttl(Some(Duration::from_secs(120)))
+            .claim_ttl(Some(Duration::from_mins(2)))
             .batch_size(NonZeroUsize::new(8).unwrap())
             .build();
 
         assert_eq!(worker.worker_id, "w1");
-        assert_eq!(worker.claim_ttl, Some(Duration::from_secs(120)));
+        assert_eq!(worker.claim_ttl, Some(Duration::from_mins(2)));
         assert_eq!(worker.batch_size.get(), 8);
     }
 

--- a/sayiir-runtime/src/worker.rs
+++ b/sayiir-runtime/src/worker.rs
@@ -26,7 +26,7 @@ use sayiir_core::snapshot::{
 };
 use sayiir_core::task_claim::AvailableTask;
 use sayiir_core::workflow::{Workflow, WorkflowContinuation, WorkflowStatus};
-use sayiir_persistence::{PersistentBackend, TaskClaimStore};
+use sayiir_persistence::{PersistentBackend, TaskClaimStore, TaskWakeupHint};
 use std::num::NonZeroUsize;
 use std::panic::AssertUnwindSafe;
 use std::pin::Pin;
@@ -54,6 +54,26 @@ pub struct ExternalWorkflow {
 
 /// Workflow index keyed by definition hash for O(1) lookup during task dispatch.
 pub type WorkflowIndex = HashMap<String, ExternalWorkflow>;
+
+/// Definition-hash containment over either [`WorkflowIndex`] (`HashMap`,
+/// O(1)) or [`WorkflowRegistry`] (`Vec`, O(n)). Lets `can_handle_hint`
+/// accept any worker-registered workflows collection uniformly instead
+/// of taking a hand-rolled closure per call site.
+pub(crate) trait WorkflowLookup {
+    fn contains_definition_hash(&self, hash: &str) -> bool;
+}
+
+impl WorkflowLookup for WorkflowIndex {
+    fn contains_definition_hash(&self, hash: &str) -> bool {
+        self.contains_key(hash)
+    }
+}
+
+impl<C, Input, M> WorkflowLookup for WorkflowRegistry<C, Input, M> {
+    fn contains_definition_hash(&self, hash: &str) -> bool {
+        self.iter().any(|(k, _)| k == hash)
+    }
+}
 
 /// External task executor function signature.
 ///
@@ -463,7 +483,7 @@ where
         let mut interval = time::interval(poll_interval);
 
         loop {
-            tokio::select! {
+            let hint = tokio::select! {
                 biased;
 
                 cmd = cmd_rx.recv() => {
@@ -474,9 +494,42 @@ where
                         }
                     }
                 }
-
                 _ = interval.tick() => {
-                    tracing::trace!(worker_id = %self.worker_id, "Will poll for available tasks");
+                    tracing::trace!(worker_id = %self.worker_id, "fallback poll tick");
+                    None
+                }
+                hint = self.backend.wait_for_wakeup(poll_interval) => {
+                    let hint = hint?;
+                    tracing::debug!(
+                        worker_id = %self.worker_id,
+                        has_hint = hint.is_some(),
+                        "wakeup notification",
+                    );
+                    hint
+                }
+            };
+
+            if let Some(h) = hint.as_ref()
+                && !self.can_handle_hint(h, &workflows)
+            {
+                // This optimization cuts PG load proportional to NOTIFY volume x fleet-tag-fragmentation.
+                tracing::trace!(
+                    worker_id = %self.worker_id,
+                    instance_id = %h.instance_id,
+                    "skipping wakeup, hint not handleable here",
+                );
+                continue;
+            }
+
+            if let Some(h) = hint.as_ref() {
+                match self.try_hinted_execute(h, &workflows, &executor).await {
+                    Ok(true) => continue,
+                    Ok(false) => {}
+                    Err(ref e) if e.is_timeout() => {
+                        tracing::error!(worker_id = %self.worker_id, error = %e, "Task timed out — worker shutting down");
+                        return Ok(());
+                    }
+                    Err(e) => return Err(e),
                 }
             }
 
@@ -531,6 +584,43 @@ where
                 }
             }
         }
+    }
+
+    /// True if the worker has the hint's workflow registered and its
+    /// tag set covers the hint's tags.
+    fn can_handle_hint(&self, hint: &TaskWakeupHint, workflows: &impl WorkflowLookup) -> bool {
+        if !workflows.contains_definition_hash(&hint.definition_hash) {
+            return false;
+        }
+        hint.tags.iter().all(|t| self.tags.contains(t))
+    }
+
+    /// `Ok(true)` if the hinted task was claimed and executed (or its
+    /// execution failed non-fatally), `Ok(false)` to fall through to the
+    /// full polling scan, `Err(e)` on a fatal task timeout.
+    async fn try_hinted_execute(
+        &self,
+        hint: &TaskWakeupHint,
+        workflows: &WorkflowIndex,
+        executor: &ExternalTaskExecutor,
+    ) -> Result<bool, crate::error::RuntimeError> {
+        let Some(task) = self.backend.find_hinted_task(hint).await? else {
+            return Ok(false);
+        };
+        let Some(ext_wf) = workflows.get(&task.workflow_definition_hash) else {
+            return Ok(false);
+        };
+        match self
+            .execute_external_task(ext_wf, &task.workflow_definition_hash, executor, &task)
+            .await
+        {
+            Err(e) if e.is_timeout() => return Err(e),
+            Ok(_) => tracing::info!(worker_id = %self.worker_id, "completed hinted task"),
+            Err(e) => {
+                tracing::error!(worker_id = %self.worker_id, error = %e, "hinted task execution failed");
+            }
+        }
+        Ok(true)
     }
 
     /// Execute a single task using an external executor.
@@ -763,11 +853,12 @@ where
         let mut interval = time::interval(poll_interval);
 
         loop {
-            tokio::select! {
+            // In-process mode only filters irrelevant wakes; the direct-
+            // claim shortcut lives on the external-executor path.
+            let hint = tokio::select! {
                 biased;
 
                 cmd = cmd_rx.recv() => {
-                    // None (all handles dropped) or Some(Shutdown) → exit
                     match cmd {
                         Some(WorkerCommand::Shutdown) | None => {
                             tracing::info!(worker_id = %self.worker_id, "Worker shutting down");
@@ -775,10 +866,31 @@ where
                         }
                     }
                 }
-
                 _ = interval.tick() => {
-                    tracing::trace!(worker_id = %self.worker_id, "Will poll for available tasks");
+                    tracing::trace!(worker_id = %self.worker_id, "fallback poll tick");
+                    None
                 }
+                hint = self.backend.wait_for_wakeup(poll_interval) => {
+                    let hint = hint?;
+                    tracing::debug!(
+                        worker_id = %self.worker_id,
+                        has_hint = hint.is_some(),
+                        "wakeup notification",
+                    );
+                    hint
+                }
+            };
+
+            if let Some(h) = hint.as_ref()
+                && !self.can_handle_hint(h, &workflows)
+            {
+                // This optimization cuts PG load proportional to NOTIFY volume x fleet-tag-fragmentation.
+                tracing::trace!(
+                    worker_id = %self.worker_id,
+                    instance_id = %h.instance_id,
+                    "skipping wakeup, hint not handleable here",
+                );
+                continue;
             }
 
             let available_tasks = self


### PR DESCRIPTION
## Overview

- Add LISTEN/NOTIFY-driven wakeups to the Postgres backend so workers learn about claimable tasks within
  milliseconds instead of waiting for the next poll tick.
- Each NOTIFY carries a TaskWakeupHint payload (instance_id, task_id, definition_hash, tags) that lets workers:
- Filter at receive time, drop wakes for workflows they don't have registered or tag sets they can't cover,
  before any DB round-trip.
- Direct-claim the named task — find_hinted_task runs a one-row eligibility check instead of the full priority-ordered find_available_tasks scan; the worker then claims atomically through the existing execute pipeline.
- The fallback find_available_tasks poll stays as the safety net for the cases NOTIFY can't cover (delay expiry, expired claim cleanup, lost LISTEN connection).

- Default polling interval raised from 5 s → 30 s. NOTIFY now handles the latency floor on PG; the timer just bounds worst-case staleness for the cases above. **6× less polling pressure on PG in steady state**.


#107 