### PR TITLE
significant reduction of string allocations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ chrono = { version = "0.4", default-features = false, features = [
     "serde",
     "clock",
 ] }
-serde = { version = "1", features = ["derive"] }
+serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 rkyv = { version = "0.8", features = ["std", "bytecheck", "bytes-1"] }
 bytecheck = "0.8"

--- a/sayiir-cloudflare/src/codec.rs
+++ b/sayiir-cloudflare/src/codec.rs
@@ -224,6 +224,12 @@ pub(crate) fn decode_loop_result(bytes: &[u8]) -> Result<(String, Bytes), JsValu
 }
 
 #[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing
+)]
 mod tests {
     use super::*;
     use wasm_bindgen_test::*;

--- a/sayiir-cloudflare/src/durable.rs
+++ b/sayiir-cloudflare/src/durable.rs
@@ -103,7 +103,7 @@ impl WasmDurableEngine {
         let first_task = continuation.first_task_hint();
 
         let outcome = lifecycle::prepare_run(
-            instance_id,
+            &instance_id,
             workflow.definition_hash,
             input_bytes.clone(),
             first_task,
@@ -418,7 +418,9 @@ impl<'a> Executor<'a> {
         // Park at delay — save checkpoint and return
         let wake_at =
             Utc::now() + chrono::Duration::from_std(*duration).unwrap_or(chrono::Duration::zero());
-        let next_task_id = next.as_deref().map(|n| n.first_task_id().to_string());
+        let next_task_id = next
+            .as_deref()
+            .map(|n| sayiir_core::TaskId::from(n.first_task_id()));
 
         self.snapshot.update_position(ExecutionPosition::AtDelay {
             delay_id: sayiir_core::TaskId::from(id),
@@ -485,7 +487,9 @@ impl<'a> Executor<'a> {
                 let wake_at = timeout.map(|d| {
                     Utc::now() + chrono::Duration::from_std(d).unwrap_or(chrono::Duration::zero())
                 });
-                let next_task_id = next.as_deref().map(|n| n.first_task_id().to_string());
+                let next_task_id = next
+                    .as_deref()
+                    .map(|n| sayiir_core::TaskId::from(n.first_task_id()));
 
                 self.snapshot.update_position(ExecutionPosition::AtSignal {
                     signal_id: sayiir_core::TaskId::from(id),
@@ -530,13 +534,11 @@ impl<'a> Executor<'a> {
         let mut max_wake_at: Option<chrono::DateTime<Utc>> = None;
 
         for branch in branches {
-            let branch_id = branch.id().to_string();
+            let branch_name = branch.id().to_string();
+            let branch_hash = sayiir_core::TaskId::from(branch_name.as_str());
 
-            if let Some(cached) = self
-                .snapshot
-                .get_task_result(&sayiir_core::TaskId::from(branch_id))
-            {
-                branch_results.push((branch_id, cached.output.clone()));
+            if let Some(cached) = self.snapshot.get_task_result(&branch_hash) {
+                branch_results.push((branch_name, cached.output.clone()));
                 continue;
             }
 
@@ -548,9 +550,9 @@ impl<'a> Executor<'a> {
                     // output (because the first task uses `branch_id` as
                     // its own id) and feed the wrong value into the join.
                     self.snapshot
-                        .mark_task_completed(sayiir_core::TaskId::from(branch_id), output.clone());
+                        .mark_task_completed(branch_hash, output.clone());
                     self.checkpoint().await?;
-                    branch_results.push((branch_id, output));
+                    branch_results.push((branch_name, output));
                 }
                 Err(WorkflowError::Waiting { wake_at }) => {
                     max_wake_at = Some(match max_wake_at {
@@ -591,14 +593,14 @@ impl<'a> Executor<'a> {
                 (
                     id.clone(),
                     TaskResult {
-                        task_id: sayiir_core::TaskId::from(id),
+                        task_id: sayiir_core::TaskId::from(id.as_str()),
                         output: output.clone(),
                     },
                 )
             })
             .collect();
         self.snapshot.update_position(ExecutionPosition::AtFork {
-            fork_id: fork_id,
+            fork_id: sayiir_core::TaskId::from(fork_id),
             completed_branches,
             wake_at,
         });
@@ -819,13 +821,13 @@ async fn execute_with_checkpointing(
 /// return values.
 async fn call_js_task(
     registry: &js_sys::Object,
-    task_id: &sayiir_core::TaskId,
+    task_name: &str,
     input: &Bytes,
 ) -> Result<Bytes, WorkflowError> {
-    let func: js_sys::Function = js_sys::Reflect::get(registry, &JsValue::from_str(task_id))
-        .map_err(|_| WorkflowError::TaskNotFound(task_id.to_string()))?
+    let func: js_sys::Function = js_sys::Reflect::get(registry, &JsValue::from_str(task_name))
+        .map_err(|_| WorkflowError::TaskNotFound(task_name.to_string()))?
         .dyn_into()
-        .map_err(|_| WorkflowError::TaskNotFound(format!("'{task_id}' is not a function")))?;
+        .map_err(|_| WorkflowError::TaskNotFound(format!("'{task_name}' is not a function")))?;
 
     let input_js = decode_to_js_value(input)
         .map_err(|e| WorkflowError::ResumeError(format!("Failed to decode task input: {e:?}")))?;
@@ -839,7 +841,7 @@ async fn call_js_task(
                     .and_then(|m| m.as_string())
             })
             .unwrap_or_else(|| format!("{e:?}"));
-        WorkflowError::TaskPanicked(format!("Task '{task_id}': {msg}"))
+        WorkflowError::TaskPanicked(format!("Task '{task_name}': {msg}"))
     })?;
 
     // If the result is a Promise (thenable), await it
@@ -854,7 +856,7 @@ async fn call_js_task(
                         .and_then(|m| m.as_string())
                 })
                 .unwrap_or_else(|| format!("{e:?}"));
-            WorkflowError::TaskPanicked(format!("Task '{task_id}': {msg}"))
+            WorkflowError::TaskPanicked(format!("Task '{task_name}': {msg}"))
         })?
     } else {
         result
@@ -878,7 +880,7 @@ fn is_thenable(value: &JsValue) -> bool {
 async fn check_guards(
     backend: &D1Backend,
     instance_id: &str,
-    scope: Option<&str>,
+    scope: Option<sayiir_core::TaskId>,
 ) -> Result<(), WorkflowError> {
     if backend
         .check_and_cancel(instance_id, scope)

--- a/sayiir-cloudflare/src/durable.rs
+++ b/sayiir-cloudflare/src/durable.rs
@@ -104,7 +104,7 @@ impl WasmDurableEngine {
 
         let outcome = lifecycle::prepare_run(
             instance_id,
-            workflow.definition_hash.clone(),
+            workflow.definition_hash,
             input_bytes.clone(),
             first_task,
             self.backend.as_ref(),

--- a/sayiir-cloudflare/src/durable.rs
+++ b/sayiir-cloudflare/src/durable.rs
@@ -358,27 +358,35 @@ impl<'a> Executor<'a> {
             unreachable!()
         };
 
-        check_guards(self.backend, &self.snapshot.instance_id, Some(id)).await?;
+        check_guards(
+            self.backend,
+            &self.snapshot.instance_id,
+            Some(sayiir_core::TaskId::from(id)),
+        )
+        .await?;
 
-        let output =
-            if let Some(cached) = self.snapshot.get_task_result(id).map(|r| r.output.clone()) {
-                cached
-            } else {
-                let result = call_js_task(self.task_registry, id, &input).await?;
-                self.snapshot
-                    .mark_task_completed(id.clone(), result.clone());
+        let output = if let Some(cached) = self
+            .snapshot
+            .get_task_result(&sayiir_core::TaskId::from(id))
+            .map(|r| r.output.clone())
+        {
+            cached
+        } else {
+            let result = call_js_task(self.task_registry, id, &input).await?;
+            self.snapshot
+                .mark_task_completed(sayiir_core::TaskId::from(id), result.clone());
 
-                if let Some(next_cont) = next.as_deref() {
-                    self.snapshot.update_position(ExecutionPosition::AtTask {
-                        task_id: next_cont.first_task_id().to_string(),
-                    });
-                }
-                self.checkpoint().await?;
+            if let Some(next_cont) = next.as_deref() {
+                self.snapshot.update_position(ExecutionPosition::AtTask {
+                    task_id: sayiir_core::TaskId::from(next_cont.first_task_id()),
+                });
+            }
+            self.checkpoint().await?;
 
-                check_guards(self.backend, &self.snapshot.instance_id, None).await?;
+            check_guards(self.backend, &self.snapshot.instance_id, None).await?;
 
-                result
-            };
+            result
+        };
 
         Ok(advance_or_break(next.as_deref(), output))
     }
@@ -392,9 +400,18 @@ impl<'a> Executor<'a> {
             unreachable!()
         };
 
-        check_guards(self.backend, &self.snapshot.instance_id, Some(id)).await?;
+        check_guards(
+            self.backend,
+            &self.snapshot.instance_id,
+            Some(sayiir_core::TaskId::from(id)),
+        )
+        .await?;
 
-        if self.snapshot.get_task_result(id).is_some() {
+        if self
+            .snapshot
+            .get_task_result(&sayiir_core::TaskId::from(id))
+            .is_some()
+        {
             return Ok(advance_or_break(next.as_deref(), input));
         }
 
@@ -404,12 +421,13 @@ impl<'a> Executor<'a> {
         let next_task_id = next.as_deref().map(|n| n.first_task_id().to_string());
 
         self.snapshot.update_position(ExecutionPosition::AtDelay {
-            delay_id: id.clone(),
+            delay_id: sayiir_core::TaskId::from(id),
             entered_at: Utc::now(),
             wake_at,
             next_task_id,
         });
-        self.snapshot.mark_task_completed(id.clone(), input);
+        self.snapshot
+            .mark_task_completed(sayiir_core::TaskId::from(id), input);
         self.checkpoint().await?;
 
         Err(WorkflowError::Waiting { wake_at })
@@ -430,9 +448,17 @@ impl<'a> Executor<'a> {
             unreachable!()
         };
 
-        check_guards(self.backend, &self.snapshot.instance_id, Some(id)).await?;
+        check_guards(
+            self.backend,
+            &self.snapshot.instance_id,
+            Some(sayiir_core::TaskId::from(id)),
+        )
+        .await?;
 
-        if let Some(result) = self.snapshot.get_task_result(id) {
+        if let Some(result) = self
+            .snapshot
+            .get_task_result(&sayiir_core::TaskId::from(id))
+        {
             let payload = result.output.clone();
             return Ok(advance_or_break(next.as_deref(), payload));
         }
@@ -445,10 +471,10 @@ impl<'a> Executor<'a> {
         {
             Ok(Some(payload)) => {
                 self.snapshot
-                    .mark_task_completed(id.clone(), payload.clone());
+                    .mark_task_completed(sayiir_core::TaskId::from(id), payload.clone());
                 if let Some(next_cont) = next.as_deref() {
                     self.snapshot.update_position(ExecutionPosition::AtTask {
-                        task_id: next_cont.first_task_id().to_string(),
+                        task_id: sayiir_core::TaskId::from(next_cont.first_task_id()),
                     });
                 }
                 self.checkpoint().await?;
@@ -462,7 +488,7 @@ impl<'a> Executor<'a> {
                 let next_task_id = next.as_deref().map(|n| n.first_task_id().to_string());
 
                 self.snapshot.update_position(ExecutionPosition::AtSignal {
-                    signal_id: id.clone(),
+                    signal_id: sayiir_core::TaskId::from(id),
                     signal_name: signal_name.clone(),
                     wake_at,
                     next_task_id,
@@ -470,7 +496,7 @@ impl<'a> Executor<'a> {
                 self.checkpoint().await?;
 
                 Err(WorkflowError::AwaitingSignal {
-                    signal_id: id.clone(),
+                    signal_id: sayiir_core::TaskId::from(id),
                     signal_name: signal_name.clone(),
                     wake_at,
                 })
@@ -506,7 +532,10 @@ impl<'a> Executor<'a> {
         for branch in branches {
             let branch_id = branch.id().to_string();
 
-            if let Some(cached) = self.snapshot.get_task_result(&branch_id) {
+            if let Some(cached) = self
+                .snapshot
+                .get_task_result(&sayiir_core::TaskId::from(branch_id))
+            {
                 branch_results.push((branch_id, cached.output.clone()));
                 continue;
             }
@@ -519,7 +548,7 @@ impl<'a> Executor<'a> {
                     // output (because the first task uses `branch_id` as
                     // its own id) and feed the wrong value into the join.
                     self.snapshot
-                        .mark_task_completed(branch_id.clone(), output.clone());
+                        .mark_task_completed(sayiir_core::TaskId::from(branch_id), output.clone());
                     self.checkpoint().await?;
                     branch_results.push((branch_id, output));
                 }
@@ -562,14 +591,14 @@ impl<'a> Executor<'a> {
                 (
                     id.clone(),
                     TaskResult {
-                        task_id: id.clone(),
+                        task_id: sayiir_core::TaskId::from(id),
                         output: output.clone(),
                     },
                 )
             })
             .collect();
         self.snapshot.update_position(ExecutionPosition::AtFork {
-            fork_id: fork_id.to_string(),
+            fork_id: fork_id,
             completed_branches,
             wake_at,
         });
@@ -592,9 +621,17 @@ impl<'a> Executor<'a> {
             unreachable!()
         };
 
-        check_guards(self.backend, &self.snapshot.instance_id, Some(id)).await?;
+        check_guards(
+            self.backend,
+            &self.snapshot.instance_id,
+            Some(sayiir_core::TaskId::from(id)),
+        )
+        .await?;
 
-        if let Some(result) = self.snapshot.get_task_result(id) {
+        if let Some(result) = self
+            .snapshot
+            .get_task_result(&sayiir_core::TaskId::from(id))
+        {
             return Ok(advance_or_break(next.as_deref(), result.output.clone()));
         }
 
@@ -619,7 +656,7 @@ impl<'a> Executor<'a> {
             .map_err(|e| WorkflowError::ResumeError(format!("{e:?}")))?;
 
         self.snapshot
-            .mark_task_completed(id.clone(), envelope_bytes.clone());
+            .mark_task_completed(sayiir_core::TaskId::from(id), envelope_bytes.clone());
         self.checkpoint().await?;
 
         Ok(advance_or_break(next.as_deref(), envelope_bytes))
@@ -641,13 +678,21 @@ impl<'a> Executor<'a> {
             unreachable!()
         };
 
-        check_guards(self.backend, &self.snapshot.instance_id, Some(id)).await?;
+        check_guards(
+            self.backend,
+            &self.snapshot.instance_id,
+            Some(sayiir_core::TaskId::from(id)),
+        )
+        .await?;
 
-        if let Some(result) = self.snapshot.get_task_result(id) {
+        if let Some(result) = self
+            .snapshot
+            .get_task_result(&sayiir_core::TaskId::from(id))
+        {
             return Ok(advance_or_break(next.as_deref(), result.output.clone()));
         }
 
-        let start = self.snapshot.loop_iteration(id);
+        let start = self.snapshot.loop_iteration(&sayiir_core::TaskId::from(id));
         let mut loop_input = input;
 
         for iteration in start..*max_iterations {
@@ -656,24 +701,27 @@ impl<'a> Executor<'a> {
             // Clear body task results for next iteration
             let body_ser = body.to_serializable();
             for tid in &body_ser.task_ids() {
-                self.snapshot.remove_task_result(tid);
+                self.snapshot
+                    .remove_task_result(&sayiir_core::TaskId::from(*tid));
             }
 
             let (tag, inner_bytes) = decode_loop_result(&output)
                 .map_err(|e| WorkflowError::ResumeError(format!("{e:?}")))?;
 
             if tag == sayiir_core::codec::LoopDecision::Done.as_ref() {
-                self.snapshot.clear_loop_iteration(id);
                 self.snapshot
-                    .mark_task_completed(id.clone(), inner_bytes.clone());
+                    .clear_loop_iteration(&sayiir_core::TaskId::from(id));
+                self.snapshot
+                    .mark_task_completed(sayiir_core::TaskId::from(id), inner_bytes.clone());
                 self.checkpoint().await?;
                 return Ok(advance_or_break(next.as_deref(), inner_bytes));
             } else if tag == sayiir_core::codec::LoopDecision::Again.as_ref() {
-                self.snapshot.set_loop_iteration(id, iteration + 1);
+                self.snapshot
+                    .set_loop_iteration(sayiir_core::TaskId::from(id), iteration + 1);
                 self.snapshot.update_position(ExecutionPosition::InLoop {
-                    loop_id: id.clone(),
+                    loop_id: sayiir_core::TaskId::from(id),
                     iteration: iteration + 1,
-                    next_task_id: Some(body.first_task_id().to_string()),
+                    next_task_id: Some(sayiir_core::TaskId::from(body.first_task_id())),
                 });
                 self.checkpoint().await?;
                 loop_input = inner_bytes;
@@ -688,14 +736,15 @@ impl<'a> Executor<'a> {
         match on_max {
             sayiir_core::workflow::MaxIterationsPolicy::Fail => {
                 Err(WorkflowError::MaxIterationsExceeded {
-                    loop_id: id.clone(),
+                    loop_id: sayiir_core::TaskId::from(id),
                     max_iterations: *max_iterations,
                 })
             }
             sayiir_core::workflow::MaxIterationsPolicy::ExitWithLast => {
-                self.snapshot.clear_loop_iteration(id);
                 self.snapshot
-                    .mark_task_completed(id.clone(), loop_input.clone());
+                    .clear_loop_iteration(&sayiir_core::TaskId::from(id));
+                self.snapshot
+                    .mark_task_completed(sayiir_core::TaskId::from(id), loop_input.clone());
                 self.checkpoint().await?;
                 Ok(advance_or_break(next.as_deref(), loop_input))
             }
@@ -714,16 +763,24 @@ impl<'a> Executor<'a> {
             unreachable!()
         };
 
-        check_guards(self.backend, &self.snapshot.instance_id, Some(id)).await?;
+        check_guards(
+            self.backend,
+            &self.snapshot.instance_id,
+            Some(sayiir_core::TaskId::from(id)),
+        )
+        .await?;
 
-        if let Some(result) = self.snapshot.get_task_result(id) {
+        if let Some(result) = self
+            .snapshot
+            .get_task_result(&sayiir_core::TaskId::from(id))
+        {
             return Ok(advance_or_break(next.as_deref(), result.output.clone()));
         }
 
         let output = Box::pin(self.run(child, input)).await?;
 
         self.snapshot
-            .mark_task_completed(id.clone(), output.clone());
+            .mark_task_completed(sayiir_core::TaskId::from(id), output.clone());
         self.checkpoint().await?;
 
         Ok(advance_or_break(next.as_deref(), output))
@@ -762,7 +819,7 @@ async fn execute_with_checkpointing(
 /// return values.
 async fn call_js_task(
     registry: &js_sys::Object,
-    task_id: &str,
+    task_id: &sayiir_core::TaskId,
     input: &Bytes,
 ) -> Result<Bytes, WorkflowError> {
     let func: js_sys::Function = js_sys::Reflect::get(registry, &JsValue::from_str(task_id))

--- a/sayiir-cloudflare/src/flow.rs
+++ b/sayiir-cloudflare/src/flow.rs
@@ -17,7 +17,7 @@ use crate::error::to_js_error;
 #[wasm_bindgen]
 pub struct WasmWorkflow {
     pub(crate) workflow_id: String,
-    pub(crate) definition_hash: String,
+    pub(crate) definition_hash: sayiir_core::DefinitionHash,
     pub(crate) continuation: Arc<WorkflowContinuation>,
     pub(crate) metadata_json: Option<String>,
 }
@@ -32,7 +32,7 @@ impl WasmWorkflow {
 
     #[wasm_bindgen(getter, js_name = "definitionHash")]
     pub fn definition_hash(&self) -> String {
-        self.definition_hash.clone()
+        self.definition_hash.to_hex()
     }
 
     #[wasm_bindgen(getter, js_name = "metadataJson")]

--- a/sayiir-cloudflare/src/lifecycle.rs
+++ b/sayiir-cloudflare/src/lifecycle.rs
@@ -81,12 +81,12 @@ pub(crate) async fn finalize_execution<B: SnapshotStore>(
                 WorkflowSnapshotState::InProgress {
                     position: ExecutionPosition::AtDelay { delay_id, .. },
                     ..
-                } => delay_id.clone(),
+                } => *delay_id,
                 WorkflowSnapshotState::InProgress {
                     position: ExecutionPosition::AtFork { fork_id, .. },
                     ..
-                } => fork_id.clone(),
-                _ => String::new(),
+                } => *fork_id,
+                _ => sayiir_core::TaskId::default(),
             };
             Ok((WorkflowStatus::Waiting { wake_at, delay_id }, None))
         }
@@ -187,12 +187,12 @@ async fn resolve_parked<B: SignalStore>(
                 },
             ..
         } => {
-            let delay_id = delay_id.clone();
+            let delay_id = *delay_id;
             let wake_at = *wake_at;
-            let next_task_id = next_task_id.clone();
+            let next_task_id = *next_task_id;
 
             // Check cancel/pause
-            if let Some(status) = check_cancel_pause(backend, instance_id, Some(&delay_id)).await? {
+            if let Some(status) = check_cancel_pause(backend, instance_id, Some(delay_id)).await? {
                 return Ok(Some(status));
             }
 
@@ -220,10 +220,10 @@ async fn resolve_parked<B: SignalStore>(
             },
             ..
         } => {
-            let fork_id = fork_id.clone();
+            let fork_id = *fork_id;
             let wake_at = *wake_at;
 
-            if let Some(status) = check_cancel_pause(backend, instance_id, Some(&fork_id)).await? {
+            if let Some(status) = check_cancel_pause(backend, instance_id, Some(fork_id)).await? {
                 return Ok(Some(status));
             }
 
@@ -253,13 +253,12 @@ async fn resolve_parked<B: SignalStore>(
                 },
             ..
         } => {
-            let signal_id = signal_id.clone();
+            let signal_id = *signal_id;
             let signal_name = signal_name.clone();
             let wake_at = *wake_at;
-            let next_task_id = next_task_id.clone();
+            let next_task_id = *next_task_id;
 
-            if let Some(status) = check_cancel_pause(backend, instance_id, Some(&signal_id)).await?
-            {
+            if let Some(status) = check_cancel_pause(backend, instance_id, Some(signal_id)).await? {
                 return Ok(Some(status));
             }
 
@@ -318,7 +317,7 @@ async fn resolve_parked<B: SignalStore>(
 async fn check_cancel_pause<B: SignalStore>(
     backend: &B,
     instance_id: &str,
-    scope: Option<&str>,
+    scope: Option<sayiir_core::TaskId>,
 ) -> Result<Option<WorkflowStatus>, wasm_bindgen::JsValue> {
     if backend
         .check_and_cancel(instance_id, scope)

--- a/sayiir-cloudflare/src/lifecycle.rs
+++ b/sayiir-cloudflare/src/lifecycle.rs
@@ -34,6 +34,7 @@ pub(crate) async fn prepare_resume<B: SignalStore>(
     definition_hash: &sayiir_core::DefinitionHash,
     backend: &B,
 ) -> Result<ResumeOutcome, wasm_bindgen::JsValue> {
+    sayiir_core::validate_instance_id(instance_id).map_err(to_js_error)?;
     let mut snapshot = backend
         .load_snapshot(instance_id)
         .await

--- a/sayiir-cloudflare/src/lifecycle.rs
+++ b/sayiir-cloudflare/src/lifecycle.rs
@@ -31,7 +31,7 @@ pub(crate) enum ResumeOutcome {
 /// Prepare to resume a workflow from a saved snapshot.
 pub(crate) async fn prepare_resume<B: SignalStore>(
     instance_id: &str,
-    definition_hash: &str,
+    definition_hash: &sayiir_core::DefinitionHash,
     backend: &B,
 ) -> Result<ResumeOutcome, wasm_bindgen::JsValue> {
     let mut snapshot = backend
@@ -39,7 +39,7 @@ pub(crate) async fn prepare_resume<B: SignalStore>(
         .await
         .map_err(to_js_error)?;
 
-    if snapshot.definition_hash != definition_hash {
+    if snapshot.definition_hash != *definition_hash {
         return Err(to_js_error(format!(
             "Definition mismatch: expected '{}', found '{}'",
             definition_hash, snapshot.definition_hash

--- a/sayiir-cloudflare/src/lifecycle.rs
+++ b/sayiir-cloudflare/src/lifecycle.rs
@@ -272,7 +272,7 @@ async fn resolve_parked<B: SignalStore>(
                 .await
                 .map_err(to_js_error)?
             {
-                snapshot.mark_task_completed(signal_id.clone(), payload);
+                snapshot.mark_task_completed(signal_id, payload);
                 if let Some(next_id) = next_task_id {
                     snapshot.update_position(ExecutionPosition::AtTask { task_id: next_id });
                 } else {

--- a/sayiir-core/src/builder.rs
+++ b/sayiir-core/src/builder.rs
@@ -1361,11 +1361,13 @@ impl<C, Input, Output, M> WorkflowBuilder<C, Input, Output, M, WorkflowContinuat
             .continuation
             .to_serializable()
             .compute_definition_hash();
+        let task_index = Arc::new(crate::task_index::TaskIndex::build(&self.continuation));
 
         Ok(Workflow {
             definition_hash,
             continuation: self.continuation,
             context: self.context,
+            task_index,
             _phantom: PhantomData,
         })
     }
@@ -1400,11 +1402,13 @@ impl<C, Input, Output, M> WorkflowBuilder<C, Input, Output, M, WorkflowContinuat
             .continuation
             .to_serializable()
             .compute_definition_hash();
+        let task_index = Arc::new(crate::task_index::TaskIndex::build(&self.continuation));
 
         let inner = Workflow {
             definition_hash,
             continuation: self.continuation,
             context: self.context,
+            task_index,
             _phantom: PhantomData,
         };
 

--- a/sayiir-core/src/builder.rs
+++ b/sayiir-core/src/builder.rs
@@ -1248,9 +1248,10 @@ impl<C, Input, Output, M> WorkflowBuilder<C, Input, Output, M, WorkflowContinuat
             self.registry.set_metadata(id, metadata);
             // Also update the timeout, retry policy, and version on the continuation node
             // so they're available for direct execution (not just the serializable roundtrip path).
-            self.continuation.set_task_timeout(id, timeout);
-            self.continuation.set_task_retry_policy(id, retry_policy);
-            self.continuation.set_task_version(id, version);
+            let tid = crate::TaskId::from(id);
+            self.continuation.set_task_timeout(&tid, timeout);
+            self.continuation.set_task_retry_policy(&tid, retry_policy);
+            self.continuation.set_task_version(&tid, version);
         }
         self
     }

--- a/sayiir-core/src/context.rs
+++ b/sayiir-core/src/context.rs
@@ -19,11 +19,16 @@ use crate::task::TaskMetadata;
 /// language-specific context APIs (Python/Node.js).
 #[derive(Clone, Debug)]
 pub struct TaskExecutionContext {
-    /// The workflow definition identifier.
+    /// The workflow definition identifier (human-readable name).
+    ///
+    /// Carried as `Arc<str>` because the external task executor (Python /
+    /// Node FFI) needs to look up the task function by its registered name.
+    /// The runtime's hot map lookups happen against the hashed
+    /// [`WorkflowId`](crate::WorkflowId) elsewhere; here we keep the name.
     pub workflow_id: Arc<str>,
     /// The workflow instance identifier.
     pub instance_id: Arc<str>,
-    /// The current task identifier.
+    /// The current task identifier (human-readable name).
     pub task_id: Arc<str>,
     /// Task metadata (timeout, retry policy, version, etc.).
     pub metadata: TaskMetadata,
@@ -34,10 +39,14 @@ pub struct TaskExecutionContext {
 /// Workflow execution context that provides access to metadata and codec.
 ///
 /// This context is always available as a plain struct used during workflow
-/// building and by the runner for codec/metadata access.
+/// building and by the runner for codec/metadata access. The `workflow_id`
+/// is kept as both a hash ([`WorkflowId`](crate::WorkflowId)) for fast
+/// runtime comparison and an `Arc<str>` for log/error display.
 pub struct WorkflowContext<C, M> {
-    /// The unique workflow identifier.
-    pub workflow_id: Arc<str>,
+    /// SHA-256 hash of the workflow identifier (for fast comparison and maps).
+    pub workflow_id: crate::WorkflowId,
+    /// Human-readable workflow name (for logs / error messages).
+    pub workflow_name: Arc<str>,
     /// The codec used for serialization/deserialization.
     pub codec: Arc<C>,
     /// Immutable metadata attached to the workflow.
@@ -49,7 +58,8 @@ pub struct WorkflowContext<C, M> {
 impl<C, M> Clone for WorkflowContext<C, M> {
     fn clone(&self) -> Self {
         Self {
-            workflow_id: Arc::clone(&self.workflow_id),
+            workflow_id: self.workflow_id,
+            workflow_name: Arc::clone(&self.workflow_name),
             codec: Arc::clone(&self.codec),
             metadata: Arc::clone(&self.metadata),
             metadata_json: self.metadata_json.clone(),
@@ -59,19 +69,28 @@ impl<C, M> Clone for WorkflowContext<C, M> {
 
 impl<C, M> WorkflowContext<C, M> {
     /// Create a new workflow context.
-    pub fn new(workflow_id: impl Into<Arc<str>>, codec: Arc<C>, metadata: Arc<M>) -> Self {
+    pub fn new(workflow_name: impl Into<Arc<str>>, codec: Arc<C>, metadata: Arc<M>) -> Self {
+        let workflow_name: Arc<str> = workflow_name.into();
+        let workflow_id = crate::WorkflowId::from(workflow_name.as_ref());
         Self {
-            workflow_id: workflow_id.into(),
+            workflow_id,
+            workflow_name,
             codec,
             metadata,
             metadata_json: None,
         }
     }
 
-    /// Returns the workflow identifier.
+    /// Returns the workflow human-readable name.
     #[must_use]
     pub fn workflow_id(&self) -> &str {
-        &self.workflow_id
+        &self.workflow_name
+    }
+
+    /// Returns the workflow identifier hash.
+    #[must_use]
+    pub fn workflow_id_hash(&self) -> crate::WorkflowId {
+        self.workflow_id
     }
 
     /// Returns a clone of the codec `Arc`.

--- a/sayiir-core/src/error.rs
+++ b/sayiir-core/src/error.rs
@@ -84,9 +84,9 @@ pub enum BuildError {
     #[error("Workflow definition mismatch: expected hash '{expected}', found '{found}'")]
     DefinitionMismatch {
         /// The expected hash (from current workflow).
-        expected: String,
+        expected: crate::DefinitionHash,
         /// The hash found in the serialized state.
-        found: String,
+        found: crate::DefinitionHash,
     },
 
     /// A `#[task]` requires a dependency that is missing from the `Deps`
@@ -235,9 +235,9 @@ pub enum WorkflowError {
     #[error("Workflow definition mismatch: expected hash '{expected}', found '{found}'")]
     DefinitionMismatch {
         /// The expected hash (from current workflow).
-        expected: String,
+        expected: crate::DefinitionHash,
         /// The hash found in the serialized state.
-        found: String,
+        found: crate::DefinitionHash,
     },
 
     /// The workflow was cancelled.

--- a/sayiir-core/src/error.rs
+++ b/sayiir-core/src/error.rs
@@ -14,7 +14,7 @@ pub enum CodecError {
     #[error("Failed to decode input for task '{task_id}' (expected {expected_type}): {source}")]
     DecodeFailed {
         /// The task whose input could not be decoded.
-        task_id: String,
+        task_id: crate::TaskId,
         /// The Rust type name that was expected (via `std::any::type_name`).
         expected_type: &'static str,
         /// The underlying deserialization error.
@@ -24,7 +24,7 @@ pub enum CodecError {
     #[error("Failed to encode output for task '{task_id}': {source}")]
     EncodeFailed {
         /// The task whose output could not be encoded.
-        task_id: String,
+        task_id: crate::TaskId,
         /// The underlying serialization error.
         source: BoxError,
     },
@@ -297,7 +297,7 @@ pub enum WorkflowError {
     #[error("Task '{task_id}' timed out after {timeout:?}")]
     TaskTimedOut {
         /// The task that timed out.
-        task_id: String,
+        task_id: crate::TaskId,
         /// The configured timeout duration.
         timeout: std::time::Duration,
     },
@@ -306,7 +306,7 @@ pub enum WorkflowError {
     #[error("Workflow awaiting signal '{signal_name}' at node '{signal_id}'")]
     AwaitingSignal {
         /// The signal node ID.
-        signal_id: String,
+        signal_id: crate::TaskId,
         /// The named signal being waited on.
         signal_name: String,
         /// Optional timeout deadline.
@@ -317,7 +317,7 @@ pub enum WorkflowError {
     #[error("Loop '{loop_id}' exceeded max iterations ({max_iterations})")]
     MaxIterationsExceeded {
         /// The loop node ID.
-        loop_id: String,
+        loop_id: crate::TaskId,
         /// The configured maximum.
         max_iterations: u32,
     },

--- a/sayiir-core/src/hash32.rs
+++ b/sayiir-core/src/hash32.rs
@@ -1,0 +1,393 @@
+//! Fixed-length 32-byte identifiers backed by SHA-256.
+//!
+//! [`Hash32`] is a primitive value type — a `[u8; 32]` with cheap `Copy`,
+//! constant-time-equivalent comparison (single SIMD-friendly memcmp), and a
+//! single hash-map probe instead of the per-character hashing a `String`
+//! incurs. It is the building block for the semantic id newtypes (currently
+//! [`DefinitionHash`]; `WorkflowId` and `TaskId` will follow in Phase 2).
+//!
+//! Serde encodes a `Hash32` as a 64-character lowercase hex string on
+//! human-readable formats (JSON, TOML) and as raw 32 bytes on binary formats
+//! (bincode, rkyv-derived codecs). This keeps user-facing snapshot blobs and
+//! API payloads readable while making over-the-wire transports compact.
+
+use core::fmt;
+use core::str::FromStr;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use sha2::{Digest, Sha256};
+
+/// A 32-byte fixed-length identifier, typically the output of SHA-256.
+///
+/// Stored inline as `[u8; 32]` — no heap allocation, no length prefix, `Copy`,
+/// and trivially `Hash`/`Eq` (one memcmp).
+#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct Hash32([u8; 32]);
+
+impl Hash32 {
+    /// Zero hash — useful as a sentinel for "uninitialised". Not a valid
+    /// SHA-256 output in practice.
+    pub const ZERO: Self = Self([0u8; 32]);
+
+    /// Construct from raw bytes.
+    #[must_use]
+    pub const fn from_bytes(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+
+    /// Borrow the underlying bytes.
+    #[must_use]
+    pub const fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+
+    /// Consume into the underlying bytes.
+    #[must_use]
+    pub const fn into_bytes(self) -> [u8; 32] {
+        self.0
+    }
+
+    /// Compute SHA-256 of the given input.
+    #[must_use]
+    pub fn sha256(input: impl AsRef<[u8]>) -> Self {
+        let mut hasher = Sha256::new();
+        hasher.update(input.as_ref());
+        Self::from_digest(hasher)
+    }
+
+    /// Finalise a hasher into a `Hash32`.
+    #[must_use]
+    pub fn from_digest(hasher: Sha256) -> Self {
+        let out = hasher.finalize();
+        let mut bytes = [0u8; 32];
+        bytes.copy_from_slice(&out);
+        Self(bytes)
+    }
+
+    /// Lowercase hex encoding (64 chars). Allocates.
+    #[must_use]
+    pub fn to_hex(&self) -> String {
+        use fmt::Write as _;
+        let mut s = String::with_capacity(64);
+        for byte in &self.0 {
+            let _ = write!(&mut s, "{byte:02x}");
+        }
+        s
+    }
+
+    /// Parse from a 64-character lowercase or uppercase hex string.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Hash32ParseError`] if the input is not 64 hex digits.
+    pub fn from_hex(s: &str) -> Result<Self, Hash32ParseError> {
+        let bytes_in = s.as_bytes();
+        if bytes_in.len() != 64 {
+            return Err(Hash32ParseError::WrongLength(bytes_in.len()));
+        }
+        let mut bytes = [0u8; 32];
+        for (i, byte) in bytes.iter_mut().enumerate() {
+            let lo = bytes_in.get(i * 2).copied().unwrap_or(0);
+            let hi = bytes_in.get(i * 2 + 1).copied().unwrap_or(0);
+            *byte = (decode_nibble(lo)? << 4) | decode_nibble(hi)?;
+        }
+        Ok(Self(bytes))
+    }
+}
+
+#[inline]
+fn decode_nibble(c: u8) -> Result<u8, Hash32ParseError> {
+    match c {
+        b'0'..=b'9' => Ok(c - b'0'),
+        b'a'..=b'f' => Ok(c - b'a' + 10),
+        b'A'..=b'F' => Ok(c - b'A' + 10),
+        _ => Err(Hash32ParseError::InvalidChar(c)),
+    }
+}
+
+/// Errors from parsing a hex-encoded [`Hash32`].
+#[derive(Debug, thiserror::Error)]
+pub enum Hash32ParseError {
+    /// Input length was not exactly 64 hex characters.
+    #[error("expected 64 hex characters, got {0}")]
+    WrongLength(usize),
+    /// Non-hex byte encountered.
+    #[error("invalid hex character: {:?}", *.0 as char)]
+    InvalidChar(u8),
+}
+
+impl fmt::Display for Hash32 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for byte in &self.0 {
+            write!(f, "{byte:02x}")?;
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Debug for Hash32 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, f)
+    }
+}
+
+impl FromStr for Hash32 {
+    type Err = Hash32ParseError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::from_hex(s)
+    }
+}
+
+impl AsRef<[u8]> for Hash32 {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl Serialize for Hash32 {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        if serializer.is_human_readable() {
+            serializer.collect_str(self)
+        } else {
+            serializer.serialize_bytes(&self.0)
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for Hash32 {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        if deserializer.is_human_readable() {
+            let s = <&str>::deserialize(deserializer)?;
+            Self::from_hex(s).map_err(serde::de::Error::custom)
+        } else {
+            struct V;
+            impl<'de> serde::de::Visitor<'de> for V {
+                type Value = Hash32;
+                fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                    f.write_str("32 raw bytes")
+                }
+                fn visit_bytes<E: serde::de::Error>(self, v: &[u8]) -> Result<Hash32, E> {
+                    if v.len() != 32 {
+                        return Err(E::invalid_length(v.len(), &self));
+                    }
+                    let mut bytes = [0u8; 32];
+                    bytes.copy_from_slice(v);
+                    Ok(Hash32(bytes))
+                }
+                fn visit_borrowed_bytes<E: serde::de::Error>(
+                    self,
+                    v: &'de [u8],
+                ) -> Result<Hash32, E> {
+                    self.visit_bytes(v)
+                }
+                fn visit_byte_buf<E: serde::de::Error>(self, v: Vec<u8>) -> Result<Hash32, E> {
+                    self.visit_bytes(&v)
+                }
+                fn visit_seq<A: serde::de::SeqAccess<'de>>(
+                    self,
+                    mut seq: A,
+                ) -> Result<Hash32, A::Error> {
+                    let mut bytes = [0u8; 32];
+                    for (i, byte) in bytes.iter_mut().enumerate() {
+                        *byte = seq
+                            .next_element()?
+                            .ok_or_else(|| serde::de::Error::invalid_length(i, &"32 bytes"))?;
+                    }
+                    Ok(Hash32(bytes))
+                }
+            }
+            deserializer.deserialize_bytes(V)
+        }
+    }
+}
+
+// ============================================================================
+// DefinitionHash — semantic newtype for workflow-definition fingerprints.
+// ============================================================================
+
+/// SHA-256 fingerprint of a workflow's structural definition.
+///
+/// Computed from the workflow's continuation tree (task IDs, retry policies,
+/// fork shapes, delays, signals, loops, child workflows). Used by the runtime
+/// to detect when a serialised snapshot was written against a different
+/// workflow definition than the one currently in memory.
+///
+/// Compares in a single 32-byte memcmp instead of a 64-character string
+/// equality, and hashes to one `u64` instead of per-character siphash.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct DefinitionHash(Hash32);
+
+impl DefinitionHash {
+    /// Construct from a [`Hash32`].
+    #[must_use]
+    pub const fn from_hash(hash: Hash32) -> Self {
+        Self(hash)
+    }
+
+    /// Construct from raw 32 bytes.
+    #[must_use]
+    pub const fn from_bytes(bytes: [u8; 32]) -> Self {
+        Self(Hash32::from_bytes(bytes))
+    }
+
+    /// Hash the given input with SHA-256 and wrap the result.
+    #[must_use]
+    pub fn sha256(input: impl AsRef<[u8]>) -> Self {
+        Self(Hash32::sha256(input))
+    }
+
+    /// Borrow the underlying hash.
+    #[must_use]
+    pub const fn as_hash(&self) -> &Hash32 {
+        &self.0
+    }
+
+    /// Borrow the raw bytes.
+    #[must_use]
+    pub const fn as_bytes(&self) -> &[u8; 32] {
+        self.0.as_bytes()
+    }
+
+    /// Lowercase hex encoding (64 chars).
+    #[must_use]
+    pub fn to_hex(&self) -> String {
+        self.0.to_hex()
+    }
+
+    /// Parse from a 64-character hex string.
+    ///
+    /// # Errors
+    ///
+    /// See [`Hash32::from_hex`].
+    pub fn from_hex(s: &str) -> Result<Self, Hash32ParseError> {
+        Hash32::from_hex(s).map(Self)
+    }
+}
+
+impl fmt::Display for DefinitionHash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}
+
+impl fmt::Debug for DefinitionHash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "DefinitionHash({})", self.0)
+    }
+}
+
+impl FromStr for DefinitionHash {
+    type Err = Hash32ParseError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::from_hex(s)
+    }
+}
+
+impl From<Hash32> for DefinitionHash {
+    fn from(h: Hash32) -> Self {
+        Self(h)
+    }
+}
+
+impl From<DefinitionHash> for Hash32 {
+    fn from(h: DefinitionHash) -> Self {
+        h.0
+    }
+}
+
+// NOTE: `From<&str>` / `From<String>` SHA-256-hash the input — they do NOT
+// parse a hex hash. For parsing an existing hex hash use [`DefinitionHash::from_hex`].
+// These impls exist to keep tests/fixtures (`"hash-1".into()`) ergonomic; in
+// production, `DefinitionHash` is produced by `compute_definition_hash` or
+// deserialised via serde.
+impl From<&str> for DefinitionHash {
+    fn from(s: &str) -> Self {
+        Self::sha256(s.as_bytes())
+    }
+}
+
+impl From<String> for DefinitionHash {
+    fn from(s: String) -> Self {
+        Self::sha256(s.as_bytes())
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hash32_round_trips_via_hex() {
+        let h = Hash32::sha256(b"hello world");
+        let hex = h.to_hex();
+        assert_eq!(hex.len(), 64);
+        assert_eq!(Hash32::from_hex(&hex).unwrap(), h);
+    }
+
+    #[test]
+    fn from_hex_rejects_wrong_length() {
+        assert!(matches!(
+            Hash32::from_hex("abc"),
+            Err(Hash32ParseError::WrongLength(3))
+        ));
+    }
+
+    #[test]
+    fn from_hex_rejects_non_hex_char() {
+        let bad = "z".repeat(64);
+        assert!(matches!(
+            Hash32::from_hex(&bad),
+            Err(Hash32ParseError::InvalidChar(b'z'))
+        ));
+    }
+
+    #[test]
+    fn from_hex_accepts_uppercase() {
+        let lower = "abcd".repeat(16);
+        let upper = "ABCD".repeat(16);
+        assert_eq!(
+            Hash32::from_hex(&lower).unwrap(),
+            Hash32::from_hex(&upper).unwrap()
+        );
+    }
+
+    #[test]
+    fn json_round_trip_is_hex_string() {
+        let h = Hash32::sha256(b"payload");
+        let json = serde_json::to_string(&h).unwrap();
+        assert_eq!(json.len(), 66);
+        assert!(json.starts_with('"') && json.ends_with('"'));
+        let parsed: Hash32 = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, h);
+    }
+
+    #[test]
+    fn definition_hash_displays_as_hex() {
+        let d = DefinitionHash::from_bytes([0xab; 32]);
+        assert_eq!(format!("{d}"), "ab".repeat(32));
+    }
+
+    #[test]
+    fn definition_hash_serde_transparent() {
+        let d = DefinitionHash::from_hash(Hash32::sha256(b"wf"));
+        let as_hash_json = serde_json::to_string(d.as_hash()).unwrap();
+        let as_def_json = serde_json::to_string(&d).unwrap();
+        assert_eq!(as_hash_json, as_def_json);
+    }
+
+    #[test]
+    fn definition_hash_round_trips_via_hex() {
+        let d = DefinitionHash::from_hash(Hash32::sha256(b"abc"));
+        let parsed: DefinitionHash = d.to_hex().parse().unwrap();
+        assert_eq!(parsed, d);
+    }
+
+    #[test]
+    fn definition_hash_from_str_hashes_input() {
+        let by_str: DefinitionHash = "wf-1".into();
+        let by_sha = DefinitionHash::sha256(b"wf-1");
+        assert_eq!(by_str, by_sha);
+    }
+}

--- a/sayiir-core/src/hash32.rs
+++ b/sayiir-core/src/hash32.rs
@@ -299,6 +299,10 @@ macro_rules! hash32_newtype {
             fn from(s: &str) -> Self { Self::sha256(s.as_bytes()) }
         }
 
+        impl From<&String> for $name {
+            fn from(s: &String) -> Self { Self::sha256(s.as_bytes()) }
+        }
+
         impl From<String> for $name {
             fn from(s: String) -> Self { Self::sha256(s.as_bytes()) }
         }
@@ -322,16 +326,30 @@ hash32_newtype! {
 hash32_newtype! {
     /// SHA-256 hash of a task's user-facing name (e.g. `"validate"`).
     ///
-    /// Used as a precomputed lookup key alongside the human-readable id on
-    /// hot data structures (e.g. [`TaskHint`](crate::snapshot::TaskHint)). The
-    /// runtime stores the name (`String`) on
-    /// [`ExecutionPosition`](crate::snapshot::ExecutionPosition) variants for
-    /// readability of serialised snapshots; the `TaskId` is what comparisons
-    /// and map probes use when callers have access to it.
+    /// Stored on every runtime data structure that previously held a task
+    /// id as a `String` — [`ExecutionPosition`](crate::snapshot::ExecutionPosition)
+    /// variants, [`TaskResult`](crate::snapshot::TaskResult), the
+    /// `completed_tasks`/`task_retries`/`loop_iterations` `HashMap` keys on
+    /// [`WorkflowSnapshot`](crate::snapshot::WorkflowSnapshot),
+    /// [`AvailableTask`](crate::task_claim::AvailableTask), and so on. The
+    /// human-readable name only lives once per workflow definition on the
+    /// continuation tree.
     ///
-    /// 32-byte memcmp + single-`u64` hash, same wins as
-    /// [`DefinitionHash`].
+    /// 32-byte memcmp + single-`u64` hash, same wins as [`DefinitionHash`].
     TaskId
+}
+
+hash32_newtype! {
+    /// SHA-256 hash of a workflow's user-facing identifier (e.g.
+    /// `"order-pipeline"`).
+    ///
+    /// Used in runtime contexts and dispatch maps where the workflow
+    /// identifier needs cheap comparison without keeping the string alive.
+    /// The human-readable name remains on the
+    /// [`Workflow`](crate::workflow::Workflow) /
+    /// [`WorkflowContext`](crate::context::WorkflowContext) for log/error
+    /// display.
+    WorkflowId
 }
 
 #[cfg(test)]

--- a/sayiir-core/src/hash32.rs
+++ b/sayiir-core/src/hash32.rs
@@ -38,6 +38,22 @@ impl Hash32 {
         Self(bytes)
     }
 
+    /// Construct from a byte slice, validating the length.
+    ///
+    /// Use this on the wire/storage boundary — e.g. decoding a `BYTEA`
+    /// column from sqlx — where you have a `&[u8]` rather than a
+    /// fixed-size array.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Hash32ParseError::WrongLength`] if `bytes.len() != 32`.
+    pub fn from_slice(bytes: &[u8]) -> Result<Self, Hash32ParseError> {
+        let arr: [u8; 32] = bytes
+            .try_into()
+            .map_err(|_| Hash32ParseError::WrongLength(bytes.len()))?;
+        Ok(Self(arr))
+    }
+
     /// Borrow the underlying bytes.
     #[must_use]
     pub const fn as_bytes(&self) -> &[u8; 32] {
@@ -236,6 +252,18 @@ macro_rules! hash32_newtype {
             #[must_use]
             pub const fn from_bytes(bytes: [u8; 32]) -> Self {
                 Self(Hash32::from_bytes(bytes))
+            }
+
+            #[doc = concat!(
+                "Construct a [`", stringify!($name),
+                "`] from a length-checked byte slice. See [`Hash32::from_slice`]."
+            )]
+            ///
+            /// # Errors
+            ///
+            /// Returns [`Hash32ParseError::WrongLength`] if `bytes.len() != 32`.
+            pub fn from_slice(bytes: &[u8]) -> Result<Self, Hash32ParseError> {
+                Hash32::from_slice(bytes).map(Self)
             }
 
             /// SHA-256-hash the given input and wrap the result.

--- a/sayiir-core/src/hash32.rs
+++ b/sayiir-core/src/hash32.rs
@@ -3,8 +3,10 @@
 //! [`Hash32`] is a primitive value type — a `[u8; 32]` with cheap `Copy`,
 //! constant-time-equivalent comparison (single SIMD-friendly memcmp), and a
 //! single hash-map probe instead of the per-character hashing a `String`
-//! incurs. It is the building block for the semantic id newtypes (currently
-//! [`DefinitionHash`]; `WorkflowId` and `TaskId` will follow in Phase 2).
+//! incurs. It is the building block for the semantic id newtypes
+//! [`DefinitionHash`], [`WorkflowId`], and [`TaskId`], each of which is a
+//! distinct `Hash32` newtype so the type system prevents mixing identifier
+//! kinds at call sites.
 //!
 //! Serde encodes a `Hash32` as a 64-character lowercase hex string on
 //! human-readable formats (JSON, TOML) and as raw 32 bytes on binary formats

--- a/sayiir-core/src/lib.rs
+++ b/sayiir-core/src/lib.rs
@@ -87,8 +87,10 @@ pub mod registry;
 pub mod snapshot;
 pub mod task;
 pub mod task_claim;
+pub mod task_index;
 pub mod workflow;
 
 pub use hash32::{DefinitionHash, Hash32, TaskId, WorkflowId};
 pub use loop_result::LoopResult;
+pub use task_index::{TaskIndex, TaskNodeMetadata};
 pub use workflow::MaxIterationsPolicy;

--- a/sayiir-core/src/lib.rs
+++ b/sayiir-core/src/lib.rs
@@ -79,6 +79,7 @@ pub mod context;
 pub mod continuation_builder;
 pub mod deps;
 pub mod error;
+pub mod hash32;
 pub mod loop_result;
 pub mod prelude;
 pub mod priority;
@@ -88,5 +89,6 @@ pub mod task;
 pub mod task_claim;
 pub mod workflow;
 
+pub use hash32::{DefinitionHash, Hash32};
 pub use loop_result::LoopResult;
 pub use workflow::MaxIterationsPolicy;

--- a/sayiir-core/src/lib.rs
+++ b/sayiir-core/src/lib.rs
@@ -88,9 +88,11 @@ pub mod snapshot;
 pub mod task;
 pub mod task_claim;
 pub mod task_index;
+pub mod validation;
 pub mod workflow;
 
 pub use hash32::{DefinitionHash, Hash32, TaskId, WorkflowId};
 pub use loop_result::LoopResult;
 pub use task_index::{TaskIndex, TaskNodeMetadata};
+pub use validation::{InvalidInstanceId, MAX_INSTANCE_ID_LEN, validate_instance_id};
 pub use workflow::MaxIterationsPolicy;

--- a/sayiir-core/src/lib.rs
+++ b/sayiir-core/src/lib.rs
@@ -89,6 +89,6 @@ pub mod task;
 pub mod task_claim;
 pub mod workflow;
 
-pub use hash32::{DefinitionHash, Hash32, TaskId};
+pub use hash32::{DefinitionHash, Hash32, TaskId, WorkflowId};
 pub use loop_result::LoopResult;
 pub use workflow::MaxIterationsPolicy;

--- a/sayiir-core/src/registry.rs
+++ b/sayiir-core/src/registry.rs
@@ -714,14 +714,17 @@ where
         BytesFuture::new(async move {
             let decoded_input = codec.decode::<I>(input).map_err(|e| -> BoxError {
                 Box::new(CodecError::DecodeFailed {
-                    task_id: task_id.clone(),
+                    task_id: crate::TaskId::from(task_id.as_str()),
                     expected_type: std::any::type_name::<I>(),
                     source: e,
                 })
             })?;
             let output = func(decoded_input).await?;
             codec.encode(&output).map_err(|e| -> BoxError {
-                Box::new(CodecError::EncodeFailed { task_id, source: e })
+                Box::new(CodecError::EncodeFailed {
+                    task_id: crate::TaskId::from(task_id.as_str()),
+                    source: e,
+                })
             })
         })
     }
@@ -754,7 +757,7 @@ where
         BytesFuture::new(async move {
             let decoded_input = codec.decode::<I>(input).map_err(|e| -> BoxError {
                 Box::new(CodecError::DecodeFailed {
-                    task_id: task_id.clone(),
+                    task_id: crate::TaskId::from(task_id.as_str()),
                     expected_type: std::any::type_name::<I>(),
                     source: e,
                 })
@@ -762,7 +765,10 @@ where
             let loop_result = func(decoded_input).await?;
             let (decision, inner) = loop_result.into_decision();
             let inner_bytes = codec.encode(&inner).map_err(|e| -> BoxError {
-                Box::new(CodecError::EncodeFailed { task_id, source: e })
+                Box::new(CodecError::EncodeFailed {
+                    task_id: crate::TaskId::from(task_id.as_str()),
+                    source: e,
+                })
             })?;
             Ok(crate::codec::encode_loop_envelope(decision, &inner_bytes))
         })
@@ -795,14 +801,17 @@ where
         BytesFuture::new(async move {
             let decoded_input = codec.decode::<T::Input>(input).map_err(|e| -> BoxError {
                 Box::new(CodecError::DecodeFailed {
-                    task_id: task_id.clone(),
+                    task_id: crate::TaskId::from(task_id.as_str()),
                     expected_type: std::any::type_name::<T::Input>(),
                     source: e,
                 })
             })?;
             let output = task.run(decoded_input).await?;
             codec.encode(&output).map_err(|e| -> BoxError {
-                Box::new(CodecError::EncodeFailed { task_id, source: e })
+                Box::new(CodecError::EncodeFailed {
+                    task_id: crate::TaskId::from(task_id.as_str()),
+                    source: e,
+                })
             })
         })
     }

--- a/sayiir-core/src/snapshot.rs
+++ b/sayiir-core/src/snapshot.rs
@@ -8,6 +8,7 @@ use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use crate::task::RetryPolicy;
 
@@ -506,7 +507,7 @@ impl WorkflowSnapshotState {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WorkflowSnapshot {
     /// Unique identifier for this workflow instance.
-    pub instance_id: String,
+    pub instance_id: Arc<str>,
     /// Hash of the workflow definition (for validation).
     pub definition_hash: crate::DefinitionHash,
     /// Current state of execution.
@@ -562,7 +563,8 @@ impl WorkflowSnapshot {
 
     /// Create a new snapshot for a workflow instance.
     #[must_use]
-    pub fn new(instance_id: String, definition_hash: crate::DefinitionHash) -> Self {
+    pub fn new(instance_id: &str, definition_hash: crate::DefinitionHash) -> Self {
+        let instance_id: Arc<str> = Arc::from(instance_id);
         let now = Self::current_timestamp();
         Self {
             instance_id,
@@ -586,10 +588,11 @@ impl WorkflowSnapshot {
 
     /// Create a new snapshot with initial input.
     pub fn with_initial_input(
-        instance_id: String,
+        instance_id: &str,
         definition_hash: crate::DefinitionHash,
         initial_input: Bytes,
     ) -> Self {
+        let instance_id: Arc<str> = Arc::from(instance_id);
         let now = Self::current_timestamp();
         Self {
             instance_id,
@@ -1074,8 +1077,8 @@ mod tests {
 
     #[test]
     fn test_new_snapshot_in_progress() {
-        let snapshot = WorkflowSnapshot::new("inst-1".into(), "hash-1".into());
-        assert_eq!(snapshot.instance_id, "inst-1");
+        let snapshot = WorkflowSnapshot::new("inst-1", "hash-1".into());
+        assert_eq!(&*snapshot.instance_id, "inst-1");
         assert_eq!(
             snapshot.definition_hash,
             crate::DefinitionHash::from("hash-1")
@@ -1154,18 +1157,15 @@ mod tests {
 
     #[test]
     fn test_snapshot_with_initial_input() {
-        let snapshot = WorkflowSnapshot::with_initial_input(
-            "inst-1".into(),
-            "hash-1".into(),
-            Bytes::from("hello"),
-        );
+        let snapshot =
+            WorkflowSnapshot::with_initial_input("inst-1", "hash-1".into(), Bytes::from("hello"));
         assert_eq!(snapshot.initial_input_bytes(), Some(Bytes::from("hello")));
         assert!(snapshot.state.is_in_progress());
     }
 
     #[test]
     fn test_mark_task_completed_and_retrieve() {
-        let mut snapshot = WorkflowSnapshot::new("inst-1".into(), "hash-1".into());
+        let mut snapshot = WorkflowSnapshot::new("inst-1", "hash-1".into());
         snapshot.mark_task_completed(crate::TaskId::from("task-1"), Bytes::from("output1"));
 
         let result = snapshot.get_task_result(&crate::TaskId::from("task-1"));
@@ -1176,7 +1176,7 @@ mod tests {
 
     #[test]
     fn test_get_last_task_output() {
-        let mut snapshot = WorkflowSnapshot::new("inst-1".into(), "hash-1".into());
+        let mut snapshot = WorkflowSnapshot::new("inst-1", "hash-1".into());
         assert!(snapshot.get_last_task_output().is_none());
 
         snapshot.mark_task_completed(crate::TaskId::from("task-1"), Bytes::from("out1"));
@@ -1188,7 +1188,7 @@ mod tests {
 
     #[test]
     fn test_get_task_result_bytes() {
-        let mut snapshot = WorkflowSnapshot::new("inst-1".into(), "hash-1".into());
+        let mut snapshot = WorkflowSnapshot::new("inst-1", "hash-1".into());
         snapshot.mark_task_completed(crate::TaskId::from("task-1"), Bytes::from("data"));
         assert_eq!(
             snapshot.get_task_result_bytes(&crate::TaskId::from("task-1")),
@@ -1203,7 +1203,7 @@ mod tests {
 
     #[test]
     fn test_mark_completed() {
-        let mut snapshot = WorkflowSnapshot::new("inst-1".into(), "hash-1".into());
+        let mut snapshot = WorkflowSnapshot::new("inst-1", "hash-1".into());
         snapshot.mark_completed(Bytes::from("final"));
         assert!(snapshot.state.is_completed());
         assert!(snapshot.state.is_terminal());
@@ -1213,7 +1213,7 @@ mod tests {
 
     #[test]
     fn test_mark_failed() {
-        let mut snapshot = WorkflowSnapshot::new("inst-1".into(), "hash-1".into());
+        let mut snapshot = WorkflowSnapshot::new("inst-1", "hash-1".into());
         snapshot.mark_failed("something went wrong".into());
         assert!(snapshot.state.is_failed());
         assert!(snapshot.state.is_terminal());
@@ -1223,7 +1223,7 @@ mod tests {
 
     #[test]
     fn test_mark_cancelled_preserves_completed_tasks() {
-        let mut snapshot = WorkflowSnapshot::new("inst-1".into(), "hash-1".into());
+        let mut snapshot = WorkflowSnapshot::new("inst-1", "hash-1".into());
         snapshot.mark_task_completed(crate::TaskId::from("task-1"), Bytes::from("output1"));
         snapshot.mark_cancelled(
             Some("user request".into()),
@@ -1243,7 +1243,7 @@ mod tests {
 
     #[test]
     fn test_cancellation_details() {
-        let mut snapshot = WorkflowSnapshot::new("inst-1".into(), "hash-1".into());
+        let mut snapshot = WorkflowSnapshot::new("inst-1", "hash-1".into());
         assert!(snapshot.state.cancellation_details().is_none());
 
         snapshot.mark_cancelled(Some("timeout".into()), Some("system".into()), None);
@@ -1256,7 +1256,7 @@ mod tests {
 
     #[test]
     fn test_update_position() {
-        let mut snapshot = WorkflowSnapshot::new("inst-1".into(), "hash-1".into());
+        let mut snapshot = WorkflowSnapshot::new("inst-1", "hash-1".into());
         snapshot.update_position(ExecutionPosition::AtTask {
             task_id: crate::TaskId::from("task-1"),
         });
@@ -1273,7 +1273,7 @@ mod tests {
 
     #[test]
     fn test_update_position_noop_on_terminal() {
-        let mut snapshot = WorkflowSnapshot::new("inst-1".into(), "hash-1".into());
+        let mut snapshot = WorkflowSnapshot::new("inst-1", "hash-1".into());
         snapshot.mark_completed(Bytes::from("done"));
         snapshot.update_position(ExecutionPosition::AtTask {
             task_id: crate::TaskId::from("task-1"),
@@ -1284,7 +1284,7 @@ mod tests {
 
     #[test]
     fn test_mark_task_completed_noop_on_terminal() {
-        let mut snapshot = WorkflowSnapshot::new("inst-1".into(), "hash-1".into());
+        let mut snapshot = WorkflowSnapshot::new("inst-1", "hash-1".into());
         snapshot.mark_completed(Bytes::from("done"));
         snapshot.mark_task_completed(crate::TaskId::from("task-1"), Bytes::from("output"));
         // Should not crash, just be a no-op
@@ -1293,7 +1293,7 @@ mod tests {
 
     #[test]
     fn test_get_task_result_on_completed_state() {
-        let mut snapshot = WorkflowSnapshot::new("inst-1".into(), "hash-1".into());
+        let mut snapshot = WorkflowSnapshot::new("inst-1", "hash-1".into());
         snapshot.mark_completed(Bytes::from("done"));
         assert!(
             snapshot
@@ -1304,7 +1304,7 @@ mod tests {
 
     #[test]
     fn test_get_task_result_on_failed_state() {
-        let mut snapshot = WorkflowSnapshot::new("inst-1".into(), "hash-1".into());
+        let mut snapshot = WorkflowSnapshot::new("inst-1", "hash-1".into());
         snapshot.mark_failed("err".into());
         assert!(
             snapshot
@@ -1315,7 +1315,7 @@ mod tests {
 
     #[test]
     fn test_get_all_task_results_in_progress() {
-        let mut snapshot = WorkflowSnapshot::new("inst-1".into(), "hash-1".into());
+        let mut snapshot = WorkflowSnapshot::new("inst-1", "hash-1".into());
         snapshot.mark_task_completed(crate::TaskId::from("task-1"), Bytes::from("out1"));
         snapshot.mark_task_completed(crate::TaskId::from("task-2"), Bytes::from("out2"));
 
@@ -1335,7 +1335,7 @@ mod tests {
 
     #[test]
     fn test_get_all_task_results_cancelled() {
-        let mut snapshot = WorkflowSnapshot::new("inst-1".into(), "hash-1".into());
+        let mut snapshot = WorkflowSnapshot::new("inst-1", "hash-1".into());
         snapshot.mark_task_completed(crate::TaskId::from("task-1"), Bytes::from("out1"));
         snapshot.mark_cancelled(Some("reason".into()), None, Some("task-2".into()));
 
@@ -1350,7 +1350,7 @@ mod tests {
 
     #[test]
     fn test_get_all_task_results_paused() {
-        let mut snapshot = WorkflowSnapshot::new("inst-1".into(), "hash-1".into());
+        let mut snapshot = WorkflowSnapshot::new("inst-1", "hash-1".into());
         snapshot.mark_task_completed(crate::TaskId::from("task-1"), Bytes::from("out1"));
         let request = PauseRequest::new(Some("maintenance".into()), None);
         snapshot.mark_paused(&request);
@@ -1362,7 +1362,7 @@ mod tests {
 
     #[test]
     fn test_get_all_task_results_completed() {
-        let mut snapshot = WorkflowSnapshot::new("inst-1".into(), "hash-1".into());
+        let mut snapshot = WorkflowSnapshot::new("inst-1", "hash-1".into());
         snapshot.mark_task_completed(crate::TaskId::from("task-1"), Bytes::from("out1"));
         snapshot.mark_completed(Bytes::from("final"));
         assert!(snapshot.get_all_task_results().is_none());
@@ -1370,7 +1370,7 @@ mod tests {
 
     #[test]
     fn test_get_all_task_results_failed() {
-        let mut snapshot = WorkflowSnapshot::new("inst-1".into(), "hash-1".into());
+        let mut snapshot = WorkflowSnapshot::new("inst-1", "hash-1".into());
         snapshot.mark_task_completed(crate::TaskId::from("task-1"), Bytes::from("out1"));
         snapshot.mark_failed("error".into());
         assert!(snapshot.get_all_task_results().is_none());
@@ -1415,7 +1415,7 @@ mod tests {
 
     #[test]
     fn test_timestamps_are_set() {
-        let snapshot = WorkflowSnapshot::new("inst-1".into(), "hash-1".into());
+        let snapshot = WorkflowSnapshot::new("inst-1", "hash-1".into());
         assert!(snapshot.created_at > 0);
         assert!(snapshot.updated_at > 0);
         assert_eq!(snapshot.created_at, snapshot.updated_at);

--- a/sayiir-core/src/snapshot.rs
+++ b/sayiir-core/src/snapshot.rs
@@ -29,11 +29,11 @@ pub struct TaskHint {
 impl TaskHint {
     /// Build a hint by hashing the task name.
     #[must_use]
-    pub fn new(name: &str, priority: Option<u8>, tags: Vec<String>) -> Self {
+    pub fn new(name: &str, priority: Option<u8>, tags: &[String]) -> Self {
         Self {
             id: crate::TaskId::from(name),
             priority,
-            tags,
+            tags: tags.to_vec(),
         }
     }
 }

--- a/sayiir-core/src/snapshot.rs
+++ b/sayiir-core/src/snapshot.rs
@@ -15,27 +15,10 @@ use crate::task::RetryPolicy;
 ///
 /// Carried through `ParkReason` and `prepare_run` so that persistence-layer
 /// advancement inherits priority and tags without re-reading the continuation.
-///
-/// Both forms of the id are kept here: [`id`] is the human-readable name
-/// (used to populate [`ExecutionPosition::AtTask::task_id`] for snapshot
-/// readability), and [`task_id_hash`] is the SHA-256 [`TaskId`] used for
-/// fast O(1) comparison and `HashMap` probes — precomputed once at
-/// hint-build time so downstream consumers don't pay the hash cost on every
-/// check.
-///
-/// [`id`]: TaskHint::id
-/// [`task_id_hash`]: TaskHint::task_id_hash
-/// [`TaskId`]: crate::TaskId
 #[derive(Debug, Clone, Default)]
 pub struct TaskHint {
-    /// The task identifier (human-readable name).
-    pub id: String,
-    /// Precomputed [`crate::TaskId`] = SHA-256 of `id`.
-    ///
-    /// Built once when the hint is created so callers that need a fast id
-    /// comparison (e.g. claim matching, dispatch routing) can avoid
-    /// re-hashing the name on every call.
-    pub task_id_hash: crate::TaskId,
+    /// SHA-256 hash of the task's user-facing name.
+    pub id: crate::TaskId,
     /// Optional execution priority (lower = higher priority).
     pub priority: Option<u8>,
     /// Affinity tags for worker routing.
@@ -43,14 +26,11 @@ pub struct TaskHint {
 }
 
 impl TaskHint {
-    /// Build a hint from a task name, precomputing the [`crate::TaskId`].
+    /// Build a hint by hashing the task name.
     #[must_use]
-    pub fn new(id: impl Into<String>, priority: Option<u8>, tags: Vec<String>) -> Self {
-        let id = id.into();
-        let task_id_hash = crate::TaskId::from(id.as_str());
+    pub fn new(name: &str, priority: Option<u8>, tags: Vec<String>) -> Self {
         Self {
-            id,
-            task_id_hash,
+            id: crate::TaskId::from(name),
             priority,
             tags,
         }
@@ -73,7 +53,7 @@ impl TaskHint {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TaskDeadline {
     /// The task this deadline applies to.
-    pub task_id: String,
+    pub task_id: crate::TaskId,
     /// Absolute wall-clock deadline.
     pub deadline: DateTime<Utc>,
     /// Original configured timeout in milliseconds (for error reporting).
@@ -110,15 +90,15 @@ pub enum ExecutionPosition {
     /// The task ID indicates which task should be executed next.
     AtTask {
         /// ID of the task to execute next.
-        task_id: String,
+        task_id: crate::TaskId,
     },
     /// Execution is parked at a fork because one or more branches hit a delay.
     /// Completed branches have their results cached; delayed branches will
     /// re-execute (skipping cached sub-tasks) once `wake_at` passes.
     AtFork {
         /// Fork node ID.
-        fork_id: String,
-        /// Branch results collected so far.
+        fork_id: crate::TaskId,
+        /// Branch results collected so far. Keyed by branch label, not task id.
         completed_branches: HashMap<String, TaskResult>,
         /// Earliest time the fork can resume.
         wake_at: DateTime<Utc>,
@@ -126,40 +106,40 @@ pub enum ExecutionPosition {
     /// Execution is at a join task, waiting for all branches.
     AtJoin {
         /// Join task ID.
-        join_id: String,
-        /// Branch results collected so far.
+        join_id: crate::TaskId,
+        /// Branch results collected so far. Keyed by branch label, not task id.
         completed_branches: HashMap<String, TaskResult>,
     },
     /// Execution is parked at a delay node, waiting for `wake_at`.
     AtDelay {
         /// Delay node ID.
-        delay_id: String,
+        delay_id: crate::TaskId,
         /// When the delay was entered.
         entered_at: DateTime<Utc>,
         /// When the delay expires.
         wake_at: DateTime<Utc>,
         /// First task ID after the delay (so backends can advance without traversing the workflow tree).
-        next_task_id: Option<String>,
+        next_task_id: Option<crate::TaskId>,
     },
     /// Execution is parked waiting for an external signal.
     AtSignal {
         /// Signal node ID.
-        signal_id: String,
-        /// Name of the signal being waited on.
+        signal_id: crate::TaskId,
+        /// Name of the signal being waited on (user-defined string).
         signal_name: String,
         /// Optional timeout deadline. `None` means wait indefinitely.
         wake_at: Option<DateTime<Utc>>,
         /// First task ID after the signal (so backends can advance without traversing the workflow tree).
-        next_task_id: Option<String>,
+        next_task_id: Option<crate::TaskId>,
     },
     /// Execution is inside a loop at a given iteration.
     InLoop {
         /// Loop node ID.
-        loop_id: String,
+        loop_id: crate::TaskId,
         /// Current iteration (0-based).
         iteration: u32,
         /// Next task to execute within the loop body (for resume positioning).
-        next_task_id: Option<String>,
+        next_task_id: Option<crate::TaskId>,
     },
 }
 
@@ -167,7 +147,7 @@ pub enum ExecutionPosition {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TaskResult {
     /// The task ID that produced this result.
-    pub task_id: String,
+    pub task_id: crate::TaskId,
     /// The serialized output of the task.
     pub output: Bytes,
 }
@@ -312,10 +292,10 @@ pub enum WorkflowSnapshotState {
         /// Current execution position.
         position: ExecutionPosition,
         /// Results from completed tasks (by task ID).
-        completed_tasks: HashMap<String, TaskResult>,
+        completed_tasks: HashMap<crate::TaskId, TaskResult>,
         /// ID of the last completed task (for deterministic resume).
         /// This is needed because `HashMap` iteration order is not guaranteed.
-        last_completed_task_id: Option<String>,
+        last_completed_task_id: Option<crate::TaskId>,
     },
     /// Workflow completed successfully.
     Completed {
@@ -336,9 +316,9 @@ pub enum WorkflowSnapshotState {
         /// Timestamp when the workflow was cancelled.
         cancelled_at: DateTime<Utc>,
         /// Results from tasks that completed before cancellation.
-        completed_tasks: HashMap<String, TaskResult>,
+        completed_tasks: HashMap<crate::TaskId, TaskResult>,
         /// The task ID that was interrupted (if any).
-        interrupted_at_task: Option<String>,
+        interrupted_at_task: Option<crate::TaskId>,
     },
     /// Workflow was paused. Unlike Cancelled, this preserves position and
     /// `last_completed_task_id` so that the workflow can resume from exactly
@@ -351,11 +331,11 @@ pub enum WorkflowSnapshotState {
         /// Timestamp when the workflow was paused.
         paused_at: DateTime<Utc>,
         /// Results from tasks that completed before pausing.
-        completed_tasks: HashMap<String, TaskResult>,
+        completed_tasks: HashMap<crate::TaskId, TaskResult>,
         /// Execution position at the time of pause (for exact resume).
         position: ExecutionPosition,
         /// ID of the last completed task (for deterministic resume).
-        last_completed_task_id: Option<String>,
+        last_completed_task_id: Option<crate::TaskId>,
     },
 }
 
@@ -442,7 +422,7 @@ impl WorkflowSnapshotState {
                 ..
             } => WorkflowStatus::Waiting {
                 wake_at: *wake_at,
-                delay_id: delay_id.clone(),
+                delay_id: *delay_id,
             },
             Self::InProgress {
                 position:
@@ -452,7 +432,7 @@ impl WorkflowSnapshotState {
                 ..
             } => WorkflowStatus::Waiting {
                 wake_at: *wake_at,
-                delay_id: fork_id.clone(),
+                delay_id: *fork_id,
             },
             Self::InProgress {
                 position:
@@ -464,7 +444,7 @@ impl WorkflowSnapshotState {
                     },
                 ..
             } => WorkflowStatus::AwaitingSignal {
-                signal_id: signal_id.clone(),
+                signal_id: *signal_id,
                 signal_name: signal_name.clone(),
                 wake_at: *wake_at,
             },
@@ -543,10 +523,10 @@ pub struct WorkflowSnapshot {
     pub task_deadline: Option<TaskDeadline>,
     /// Retry state for tasks that have failed and are pending retry.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub task_retries: HashMap<String, TaskRetryState>,
+    pub task_retries: HashMap<crate::TaskId, TaskRetryState>,
     /// Current iteration counts for active loops (keyed by loop ID).
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub loop_iterations: HashMap<String, u32>,
+    pub loop_iterations: HashMap<crate::TaskId, u32>,
     /// Execution priority of the current task (1–5).
     ///
     /// Set from the continuation tree when advancing to a new task. Used by
@@ -637,7 +617,7 @@ impl WorkflowSnapshot {
     }
 
     /// Get the result of a completed task, if available.
-    pub fn get_task_result(&self, task_id: &str) -> Option<&TaskResult> {
+    pub fn get_task_result(&self, task_id: &crate::TaskId) -> Option<&TaskResult> {
         match &self.state {
             WorkflowSnapshotState::InProgress {
                 completed_tasks, ..
@@ -653,7 +633,7 @@ impl WorkflowSnapshot {
     }
 
     /// Get the result of a completed task as Bytes, if available.
-    pub fn get_task_result_bytes(&self, task_id: &str) -> Option<Bytes> {
+    pub fn get_task_result_bytes(&self, task_id: &crate::TaskId) -> Option<Bytes> {
         self.get_task_result(task_id).map(|r| r.output.clone())
     }
 
@@ -663,7 +643,7 @@ impl WorkflowSnapshot {
     /// retain `completed_tasks`), and `None` for `Completed` and `Failed` states
     /// (where task results have been discarded).
     #[must_use]
-    pub fn get_all_task_results(&self) -> Option<&HashMap<String, TaskResult>> {
+    pub fn get_all_task_results(&self) -> Option<&HashMap<crate::TaskId, TaskResult>> {
         match &self.state {
             WorkflowSnapshotState::InProgress {
                 completed_tasks, ..
@@ -679,20 +659,14 @@ impl WorkflowSnapshot {
     }
 
     /// Mark a task as completed and store its result.
-    pub fn mark_task_completed(&mut self, task_id: String, output: Bytes) {
+    pub fn mark_task_completed(&mut self, task_id: crate::TaskId, output: Bytes) {
         if let WorkflowSnapshotState::InProgress {
             completed_tasks,
             last_completed_task_id,
             ..
         } = &mut self.state
         {
-            completed_tasks.insert(
-                task_id.clone(),
-                TaskResult {
-                    task_id: task_id.clone(),
-                    output,
-                },
-            );
+            completed_tasks.insert(task_id, TaskResult { task_id, output });
             *last_completed_task_id = Some(task_id);
             self.updated_at = Self::current_timestamp();
         }
@@ -706,8 +680,7 @@ impl WorkflowSnapshot {
                 last_completed_task_id,
                 ..
             } => last_completed_task_id
-                .as_ref()
-                .and_then(|id| completed_tasks.get(id))
+                .and_then(|id| completed_tasks.get(&id))
                 .map(|r| r.output.clone()),
             _ => None,
         }
@@ -733,7 +706,7 @@ impl WorkflowSnapshot {
     ///
     /// Computes `deadline = Utc::now() + timeout` and stores it in the snapshot.
     #[allow(clippy::cast_possible_truncation)]
-    pub fn set_task_deadline(&mut self, task_id: String, timeout: std::time::Duration) {
+    pub fn set_task_deadline(&mut self, task_id: crate::TaskId, timeout: std::time::Duration) {
         let deadline =
             Utc::now() + chrono::Duration::from_std(timeout).unwrap_or(chrono::Duration::MAX);
         self.task_deadline = Some(TaskDeadline {
@@ -764,13 +737,10 @@ impl WorkflowSnapshot {
     /// If the persisted deadline has expired, return `(task_id, timeout)`.
     ///
     /// Returns `None` if no deadline is set or it hasn't expired yet.
-    pub fn expired_task_deadline(&self) -> Option<(&str, std::time::Duration)> {
+    pub fn expired_task_deadline(&self) -> Option<(crate::TaskId, std::time::Duration)> {
         self.task_deadline.as_ref().and_then(|d| {
             if Utc::now() >= d.deadline {
-                Some((
-                    d.task_id.as_str(),
-                    std::time::Duration::from_millis(d.timeout_ms),
-                ))
+                Some((d.task_id, std::time::Duration::from_millis(d.timeout_ms)))
             } else {
                 None
             }
@@ -787,14 +757,14 @@ impl WorkflowSnapshot {
     #[allow(clippy::cast_possible_truncation)]
     pub fn record_retry(
         &mut self,
-        task_id: &str,
+        task_id: crate::TaskId,
         policy: &RetryPolicy,
         error: &str,
         worker_id: Option<&str>,
     ) -> DateTime<Utc> {
         let entry = self
             .task_retries
-            .entry(task_id.to_string())
+            .entry(task_id)
             .or_insert_with(|| TaskRetryState {
                 attempts: 0,
                 policy: policy.clone(),
@@ -821,12 +791,12 @@ impl WorkflowSnapshot {
 
     /// Get the retry state for a task, if any.
     #[must_use]
-    pub fn get_retry_state(&self, task_id: &str) -> Option<&TaskRetryState> {
+    pub fn get_retry_state(&self, task_id: &crate::TaskId) -> Option<&TaskRetryState> {
         self.task_retries.get(task_id)
     }
 
     /// Clear retry state for a task (e.g. on success).
-    pub fn clear_retry_state(&mut self, task_id: &str) {
+    pub fn clear_retry_state(&mut self, task_id: &crate::TaskId) {
         self.task_retries.remove(task_id);
     }
 
@@ -834,7 +804,7 @@ impl WorkflowSnapshot {
     ///
     /// Returns `true` if retry state exists and `attempts >= policy.max_retries`.
     #[must_use]
-    pub fn retries_exhausted(&self, task_id: &str) -> bool {
+    pub fn retries_exhausted(&self, task_id: &crate::TaskId) -> bool {
         self.task_retries
             .get(task_id)
             .is_some_and(|rs| rs.attempts >= rs.policy.max_retries)
@@ -842,18 +812,18 @@ impl WorkflowSnapshot {
 
     /// Get the current iteration for a loop, defaulting to 0.
     #[must_use]
-    pub fn loop_iteration(&self, loop_id: &str) -> u32 {
+    pub fn loop_iteration(&self, loop_id: &crate::TaskId) -> u32 {
         self.loop_iterations.get(loop_id).copied().unwrap_or(0)
     }
 
     /// Set the current iteration for a loop.
-    pub fn set_loop_iteration(&mut self, loop_id: &str, iteration: u32) {
-        self.loop_iterations.insert(loop_id.to_string(), iteration);
+    pub fn set_loop_iteration(&mut self, loop_id: crate::TaskId, iteration: u32) {
+        self.loop_iterations.insert(loop_id, iteration);
         self.updated_at = Self::current_timestamp();
     }
 
     /// Clear loop iteration tracking (called when a loop completes).
-    pub fn clear_loop_iteration(&mut self, loop_id: &str) {
+    pub fn clear_loop_iteration(&mut self, loop_id: &crate::TaskId) {
         self.loop_iterations.remove(loop_id);
     }
 
@@ -861,7 +831,7 @@ impl WorkflowSnapshot {
     ///
     /// Used by loop execution to clear body task results between iterations
     /// so the body re-executes on the next iteration.
-    pub fn remove_task_result(&mut self, task_id: &str) {
+    pub fn remove_task_result(&mut self, task_id: &crate::TaskId) {
         if let WorkflowSnapshotState::InProgress {
             completed_tasks, ..
         } = &mut self.state
@@ -908,7 +878,7 @@ impl WorkflowSnapshot {
                 paused_at: Utc::now(),
                 completed_tasks: completed_tasks.clone(),
                 position: position.clone(),
-                last_completed_task_id: last_completed_task_id.clone(),
+                last_completed_task_id: *last_completed_task_id,
             };
             self.updated_at = Self::current_timestamp();
         }
@@ -927,7 +897,7 @@ impl WorkflowSnapshot {
             self.state = WorkflowSnapshotState::InProgress {
                 position: position.clone(),
                 completed_tasks: completed_tasks.clone(),
-                last_completed_task_id: last_completed_task_id.clone(),
+                last_completed_task_id: *last_completed_task_id,
             };
             self.updated_at = Self::current_timestamp();
         }
@@ -940,7 +910,7 @@ impl WorkflowSnapshot {
         &mut self,
         reason: Option<String>,
         cancelled_by: Option<String>,
-        interrupted_at_task: Option<String>,
+        interrupted_at_task: Option<crate::TaskId>,
     ) {
         let completed_tasks = match &self.state {
             WorkflowSnapshotState::InProgress {
@@ -976,7 +946,7 @@ impl WorkflowSnapshot {
     ///
     /// Used as a soft bias to prefer a different worker on retry.
     #[must_use]
-    pub fn has_failed_on_worker(&self, task_id: &str, worker_id: &str) -> bool {
+    pub fn has_failed_on_worker(&self, task_id: &crate::TaskId, worker_id: &str) -> bool {
         self.task_retries
             .get(task_id)
             .and_then(|rs| rs.last_failed_worker.as_deref())
@@ -987,12 +957,12 @@ impl WorkflowSnapshot {
 
     /// The current task ID, if the workflow is at a task position.
     #[must_use]
-    pub fn current_task_id(&self) -> Option<&str> {
+    pub fn current_task_id(&self) -> Option<crate::TaskId> {
         match &self.state {
             WorkflowSnapshotState::InProgress {
                 position: ExecutionPosition::AtTask { task_id },
                 ..
-            } => Some(task_id.as_str()),
+            } => Some(*task_id),
             _ => None,
         }
     }
@@ -1131,13 +1101,13 @@ mod tests {
             (ExecutionPosition::NotStarted, "NotStarted"),
             (
                 ExecutionPosition::AtTask {
-                    task_id: "t".into(),
+                    task_id: crate::TaskId::from("t"),
                 },
                 "AtTask",
             ),
             (
                 ExecutionPosition::AtFork {
-                    fork_id: "f".into(),
+                    fork_id: crate::TaskId::from("f"),
                     completed_branches: HashMap::new(),
                     wake_at: chrono::Utc::now(),
                 },
@@ -1145,14 +1115,14 @@ mod tests {
             ),
             (
                 ExecutionPosition::AtJoin {
-                    join_id: "j".into(),
+                    join_id: crate::TaskId::from("j"),
                     completed_branches: HashMap::new(),
                 },
                 "AtJoin",
             ),
             (
                 ExecutionPosition::AtDelay {
-                    delay_id: "d".into(),
+                    delay_id: crate::TaskId::from("d"),
                     entered_at: chrono::Utc::now(),
                     wake_at: chrono::Utc::now(),
                     next_task_id: None,
@@ -1161,7 +1131,7 @@ mod tests {
             ),
             (
                 ExecutionPosition::AtSignal {
-                    signal_id: "s".into(),
+                    signal_id: crate::TaskId::from("s"),
                     signal_name: "n".into(),
                     wake_at: None,
                     next_task_id: None,
@@ -1170,7 +1140,7 @@ mod tests {
             ),
             (
                 ExecutionPosition::InLoop {
-                    loop_id: "l".into(),
+                    loop_id: crate::TaskId::from("l"),
                     iteration: 0,
                     next_task_id: None,
                 },
@@ -1196,12 +1166,12 @@ mod tests {
     #[test]
     fn test_mark_task_completed_and_retrieve() {
         let mut snapshot = WorkflowSnapshot::new("inst-1".into(), "hash-1".into());
-        snapshot.mark_task_completed("task-1".into(), Bytes::from("output1"));
+        snapshot.mark_task_completed(crate::TaskId::from("task-1"), Bytes::from("output1"));
 
-        let result = snapshot.get_task_result("task-1");
+        let result = snapshot.get_task_result(&crate::TaskId::from("task-1"));
         assert!(result.is_some());
         assert_eq!(result.unwrap().output, Bytes::from("output1"));
-        assert_eq!(result.unwrap().task_id, "task-1");
+        assert_eq!(result.unwrap().task_id, crate::TaskId::from("task-1"));
     }
 
     #[test]
@@ -1209,22 +1179,26 @@ mod tests {
         let mut snapshot = WorkflowSnapshot::new("inst-1".into(), "hash-1".into());
         assert!(snapshot.get_last_task_output().is_none());
 
-        snapshot.mark_task_completed("task-1".into(), Bytes::from("out1"));
+        snapshot.mark_task_completed(crate::TaskId::from("task-1"), Bytes::from("out1"));
         assert_eq!(snapshot.get_last_task_output(), Some(Bytes::from("out1")));
 
-        snapshot.mark_task_completed("task-2".into(), Bytes::from("out2"));
+        snapshot.mark_task_completed(crate::TaskId::from("task-2"), Bytes::from("out2"));
         assert_eq!(snapshot.get_last_task_output(), Some(Bytes::from("out2")));
     }
 
     #[test]
     fn test_get_task_result_bytes() {
         let mut snapshot = WorkflowSnapshot::new("inst-1".into(), "hash-1".into());
-        snapshot.mark_task_completed("task-1".into(), Bytes::from("data"));
+        snapshot.mark_task_completed(crate::TaskId::from("task-1"), Bytes::from("data"));
         assert_eq!(
-            snapshot.get_task_result_bytes("task-1"),
+            snapshot.get_task_result_bytes(&crate::TaskId::from("task-1")),
             Some(Bytes::from("data"))
         );
-        assert!(snapshot.get_task_result_bytes("nonexistent").is_none());
+        assert!(
+            snapshot
+                .get_task_result_bytes(&crate::TaskId::from("nonexistent"))
+                .is_none()
+        );
     }
 
     #[test]
@@ -1250,7 +1224,7 @@ mod tests {
     #[test]
     fn test_mark_cancelled_preserves_completed_tasks() {
         let mut snapshot = WorkflowSnapshot::new("inst-1".into(), "hash-1".into());
-        snapshot.mark_task_completed("task-1".into(), Bytes::from("output1"));
+        snapshot.mark_task_completed(crate::TaskId::from("task-1"), Bytes::from("output1"));
         snapshot.mark_cancelled(
             Some("user request".into()),
             Some("admin".into()),
@@ -1260,7 +1234,11 @@ mod tests {
         assert!(snapshot.state.is_cancelled());
         assert!(snapshot.state.is_terminal());
         // Completed tasks should be preserved in cancelled state
-        assert!(snapshot.get_task_result("task-1").is_some());
+        assert!(
+            snapshot
+                .get_task_result(&crate::TaskId::from("task-1"))
+                .is_some()
+        );
     }
 
     #[test]
@@ -1280,11 +1258,13 @@ mod tests {
     fn test_update_position() {
         let mut snapshot = WorkflowSnapshot::new("inst-1".into(), "hash-1".into());
         snapshot.update_position(ExecutionPosition::AtTask {
-            task_id: "task-1".into(),
+            task_id: crate::TaskId::from("task-1"),
         });
         match &snapshot.state {
             WorkflowSnapshotState::InProgress { position, .. } => match position {
-                ExecutionPosition::AtTask { task_id } => assert_eq!(task_id, "task-1"),
+                ExecutionPosition::AtTask { task_id } => {
+                    assert_eq!(*task_id, crate::TaskId::from("task-1"));
+                }
                 _ => panic!("Expected AtTask"),
             },
             _ => panic!("Expected InProgress"),
@@ -1296,7 +1276,7 @@ mod tests {
         let mut snapshot = WorkflowSnapshot::new("inst-1".into(), "hash-1".into());
         snapshot.mark_completed(Bytes::from("done"));
         snapshot.update_position(ExecutionPosition::AtTask {
-            task_id: "task-1".into(),
+            task_id: crate::TaskId::from("task-1"),
         });
         // Position update should be a no-op on completed state
         assert!(snapshot.state.is_completed());
@@ -1306,7 +1286,7 @@ mod tests {
     fn test_mark_task_completed_noop_on_terminal() {
         let mut snapshot = WorkflowSnapshot::new("inst-1".into(), "hash-1".into());
         snapshot.mark_completed(Bytes::from("done"));
-        snapshot.mark_task_completed("task-1".into(), Bytes::from("output"));
+        snapshot.mark_task_completed(crate::TaskId::from("task-1"), Bytes::from("output"));
         // Should not crash, just be a no-op
         assert!(snapshot.state.is_completed());
     }
@@ -1315,46 +1295,63 @@ mod tests {
     fn test_get_task_result_on_completed_state() {
         let mut snapshot = WorkflowSnapshot::new("inst-1".into(), "hash-1".into());
         snapshot.mark_completed(Bytes::from("done"));
-        assert!(snapshot.get_task_result("task-1").is_none());
+        assert!(
+            snapshot
+                .get_task_result(&crate::TaskId::from("task-1"))
+                .is_none()
+        );
     }
 
     #[test]
     fn test_get_task_result_on_failed_state() {
         let mut snapshot = WorkflowSnapshot::new("inst-1".into(), "hash-1".into());
         snapshot.mark_failed("err".into());
-        assert!(snapshot.get_task_result("task-1").is_none());
+        assert!(
+            snapshot
+                .get_task_result(&crate::TaskId::from("task-1"))
+                .is_none()
+        );
     }
 
     #[test]
     fn test_get_all_task_results_in_progress() {
         let mut snapshot = WorkflowSnapshot::new("inst-1".into(), "hash-1".into());
-        snapshot.mark_task_completed("task-1".into(), Bytes::from("out1"));
-        snapshot.mark_task_completed("task-2".into(), Bytes::from("out2"));
+        snapshot.mark_task_completed(crate::TaskId::from("task-1"), Bytes::from("out1"));
+        snapshot.mark_task_completed(crate::TaskId::from("task-2"), Bytes::from("out2"));
 
         let results = snapshot.get_all_task_results();
         assert!(results.is_some());
         let results = results.unwrap();
         assert_eq!(results.len(), 2);
-        assert_eq!(results["task-1"].output, Bytes::from("out1"));
-        assert_eq!(results["task-2"].output, Bytes::from("out2"));
+        assert_eq!(
+            results[&crate::TaskId::from("task-1")].output,
+            Bytes::from("out1")
+        );
+        assert_eq!(
+            results[&crate::TaskId::from("task-2")].output,
+            Bytes::from("out2")
+        );
     }
 
     #[test]
     fn test_get_all_task_results_cancelled() {
         let mut snapshot = WorkflowSnapshot::new("inst-1".into(), "hash-1".into());
-        snapshot.mark_task_completed("task-1".into(), Bytes::from("out1"));
+        snapshot.mark_task_completed(crate::TaskId::from("task-1"), Bytes::from("out1"));
         snapshot.mark_cancelled(Some("reason".into()), None, Some("task-2".into()));
 
         let results = snapshot.get_all_task_results();
         assert!(results.is_some());
         assert_eq!(results.unwrap().len(), 1);
-        assert_eq!(results.unwrap()["task-1"].output, Bytes::from("out1"));
+        assert_eq!(
+            results.unwrap()[&crate::TaskId::from("task-1")].output,
+            Bytes::from("out1")
+        );
     }
 
     #[test]
     fn test_get_all_task_results_paused() {
         let mut snapshot = WorkflowSnapshot::new("inst-1".into(), "hash-1".into());
-        snapshot.mark_task_completed("task-1".into(), Bytes::from("out1"));
+        snapshot.mark_task_completed(crate::TaskId::from("task-1"), Bytes::from("out1"));
         let request = PauseRequest::new(Some("maintenance".into()), None);
         snapshot.mark_paused(&request);
 
@@ -1366,7 +1363,7 @@ mod tests {
     #[test]
     fn test_get_all_task_results_completed() {
         let mut snapshot = WorkflowSnapshot::new("inst-1".into(), "hash-1".into());
-        snapshot.mark_task_completed("task-1".into(), Bytes::from("out1"));
+        snapshot.mark_task_completed(crate::TaskId::from("task-1"), Bytes::from("out1"));
         snapshot.mark_completed(Bytes::from("final"));
         assert!(snapshot.get_all_task_results().is_none());
     }
@@ -1374,7 +1371,7 @@ mod tests {
     #[test]
     fn test_get_all_task_results_failed() {
         let mut snapshot = WorkflowSnapshot::new("inst-1".into(), "hash-1".into());
-        snapshot.mark_task_completed("task-1".into(), Bytes::from("out1"));
+        snapshot.mark_task_completed(crate::TaskId::from("task-1"), Bytes::from("out1"));
         snapshot.mark_failed("error".into());
         assert!(snapshot.get_all_task_results().is_none());
     }
@@ -1517,14 +1514,18 @@ mod proptests {
             proptest::collection::vec(any::<u8>(), 0..32),
         )
             .prop_map(|(task_id, data)| TaskResult {
-                task_id,
+                task_id: crate::TaskId::from(task_id.as_str()),
                 output: Bytes::from(data),
             })
     }
 
-    /// Strategy for arbitrary `HashMap<String, TaskResult>`.
-    fn arb_completed_tasks() -> impl Strategy<Value = HashMap<String, TaskResult>> {
-        proptest::collection::hash_map("[a-z0-9]{1,8}", arb_task_result(), 0..4)
+    /// Strategy for arbitrary `HashMap<TaskId, TaskResult>`.
+    fn arb_completed_tasks() -> impl Strategy<Value = HashMap<crate::TaskId, TaskResult>> {
+        proptest::collection::hash_map(
+            "[a-z0-9]{1,8}".prop_map(|s| crate::TaskId::from(s.as_str())),
+            arb_task_result(),
+            0..4,
+        )
     }
 
     /// Strategy for arbitrary `WorkflowSnapshotState`.
@@ -1551,7 +1552,7 @@ mod proptests {
                 prop::option::of("[a-zA-Z0-9 ]{0,32}"),
                 prop::option::of("[a-zA-Z0-9 ]{0,32}"),
                 arb_completed_tasks(),
-                prop::option::of("[a-z0-9]{1,8}"),
+                prop::option::of("[a-z0-9]{1,8}".prop_map(|s| crate::TaskId::from(s.as_str()))),
             )
                 .prop_map(
                     |(reason, cancelled_by, completed_tasks, interrupted_at_task)| {
@@ -1569,7 +1570,7 @@ mod proptests {
                 prop::option::of("[a-zA-Z0-9 ]{0,32}"),
                 prop::option::of("[a-zA-Z0-9 ]{0,32}"),
                 arb_completed_tasks(),
-                prop::option::of("[a-z0-9]{1,8}"),
+                prop::option::of("[a-z0-9]{1,8}".prop_map(|s| crate::TaskId::from(s.as_str()))),
             )
                 .prop_map(
                     |(reason, paused_by, completed_tasks, last_completed_task_id)| {

--- a/sayiir-core/src/snapshot.rs
+++ b/sayiir-core/src/snapshot.rs
@@ -496,7 +496,7 @@ pub struct WorkflowSnapshot {
     /// Unique identifier for this workflow instance.
     pub instance_id: String,
     /// Hash of the workflow definition (for validation).
-    pub definition_hash: String,
+    pub definition_hash: crate::DefinitionHash,
     /// Current state of execution.
     pub state: WorkflowSnapshotState,
     /// Timestamp when this snapshot was created (Unix timestamp).
@@ -550,7 +550,7 @@ impl WorkflowSnapshot {
 
     /// Create a new snapshot for a workflow instance.
     #[must_use]
-    pub fn new(instance_id: String, definition_hash: String) -> Self {
+    pub fn new(instance_id: String, definition_hash: crate::DefinitionHash) -> Self {
         let now = Self::current_timestamp();
         Self {
             instance_id,
@@ -575,7 +575,7 @@ impl WorkflowSnapshot {
     /// Create a new snapshot with initial input.
     pub fn with_initial_input(
         instance_id: String,
-        definition_hash: String,
+        definition_hash: crate::DefinitionHash,
         initial_input: Bytes,
     ) -> Self {
         let now = Self::current_timestamp();
@@ -1074,7 +1074,10 @@ mod tests {
     fn test_new_snapshot_in_progress() {
         let snapshot = WorkflowSnapshot::new("inst-1".into(), "hash-1".into());
         assert_eq!(snapshot.instance_id, "inst-1");
-        assert_eq!(snapshot.definition_hash, "hash-1");
+        assert_eq!(
+            snapshot.definition_hash,
+            crate::DefinitionHash::from("hash-1")
+        );
         assert!(snapshot.state.is_in_progress());
         assert!(!snapshot.state.is_terminal());
         assert!(snapshot.initial_input.is_none());

--- a/sayiir-core/src/task.rs
+++ b/sayiir-core/src/task.rs
@@ -50,6 +50,36 @@ pub struct TaskMetadata {
     pub priority: Option<Priority>,
 }
 
+impl TaskMetadata {
+    /// Build a `TaskMetadata` from the subset of fields actually stored on a
+    /// `WorkflowContinuation::Task` node (or in the `TaskIndex`). `display_name`
+    /// and `description` aren't stored on continuation nodes, so they default.
+    ///
+    /// Shared by both [`WorkflowContinuation::build_task_metadata`] and
+    /// [`TaskIndex::build_task_metadata`] so adding a new continuation-node
+    /// field only requires updating one place.
+    ///
+    /// [`WorkflowContinuation::build_task_metadata`]: crate::workflow::WorkflowContinuation::build_task_metadata
+    /// [`TaskIndex::build_task_metadata`]: crate::task_index::TaskIndex::build_task_metadata
+    #[must_use]
+    pub fn from_node_fields(
+        timeout: Option<Duration>,
+        retries: Option<RetryPolicy>,
+        version: Option<String>,
+        priority: Option<u8>,
+        tags: Vec<String>,
+    ) -> Self {
+        Self {
+            timeout,
+            retries,
+            version,
+            priority: priority.and_then(Priority::from_u8),
+            tags,
+            ..Default::default()
+        }
+    }
+}
+
 /// Configuration for retrying failed task executions.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RetryPolicy {

--- a/sayiir-core/src/task.rs
+++ b/sayiir-core/src/task.rs
@@ -421,14 +421,14 @@ macro_rules! impl_codec_task {
                 BytesFuture::new(async move {
                     let decoded_input = codec.decode::<$input>(input)
                         .map_err(|e| -> BoxError { Box::new(CodecError::DecodeFailed {
-                            task_id: task_id.clone(),
+                            task_id: crate::TaskId::from(task_id.as_str()),
                             expected_type: std::any::type_name::<$input>(),
                             source: e,
                         }) })?;
                     let output = func(decoded_input).await?;
                     codec.encode(&output)
                         .map_err(|e| -> BoxError { Box::new(CodecError::EncodeFailed {
-                            task_id,
+                            task_id: $crate::TaskId::from(task_id.as_str()),
                             source: e,
                         }) })
                 })
@@ -536,7 +536,7 @@ where
             BytesFuture::new(async move {
                 let decoded_input = codec.decode::<I>(input).map_err(|e| -> BoxError {
                     Box::new(CodecError::DecodeFailed {
-                        task_id: task_id.clone(),
+                        task_id: crate::TaskId::from(task_id.as_str()),
                         expected_type: std::any::type_name::<I>(),
                         source: e,
                     })
@@ -544,7 +544,10 @@ where
                 let loop_result = func(decoded_input).await?;
                 let (decision, inner) = loop_result.into_decision();
                 let inner_bytes = codec.encode(&inner).map_err(|e| -> BoxError {
-                    Box::new(CodecError::EncodeFailed { task_id, source: e })
+                    Box::new(CodecError::EncodeFailed {
+                        task_id: crate::TaskId::from(task_id.as_str()),
+                        source: e,
+                    })
                 })?;
                 Ok(crate::codec::encode_loop_envelope(decision, &inner_bytes))
             })
@@ -597,7 +600,7 @@ where
             BytesFuture::new(async move {
                 let decoded_input = codec.decode::<T::Input>(input).map_err(|e| -> BoxError {
                     Box::new(CodecError::DecodeFailed {
-                        task_id: task_id.clone(),
+                        task_id: crate::TaskId::from(task_id.as_str()),
                         expected_type: std::any::type_name::<T::Input>(),
                         source: e,
                     })
@@ -605,7 +608,10 @@ where
                 let loop_result = task.run(decoded_input).await?;
                 let (decision, inner) = loop_result.into_decision();
                 let inner_bytes = codec.encode(&inner).map_err(|e| -> BoxError {
-                    Box::new(CodecError::EncodeFailed { task_id, source: e })
+                    Box::new(CodecError::EncodeFailed {
+                        task_id: crate::TaskId::from(task_id.as_str()),
+                        source: e,
+                    })
                 })?;
                 Ok(crate::codec::encode_loop_envelope(decision, &inner_bytes))
             })
@@ -739,7 +745,7 @@ where
             let named_results: NamedBranchResults =
                 codec.decode(input).map_err(|e| -> BoxError {
                     Box::new(CodecError::DecodeFailed {
-                        task_id: task_id.clone(),
+                        task_id: crate::TaskId::from(task_id.as_str()),
                         expected_type: std::any::type_name::<NamedBranchResults>(),
                         source: e,
                     })
@@ -748,7 +754,10 @@ where
 
             let output = func(branch_outputs).await?;
             codec.encode(&output).map_err(|e| -> BoxError {
-                Box::new(CodecError::EncodeFailed { task_id, source: e })
+                Box::new(CodecError::EncodeFailed {
+                    task_id: crate::TaskId::from(task_id.as_str()),
+                    source: e,
+                })
             })
         })
     }
@@ -854,14 +863,17 @@ where
             BytesFuture::new(async move {
                 let decoded_input = codec.decode::<T::Input>(input).map_err(|e| -> BoxError {
                     Box::new(CodecError::DecodeFailed {
-                        task_id: task_id.clone(),
+                        task_id: crate::TaskId::from(task_id.as_str()),
                         expected_type: std::any::type_name::<T::Input>(),
                         source: e,
                     })
                 })?;
                 let output = task.run(decoded_input).await?;
                 codec.encode(&output).map_err(|e| -> BoxError {
-                    Box::new(CodecError::EncodeFailed { task_id, source: e })
+                    Box::new(CodecError::EncodeFailed {
+                        task_id: crate::TaskId::from(task_id.as_str()),
+                        source: e,
+                    })
                 })
             })
         }

--- a/sayiir-core/src/task_claim.rs
+++ b/sayiir-core/src/task_claim.rs
@@ -152,7 +152,7 @@ pub struct AvailableTask {
     /// The input data for the task (serialized).
     pub input: bytes::Bytes,
     /// The workflow definition hash.
-    pub workflow_definition_hash: String,
+    pub workflow_definition_hash: crate::DefinitionHash,
     /// W3C `traceparent` header for distributed trace context propagation.
     pub trace_parent: Option<String>,
 }

--- a/sayiir-core/src/task_claim.rs
+++ b/sayiir-core/src/task_claim.rs
@@ -15,7 +15,7 @@ pub struct TaskClaim {
     /// The workflow instance ID (not to be confused with the workflow ID)
     pub instance_id: String,
     /// The task ID being claimed.
-    pub task_id: String,
+    pub task_id: crate::TaskId,
     /// The worker node ID that claimed this task.
     pub worker_id: String,
     /// When the claim was created (Unix timestamp).
@@ -31,7 +31,7 @@ impl TaskClaim {
     #[must_use]
     pub fn new(
         instance_id: String,
-        task_id: String,
+        task_id: crate::TaskId,
         worker_id: String,
         ttl: Option<Duration>,
     ) -> Self {
@@ -83,7 +83,7 @@ mod tests {
     fn claim(worker: &str, expires_at: Option<u64>) -> TaskClaim {
         TaskClaim {
             instance_id: "inst-1".into(),
-            task_id: "task-1".into(),
+            task_id: crate::TaskId::from("task-1"),
             worker_id: worker.into(),
             claimed_at: 1_000_000,
             expires_at,
@@ -127,7 +127,7 @@ mod tests {
     fn new_with_ttl_sets_expiry() {
         let c = TaskClaim::new(
             "i".into(),
-            "t".into(),
+            crate::TaskId::from("t"),
             "w".into(),
             Some(Duration::seconds(60)),
         );
@@ -137,7 +137,7 @@ mod tests {
 
     #[test]
     fn new_without_ttl_has_no_expiry() {
-        let c = TaskClaim::new("i".into(), "t".into(), "w".into(), None);
+        let c = TaskClaim::new("i".into(), crate::TaskId::from("t"), "w".into(), None);
         assert!(c.expires_at.is_none());
     }
 }
@@ -148,7 +148,7 @@ pub struct AvailableTask {
     /// The workflow instance ID.
     pub instance_id: String,
     /// The task ID.
-    pub task_id: String,
+    pub task_id: crate::TaskId,
     /// The input data for the task (serialized).
     pub input: bytes::Bytes,
     /// The workflow definition hash.

--- a/sayiir-core/src/task_claim.rs
+++ b/sayiir-core/src/task_claim.rs
@@ -5,6 +5,7 @@
 
 use chrono::{Duration, Utc};
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 
 /// A claim on a task by a worker node.
 ///
@@ -13,7 +14,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TaskClaim {
     /// The workflow instance ID (not to be confused with the workflow ID)
-    pub instance_id: String,
+    pub instance_id: Arc<str>,
     /// The task ID being claimed.
     pub task_id: crate::TaskId,
     /// The worker node ID that claimed this task.
@@ -30,11 +31,12 @@ impl TaskClaim {
     /// Create a new task claim.
     #[must_use]
     pub fn new(
-        instance_id: String,
+        instance_id: &str,
         task_id: crate::TaskId,
         worker_id: String,
         ttl: Option<Duration>,
     ) -> Self {
+        let instance_id: Arc<str> = Arc::from(instance_id);
         let now = Utc::now();
         let claimed_at = now.timestamp() as u64;
         let expires_at = ttl.and_then(|duration| {
@@ -126,7 +128,7 @@ mod tests {
     #[test]
     fn new_with_ttl_sets_expiry() {
         let c = TaskClaim::new(
-            "i".into(),
+            "i",
             crate::TaskId::from("t"),
             "w".into(),
             Some(Duration::seconds(60)),
@@ -137,7 +139,7 @@ mod tests {
 
     #[test]
     fn new_without_ttl_has_no_expiry() {
-        let c = TaskClaim::new("i".into(), crate::TaskId::from("t"), "w".into(), None);
+        let c = TaskClaim::new("i", crate::TaskId::from("t"), "w".into(), None);
         assert!(c.expires_at.is_none());
     }
 }
@@ -146,7 +148,7 @@ mod tests {
 #[derive(Debug, Clone)]
 pub struct AvailableTask {
     /// The workflow instance ID.
-    pub instance_id: String,
+    pub instance_id: Arc<str>,
     /// The task ID.
     pub task_id: crate::TaskId,
     /// The input data for the task (serialized).

--- a/sayiir-core/src/task_index.rs
+++ b/sayiir-core/src/task_index.rs
@@ -83,8 +83,35 @@ impl TaskIndex {
     /// node's `id` to its [`TaskId`].
     #[must_use]
     pub fn build(continuation: &WorkflowContinuation) -> Self {
-        let mut map = HashMap::new();
-        collect(continuation, &mut map);
+        // Single traversal via `iter_nodes` — keeps tree-walking logic in one
+        // place so a new continuation variant only needs to teach `NodeIter`
+        // about itself, not a parallel walker. We index every id-carrying
+        // node (Task / Delay / AwaitSignal) so worker-side `contains` lookups
+        // succeed for delay and signal positions too.
+        let map: HashMap<TaskId, TaskNodeMetadata> = continuation
+            .iter_nodes()
+            .filter(|n| {
+                matches!(
+                    n.kind,
+                    crate::workflow::NodeKind::Task
+                        | crate::workflow::NodeKind::Delay
+                        | crate::workflow::NodeKind::AwaitSignal
+                )
+            })
+            .map(|n| {
+                let metadata = TaskNodeMetadata {
+                    name: Arc::from(n.id),
+                    timeout: n
+                        .timeout
+                        .filter(|_| n.kind == crate::workflow::NodeKind::Task),
+                    priority: n.priority,
+                    tags: n.tags.to_vec(),
+                    retry_policy: n.retry_policy.cloned(),
+                    version: n.version.map(str::to_owned),
+                };
+                (TaskId::from(n.id), metadata)
+            })
+            .collect();
         Self(map)
     }
 
@@ -140,14 +167,13 @@ impl TaskIndex {
     #[must_use]
     pub fn build_task_metadata(&self, task_id: &TaskId) -> crate::task::TaskMetadata {
         match self.0.get(task_id) {
-            Some(m) => crate::task::TaskMetadata {
-                timeout: m.timeout,
-                retries: m.retry_policy.clone(),
-                version: m.version.clone(),
-                priority: m.priority.and_then(crate::priority::Priority::from_u8),
-                tags: m.tags.clone(),
-                ..Default::default()
-            },
+            Some(m) => crate::task::TaskMetadata::from_node_fields(
+                m.timeout,
+                m.retry_policy.clone(),
+                m.version.clone(),
+                m.priority,
+                m.tags.clone(),
+            ),
             None => crate::task::TaskMetadata::default(),
         }
     }
@@ -162,86 +188,5 @@ impl TaskIndex {
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
-    }
-}
-
-fn collect(cont: &WorkflowContinuation, out: &mut HashMap<TaskId, TaskNodeMetadata>) {
-    match cont {
-        WorkflowContinuation::Task {
-            id,
-            timeout,
-            retry_policy,
-            version,
-            priority,
-            tags,
-            next,
-            ..
-        } => {
-            out.insert(
-                TaskId::from(id.as_str()),
-                TaskNodeMetadata {
-                    name: Arc::from(id.as_str()),
-                    timeout: *timeout,
-                    priority: *priority,
-                    tags: tags.clone(),
-                    retry_policy: retry_policy.clone(),
-                    version: version.clone(),
-                },
-            );
-            if let Some(n) = next.as_deref() {
-                collect(n, out);
-            }
-        }
-        WorkflowContinuation::Delay { id, next, .. }
-        | WorkflowContinuation::AwaitSignal { id, next, .. } => {
-            // Non-Task nodes still hash their id so worker-side
-            // `contains(&task_id)` validation succeeds for delay/signal nodes.
-            out.insert(
-                TaskId::from(id.as_str()),
-                TaskNodeMetadata {
-                    name: Arc::from(id.as_str()),
-                    ..TaskNodeMetadata::default()
-                },
-            );
-            if let Some(n) = next.as_deref() {
-                collect(n, out);
-            }
-        }
-        WorkflowContinuation::Fork { branches, join, .. } => {
-            for branch in branches {
-                collect(branch, out);
-            }
-            if let Some(j) = join.as_deref() {
-                collect(j, out);
-            }
-        }
-        WorkflowContinuation::Branch {
-            branches,
-            default,
-            next,
-            ..
-        } => {
-            for branch in branches.values() {
-                collect(branch, out);
-            }
-            if let Some(d) = default.as_deref() {
-                collect(d, out);
-            }
-            if let Some(n) = next.as_deref() {
-                collect(n, out);
-            }
-        }
-        WorkflowContinuation::Loop { body, next, .. } => {
-            collect(body, out);
-            if let Some(n) = next.as_deref() {
-                collect(n, out);
-            }
-        }
-        WorkflowContinuation::ChildWorkflow { child, next, .. } => {
-            collect(child, out);
-            if let Some(n) = next.as_deref() {
-                collect(n, out);
-            }
-        }
     }
 }

--- a/sayiir-core/src/task_index.rs
+++ b/sayiir-core/src/task_index.rs
@@ -1,0 +1,219 @@
+//! O(1) `TaskId → metadata` lookups built once per `Workflow`.
+//!
+//! `find_task` and the metadata getters on [`WorkflowContinuation`] walk the
+//! continuation tree and recompute `TaskId::from(id.as_str())` (SHA-256) for
+//! every visited node. That's fine for occasional introspection, but it adds
+//! up on the dispatch hot path — every task claim does a `build_task_metadata`
+//! plus optional `get_task_timeout` lookup.
+//!
+//! [`TaskIndex`] flattens the tree once at workflow build time into a
+//! `HashMap<TaskId, TaskNodeMetadata>` so the per-dispatch lookups become a
+//! single hash-map probe.
+//!
+//! The index lives behind an `Arc` on [`Workflow`](crate::workflow::Workflow)
+//! and is shared cheaply with anything that needs the same view (the worker's
+//! `ExternalWorkflow`, the distributed runner's hot loop, etc.).
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::TaskId;
+use crate::task::RetryPolicy;
+use crate::workflow::WorkflowContinuation;
+
+/// Metadata captured per `Task` node, keyed by [`TaskId`] in a [`TaskIndex`].
+#[derive(Debug, Clone, Default)]
+pub struct TaskNodeMetadata {
+    /// Human-readable node id (the `id` argument given to the builder).
+    ///
+    /// Stored as `Arc<str>` so the FFI layer can clone it cheaply into
+    /// `TaskExecutionContext` without re-allocating the string per dispatch.
+    pub name: Arc<str>,
+    /// Optional per-task timeout.
+    pub timeout: Option<std::time::Duration>,
+    /// Optional execution priority (1–5; lower runs first).
+    pub priority: Option<u8>,
+    /// Affinity tags for worker-pool routing.
+    pub tags: Vec<String>,
+    /// Optional retry policy.
+    pub retry_policy: Option<RetryPolicy>,
+    /// Optional version string.
+    pub version: Option<String>,
+}
+
+/// O(1) lookup table from [`TaskId`] to per-node metadata.
+///
+/// Built once via [`TaskIndex::build`] at workflow construction. Stored behind
+/// an `Arc` on [`Workflow`](crate::workflow::Workflow) and shared with
+/// anything that needs to resolve `TaskId` → name / timeout / priority / tags
+/// on the dispatch hot path.
+#[derive(Debug, Clone, Default)]
+pub struct TaskIndex(HashMap<TaskId, TaskNodeMetadata>);
+
+impl TaskIndex {
+    /// Build the index by walking `continuation` once and hashing each `Task`
+    /// node's `id` to its [`TaskId`].
+    #[must_use]
+    pub fn build(continuation: &WorkflowContinuation) -> Self {
+        let mut map = HashMap::new();
+        collect(continuation, &mut map);
+        Self(map)
+    }
+
+    /// `true` if the index knows about `task_id`.
+    #[must_use]
+    pub fn contains(&self, task_id: &TaskId) -> bool {
+        self.0.contains_key(task_id)
+    }
+
+    /// Borrow the metadata for `task_id`.
+    #[must_use]
+    pub fn get(&self, task_id: &TaskId) -> Option<&TaskNodeMetadata> {
+        self.0.get(task_id)
+    }
+
+    /// Human-readable node id for `task_id`, if any.
+    #[must_use]
+    pub fn name(&self, task_id: &TaskId) -> Option<&Arc<str>> {
+        self.0.get(task_id).map(|m| &m.name)
+    }
+
+    /// Look up the priority configured on `task_id`.
+    #[must_use]
+    pub fn priority(&self, task_id: &TaskId) -> Option<u8> {
+        self.0.get(task_id).and_then(|m| m.priority)
+    }
+
+    /// Look up the timeout configured on `task_id`.
+    #[must_use]
+    pub fn timeout(&self, task_id: &TaskId) -> Option<std::time::Duration> {
+        self.0.get(task_id).and_then(|m| m.timeout)
+    }
+
+    /// Look up the affinity tags configured on `task_id`.
+    #[must_use]
+    pub fn tags(&self, task_id: &TaskId) -> Vec<String> {
+        self.0
+            .get(task_id)
+            .map(|m| m.tags.clone())
+            .unwrap_or_default()
+    }
+
+    /// Look up the retry policy configured on `task_id`.
+    #[must_use]
+    pub fn retry_policy(&self, task_id: &TaskId) -> Option<&RetryPolicy> {
+        self.0.get(task_id).and_then(|m| m.retry_policy.as_ref())
+    }
+
+    /// Build a [`TaskMetadata`](crate::task::TaskMetadata) from the indexed
+    /// fields. Equivalent to
+    /// [`WorkflowContinuation::build_task_metadata`](crate::workflow::WorkflowContinuation::build_task_metadata)
+    /// but O(1) instead of O(N) tree walk + per-node SHA-256.
+    #[must_use]
+    pub fn build_task_metadata(&self, task_id: &TaskId) -> crate::task::TaskMetadata {
+        match self.0.get(task_id) {
+            Some(m) => crate::task::TaskMetadata {
+                timeout: m.timeout,
+                retries: m.retry_policy.clone(),
+                version: m.version.clone(),
+                priority: m.priority.and_then(crate::priority::Priority::from_u8),
+                tags: m.tags.clone(),
+                ..Default::default()
+            },
+            None => crate::task::TaskMetadata::default(),
+        }
+    }
+
+    /// Number of indexed task nodes.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// `true` when no task nodes are indexed.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+fn collect(cont: &WorkflowContinuation, out: &mut HashMap<TaskId, TaskNodeMetadata>) {
+    match cont {
+        WorkflowContinuation::Task {
+            id,
+            timeout,
+            retry_policy,
+            version,
+            priority,
+            tags,
+            next,
+            ..
+        } => {
+            out.insert(
+                TaskId::from(id.as_str()),
+                TaskNodeMetadata {
+                    name: Arc::from(id.as_str()),
+                    timeout: *timeout,
+                    priority: *priority,
+                    tags: tags.clone(),
+                    retry_policy: retry_policy.clone(),
+                    version: version.clone(),
+                },
+            );
+            if let Some(n) = next.as_deref() {
+                collect(n, out);
+            }
+        }
+        WorkflowContinuation::Delay { id, next, .. }
+        | WorkflowContinuation::AwaitSignal { id, next, .. } => {
+            // Non-Task nodes still hash their id so worker-side
+            // `contains(&task_id)` validation succeeds for delay/signal nodes.
+            out.insert(
+                TaskId::from(id.as_str()),
+                TaskNodeMetadata {
+                    name: Arc::from(id.as_str()),
+                    ..TaskNodeMetadata::default()
+                },
+            );
+            if let Some(n) = next.as_deref() {
+                collect(n, out);
+            }
+        }
+        WorkflowContinuation::Fork { branches, join, .. } => {
+            for branch in branches {
+                collect(branch, out);
+            }
+            if let Some(j) = join.as_deref() {
+                collect(j, out);
+            }
+        }
+        WorkflowContinuation::Branch {
+            branches,
+            default,
+            next,
+            ..
+        } => {
+            for branch in branches.values() {
+                collect(branch, out);
+            }
+            if let Some(d) = default.as_deref() {
+                collect(d, out);
+            }
+            if let Some(n) = next.as_deref() {
+                collect(n, out);
+            }
+        }
+        WorkflowContinuation::Loop { body, next, .. } => {
+            collect(body, out);
+            if let Some(n) = next.as_deref() {
+                collect(n, out);
+            }
+        }
+        WorkflowContinuation::ChildWorkflow { child, next, .. } => {
+            collect(child, out);
+            if let Some(n) = next.as_deref() {
+                collect(n, out);
+            }
+        }
+    }
+}

--- a/sayiir-core/src/task_index.rs
+++ b/sayiir-core/src/task_index.rs
@@ -26,19 +26,47 @@ use crate::workflow::WorkflowContinuation;
 pub struct TaskNodeMetadata {
     /// Human-readable node id (the `id` argument given to the builder).
     ///
-    /// Stored as `Arc<str>` so the FFI layer can clone it cheaply into
-    /// `TaskExecutionContext` without re-allocating the string per dispatch.
-    pub name: Arc<str>,
-    /// Optional per-task timeout.
-    pub timeout: Option<std::time::Duration>,
-    /// Optional execution priority (1–5; lower runs first).
-    pub priority: Option<u8>,
+    /// `Arc<str>` so the FFI layer can clone it cheaply into
+    /// `TaskExecutionContext` without re-allocating per dispatch.
+    pub(crate) name: Arc<str>,
+    pub(crate) timeout: Option<std::time::Duration>,
+    pub(crate) priority: Option<u8>,
+    pub(crate) tags: Vec<String>,
+    pub(crate) retry_policy: Option<RetryPolicy>,
+    pub(crate) version: Option<String>,
+}
+
+impl TaskNodeMetadata {
+    /// Human-readable node id (`Arc<str>` for cheap FFI cloning).
+    #[must_use]
+    pub fn name(&self) -> &Arc<str> {
+        &self.name
+    }
+    /// Configured timeout, if any.
+    #[must_use]
+    pub fn timeout(&self) -> Option<std::time::Duration> {
+        self.timeout
+    }
+    /// Configured priority (1–5; lower runs first).
+    #[must_use]
+    pub fn priority(&self) -> Option<u8> {
+        self.priority
+    }
     /// Affinity tags for worker-pool routing.
-    pub tags: Vec<String>,
-    /// Optional retry policy.
-    pub retry_policy: Option<RetryPolicy>,
+    #[must_use]
+    pub fn tags(&self) -> &[String] {
+        &self.tags
+    }
+    /// Configured retry policy.
+    #[must_use]
+    pub fn retry_policy(&self) -> Option<&RetryPolicy> {
+        self.retry_policy.as_ref()
+    }
     /// Optional version string.
-    pub version: Option<String>,
+    #[must_use]
+    pub fn version(&self) -> Option<&str> {
+        self.version.as_deref()
+    }
 }
 
 /// O(1) lookup table from [`TaskId`] to per-node metadata.
@@ -91,12 +119,12 @@ impl TaskIndex {
     }
 
     /// Look up the affinity tags configured on `task_id`.
+    ///
+    /// Returns a borrow into the index — callers that need to own the tags
+    /// clone explicitly (e.g. when feeding into `TaskHint::new`).
     #[must_use]
-    pub fn tags(&self, task_id: &TaskId) -> Vec<String> {
-        self.0
-            .get(task_id)
-            .map(|m| m.tags.clone())
-            .unwrap_or_default()
+    pub fn tags(&self, task_id: &TaskId) -> &[String] {
+        self.0.get(task_id).map_or(&[], |m| m.tags.as_slice())
     }
 
     /// Look up the retry policy configured on `task_id`.

--- a/sayiir-core/src/validation.rs
+++ b/sayiir-core/src/validation.rs
@@ -1,0 +1,90 @@
+//! Input validation primitives applied at workflow-API entry points.
+//!
+//! These bounds keep user-supplied identifiers within sensible limits before
+//! they touch persistence: DB indexes, NOTIFY payloads, and log fields all
+//! degrade if an instance id can be arbitrarily large.
+
+/// Maximum byte length of a workflow `instance_id`.
+///
+/// Measured in bytes so the bound matches database storage exactly (Postgres
+/// `TEXT` is unbounded but practical index/B-tree behaviour expects short
+/// keys). 256 bytes comfortably covers UUIDs, ULIDs, ULID+prefix, and the
+/// usual `"<service>-<correlation>"` style without invoking arbitrary user
+/// data as a primary-key column.
+pub const MAX_INSTANCE_ID_LEN: usize = 256;
+
+/// Reasons [`validate_instance_id`] may reject an input.
+#[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
+pub enum InvalidInstanceId {
+    /// The supplied id was empty.
+    #[error("instance_id must not be empty")]
+    Empty,
+    /// The supplied id exceeded [`MAX_INSTANCE_ID_LEN`] bytes.
+    #[error("instance_id length {len} exceeds maximum {max} bytes")]
+    TooLong {
+        /// Length of the rejected id in bytes.
+        len: usize,
+        /// The enforced maximum (= [`MAX_INSTANCE_ID_LEN`]).
+        max: usize,
+    },
+}
+
+/// Validate a user-supplied workflow `instance_id` at the API boundary.
+///
+/// Run/resume entry points call this once before any DB I/O so a malformed id
+/// fails fast and consistently — same error shape across single-process,
+/// distributed, and FFI runners.
+///
+/// # Errors
+///
+/// - [`InvalidInstanceId::Empty`] if `instance_id` is the empty string.
+/// - [`InvalidInstanceId::TooLong`] if `instance_id.len() > MAX_INSTANCE_ID_LEN`.
+pub fn validate_instance_id(instance_id: &str) -> Result<(), InvalidInstanceId> {
+    if instance_id.is_empty() {
+        return Err(InvalidInstanceId::Empty);
+    }
+    if instance_id.len() > MAX_INSTANCE_ID_LEN {
+        return Err(InvalidInstanceId::TooLong {
+            len: instance_id.len(),
+            max: MAX_INSTANCE_ID_LEN,
+        });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_typical_ids() {
+        validate_instance_id("a").unwrap();
+        validate_instance_id("order-12345").unwrap();
+        validate_instance_id("01HQK4P9P0V7S6XQGZ9N3M2RF7").unwrap(); // ULID
+    }
+
+    #[test]
+    fn rejects_empty() {
+        assert_eq!(validate_instance_id(""), Err(InvalidInstanceId::Empty));
+    }
+
+    #[test]
+    fn accepts_exactly_max() {
+        let s = "x".repeat(MAX_INSTANCE_ID_LEN);
+        validate_instance_id(&s).unwrap();
+    }
+
+    #[test]
+    fn rejects_one_byte_too_long() {
+        let s = "x".repeat(MAX_INSTANCE_ID_LEN + 1);
+        let err = validate_instance_id(&s).unwrap_err();
+        assert_eq!(
+            err,
+            InvalidInstanceId::TooLong {
+                len: MAX_INSTANCE_ID_LEN + 1,
+                max: MAX_INSTANCE_ID_LEN,
+            }
+        );
+    }
+}

--- a/sayiir-core/src/workflow.rs
+++ b/sayiir-core/src/workflow.rs
@@ -484,7 +484,7 @@ impl WorkflowContinuation {
     #[must_use]
     pub fn first_task_hint(&self) -> crate::snapshot::TaskHint {
         crate::snapshot::TaskHint::new(
-            self.first_task_id().to_string(),
+            self.first_task_id(),
             self.first_task_priority(),
             self.first_task_tags(),
         )
@@ -508,10 +508,20 @@ impl WorkflowContinuation {
     ///
     /// Recursively walks the full continuation tree, including through `Arc`
     /// fork branches, and returns a reference to the matching `Task` node.
-    fn find_task(&self, target_id: &str) -> Option<&Self> {
+    /// Resolve a [`TaskId`](crate::TaskId) back to the human-readable task
+    /// name stored on the matching `Task` node, if any. O(N) tree walk.
+    #[must_use]
+    pub fn find_task_name(&self, target_id: &crate::TaskId) -> Option<&str> {
+        self.find_task(target_id).and_then(|n| match n {
+            WorkflowContinuation::Task { id, .. } => Some(id.as_str()),
+            _ => None,
+        })
+    }
+
+    fn find_task(&self, target_id: &crate::TaskId) -> Option<&Self> {
         match self {
             WorkflowContinuation::Task { id, next, .. } => {
-                if id == target_id {
+                if crate::TaskId::from(id.as_str()) == *target_id {
                     return Some(self);
                 }
                 next.as_ref().and_then(|n| n.find_task(target_id))
@@ -560,9 +570,13 @@ impl WorkflowContinuation {
     /// Same traversal as [`find_task`](Self::find_task) but returns a mutable
     /// reference. Fork branches behind `Arc` are skipped since they cannot be
     /// mutated; only the join continuation is searched.
-    fn find_task_mut(&mut self, target_id: &str) -> Option<&mut Self> {
+    fn find_task_mut(&mut self, target_id: &crate::TaskId) -> Option<&mut Self> {
         match self {
-            WorkflowContinuation::Task { id, .. } if id == target_id => Some(self),
+            WorkflowContinuation::Task { id, .. }
+                if crate::TaskId::from(id.as_str()) == *target_id =>
+            {
+                Some(self)
+            }
             WorkflowContinuation::Task { next, .. } => {
                 next.as_mut().and_then(|n| n.find_task_mut(target_id))
             }
@@ -605,14 +619,22 @@ impl WorkflowContinuation {
     }
 
     /// Set the timeout on a specific task node found by ID.
-    pub fn set_task_timeout(&mut self, target_id: &str, timeout: Option<std::time::Duration>) {
+    pub fn set_task_timeout(
+        &mut self,
+        target_id: &crate::TaskId,
+        timeout: Option<std::time::Duration>,
+    ) {
         if let Some(WorkflowContinuation::Task { timeout: t, .. }) = self.find_task_mut(target_id) {
             *t = timeout;
         }
     }
 
     /// Set the retry policy on a specific task node found by ID.
-    pub fn set_task_retry_policy(&mut self, target_id: &str, policy: Option<RetryPolicy>) {
+    pub fn set_task_retry_policy(
+        &mut self,
+        target_id: &crate::TaskId,
+        policy: Option<RetryPolicy>,
+    ) {
         if let Some(WorkflowContinuation::Task { retry_policy, .. }) = self.find_task_mut(target_id)
         {
             *retry_policy = policy;
@@ -620,7 +642,7 @@ impl WorkflowContinuation {
     }
 
     /// Set the schema version on a specific task node found by ID.
-    pub fn set_task_version(&mut self, target_id: &str, ver: Option<String>) {
+    pub fn set_task_version(&mut self, target_id: &crate::TaskId, ver: Option<String>) {
         if let Some(WorkflowContinuation::Task { version, .. }) = self.find_task_mut(target_id) {
             *version = ver;
         }
@@ -628,7 +650,7 @@ impl WorkflowContinuation {
 
     /// Look up the retry policy configured on a specific task by ID.
     #[must_use]
-    pub fn get_task_retry_policy(&self, task_id: &str) -> Option<&RetryPolicy> {
+    pub fn get_task_retry_policy(&self, task_id: &crate::TaskId) -> Option<&RetryPolicy> {
         match self.find_task(task_id)? {
             WorkflowContinuation::Task { retry_policy, .. } => retry_policy.as_ref(),
             _ => None,
@@ -637,7 +659,7 @@ impl WorkflowContinuation {
 
     /// Look up the timeout configured on a specific task by ID.
     #[must_use]
-    pub fn get_task_timeout(&self, task_id: &str) -> Option<std::time::Duration> {
+    pub fn get_task_timeout(&self, task_id: &crate::TaskId) -> Option<std::time::Duration> {
         match self.find_task(task_id)? {
             WorkflowContinuation::Task { timeout, .. } => *timeout,
             _ => None,
@@ -646,7 +668,7 @@ impl WorkflowContinuation {
 
     /// Look up the priority configured on a specific task by ID.
     #[must_use]
-    pub fn get_task_priority(&self, task_id: &str) -> Option<u8> {
+    pub fn get_task_priority(&self, task_id: &crate::TaskId) -> Option<u8> {
         match self.find_task(task_id)? {
             WorkflowContinuation::Task { priority, .. } => *priority,
             _ => None,
@@ -655,7 +677,7 @@ impl WorkflowContinuation {
 
     /// Look up the affinity tags configured on a specific task by ID.
     #[must_use]
-    pub fn get_task_tags(&self, task_id: &str) -> Vec<String> {
+    pub fn get_task_tags(&self, task_id: &crate::TaskId) -> Vec<String> {
         match self.find_task(task_id) {
             Some(WorkflowContinuation::Task { tags, .. }) => tags.clone(),
             _ => vec![],
@@ -663,7 +685,7 @@ impl WorkflowContinuation {
     }
 
     /// Set the affinity tags on a specific task node found by ID.
-    pub fn set_task_tags(&mut self, target_id: &str, new_tags: Vec<String>) {
+    pub fn set_task_tags(&mut self, target_id: &crate::TaskId, new_tags: Vec<String>) {
         if let Some(WorkflowContinuation::Task { tags, .. }) = self.find_task_mut(target_id) {
             *tags = new_tags;
         }
@@ -676,7 +698,7 @@ impl WorkflowContinuation {
     /// name and description are left as defaults since they are not stored in
     /// the continuation tree.
     #[must_use]
-    pub fn build_task_metadata(&self, task_id: &str) -> crate::task::TaskMetadata {
+    pub fn build_task_metadata(&self, task_id: &crate::TaskId) -> crate::task::TaskMetadata {
         match self.find_task(task_id) {
             Some(WorkflowContinuation::Task {
                 timeout,
@@ -1457,14 +1479,14 @@ pub enum WorkflowStatus {
         /// When the delay expires.
         wake_at: chrono::DateTime<chrono::Utc>,
         /// The delay node ID.
-        delay_id: String,
+        delay_id: crate::TaskId,
     },
     /// The workflow is waiting for an external signal.
     #[strum(serialize = "awaiting_signal")]
     AwaitingSignal {
         /// The signal node ID.
-        signal_id: String,
-        /// The named signal being waited on.
+        signal_id: crate::TaskId,
+        /// The named signal being waited on (user-defined string).
         signal_name: String,
         /// Optional timeout deadline.
         wake_at: Option<chrono::DateTime<chrono::Utc>>,
@@ -1521,14 +1543,15 @@ impl From<WorkflowStatus> for FlatWorkflowStatus {
             }
             WorkflowStatus::Waiting { wake_at, delay_id } => {
                 flat.wake_at = Some(wake_at.to_rfc3339());
-                flat.delay_id = Some(delay_id);
+                // FFI / flattened form keeps strings — render the hash as hex.
+                flat.delay_id = Some(delay_id.to_hex());
             }
             WorkflowStatus::AwaitingSignal {
                 signal_id,
                 signal_name,
                 wake_at,
             } => {
-                flat.signal_id = Some(signal_id);
+                flat.signal_id = Some(signal_id.to_hex());
                 flat.signal_name = Some(signal_name);
                 flat.wake_at = wake_at.map(|t| t.to_rfc3339());
             }
@@ -1554,10 +1577,10 @@ pub struct Workflow<C, Input, M = ()> {
 }
 
 impl<C, Input, M> Workflow<C, Input, M> {
-    /// Get the workflow ID.
+    /// Get the workflow name (human-readable).
     #[must_use]
     pub fn workflow_id(&self) -> &str {
-        &self.context.workflow_id
+        &self.context.workflow_name
     }
 
     /// Get the definition hash.

--- a/sayiir-core/src/workflow.rs
+++ b/sayiir-core/src/workflow.rs
@@ -142,6 +142,10 @@ pub struct NodeInfo<'a> {
     pub retry_policy: Option<&'a RetryPolicy>,
     /// Execution priority (only populated for [`NodeKind::Task`]).
     pub priority: Option<u8>,
+    /// Affinity tags (only populated for [`NodeKind::Task`]).
+    pub tags: &'a [String],
+    /// Schema version string (only populated for [`NodeKind::Task`]).
+    pub version: Option<&'a str>,
 }
 
 /// Lazy, stack-based iterator over workflow nodes in topological order.
@@ -151,6 +155,8 @@ pub struct NodeIter<'a> {
     stack: Vec<(&'a WorkflowContinuation, Option<&'a str>)>,
 }
 
+const EMPTY_TAGS: &[String] = &[];
+
 impl<'a> Iterator for NodeIter<'a> {
     type Item = NodeInfo<'a>;
 
@@ -158,12 +164,14 @@ impl<'a> Iterator for NodeIter<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         let (cont, predecessor) = self.stack.pop()?;
 
-        let (id, kind, timeout, retry_policy, priority) = match cont {
+        let (id, kind, timeout, retry_policy, priority, tags, version) = match cont {
             WorkflowContinuation::Task {
                 id,
                 timeout,
                 retry_policy,
                 priority,
+                tags,
+                version,
                 ..
             } => (
                 id.as_str(),
@@ -171,25 +179,63 @@ impl<'a> Iterator for NodeIter<'a> {
                 *timeout,
                 retry_policy.as_ref(),
                 *priority,
+                tags.as_slice(),
+                version.as_deref(),
             ),
-            WorkflowContinuation::Fork { id, .. } => {
-                (id.as_str(), NodeKind::Fork, None, None, None)
-            }
-            WorkflowContinuation::Delay { id, duration, .. } => {
-                (id.as_str(), NodeKind::Delay, Some(*duration), None, None)
-            }
-            WorkflowContinuation::AwaitSignal { id, timeout, .. } => {
-                (id.as_str(), NodeKind::AwaitSignal, *timeout, None, None)
-            }
-            WorkflowContinuation::Branch { id, .. } => {
-                (id.as_str(), NodeKind::Branch, None, None, None)
-            }
-            WorkflowContinuation::Loop { id, .. } => {
-                (id.as_str(), NodeKind::Loop, None, None, None)
-            }
-            WorkflowContinuation::ChildWorkflow { id, .. } => {
-                (id.as_str(), NodeKind::ChildWorkflow, None, None, None)
-            }
+            WorkflowContinuation::Fork { id, .. } => (
+                id.as_str(),
+                NodeKind::Fork,
+                None,
+                None,
+                None,
+                EMPTY_TAGS,
+                None,
+            ),
+            WorkflowContinuation::Delay { id, duration, .. } => (
+                id.as_str(),
+                NodeKind::Delay,
+                Some(*duration),
+                None,
+                None,
+                EMPTY_TAGS,
+                None,
+            ),
+            WorkflowContinuation::AwaitSignal { id, timeout, .. } => (
+                id.as_str(),
+                NodeKind::AwaitSignal,
+                *timeout,
+                None,
+                None,
+                EMPTY_TAGS,
+                None,
+            ),
+            WorkflowContinuation::Branch { id, .. } => (
+                id.as_str(),
+                NodeKind::Branch,
+                None,
+                None,
+                None,
+                EMPTY_TAGS,
+                None,
+            ),
+            WorkflowContinuation::Loop { id, .. } => (
+                id.as_str(),
+                NodeKind::Loop,
+                None,
+                None,
+                None,
+                EMPTY_TAGS,
+                None,
+            ),
+            WorkflowContinuation::ChildWorkflow { id, .. } => (
+                id.as_str(),
+                NodeKind::ChildWorkflow,
+                None,
+                None,
+                None,
+                EMPTY_TAGS,
+                None,
+            ),
         };
 
         // Push children in reverse order so the first child is popped next.
@@ -252,6 +298,8 @@ impl<'a> Iterator for NodeIter<'a> {
             timeout,
             retry_policy,
             priority,
+            tags,
+            version,
         })
     }
 }
@@ -707,14 +755,13 @@ impl WorkflowContinuation {
                 priority,
                 tags,
                 ..
-            }) => crate::task::TaskMetadata {
-                timeout: *timeout,
-                retries: retry_policy.clone(),
-                version: version.clone(),
-                priority: priority.and_then(crate::priority::Priority::from_u8),
-                tags: tags.clone(),
-                ..Default::default()
-            },
+            }) => crate::task::TaskMetadata::from_node_fields(
+                *timeout,
+                retry_policy.clone(),
+                version.clone(),
+                *priority,
+                tags.clone(),
+            ),
             _ => crate::task::TaskMetadata::default(),
         }
     }

--- a/sayiir-core/src/workflow.rs
+++ b/sayiir-core/src/workflow.rs
@@ -1573,6 +1573,11 @@ pub struct Workflow<C, Input, M = ()> {
     pub(crate) definition_hash: crate::DefinitionHash,
     pub(crate) context: WorkflowContext<C, M>,
     pub(crate) continuation: WorkflowContinuation,
+    /// Per-workflow `TaskId → metadata` index, built once at `build()` time.
+    ///
+    /// Avoids re-hashing every node id with SHA-256 on every dispatch lookup
+    /// (`find_task_name`, `get_task_*`, `build_task_metadata`).
+    pub(crate) task_index: Arc<crate::task_index::TaskIndex>,
     pub(crate) _phantom: PhantomData<Input>,
 }
 
@@ -1609,6 +1614,13 @@ impl<C, Input, M> Workflow<C, Input, M> {
     #[must_use]
     pub fn continuation(&self) -> &WorkflowContinuation {
         &self.continuation
+    }
+
+    /// Get a reference to the `TaskId → metadata` index. Built once at build
+    /// time; cheap to clone (it's behind an `Arc`).
+    #[must_use]
+    pub fn task_index(&self) -> &Arc<crate::task_index::TaskIndex> {
+        &self.task_index
     }
 
     /// Get a reference to the metadata attached to this workflow.

--- a/sayiir-core/src/workflow.rs
+++ b/sayiir-core/src/workflow.rs
@@ -486,7 +486,7 @@ impl WorkflowContinuation {
         crate::snapshot::TaskHint::new(
             self.first_task_id(),
             self.first_task_priority(),
-            self.first_task_tags(),
+            &self.first_task_tags(),
         )
     }
 
@@ -1616,11 +1616,17 @@ impl<C, Input, M> Workflow<C, Input, M> {
         &self.continuation
     }
 
-    /// Get a reference to the `TaskId → metadata` index. Built once at build
-    /// time; cheap to clone (it's behind an `Arc`).
+    /// Borrow the `TaskId → metadata` index. Built once at build time.
     #[must_use]
-    pub fn task_index(&self) -> &Arc<crate::task_index::TaskIndex> {
+    pub fn task_index(&self) -> &crate::task_index::TaskIndex {
         &self.task_index
+    }
+
+    /// Clone the shared `Arc<TaskIndex>` — for callers (FFI / runtime) that
+    /// want to hold onto the index alongside the continuation.
+    #[must_use]
+    pub fn task_index_arc(&self) -> Arc<crate::task_index::TaskIndex> {
+        Arc::clone(&self.task_index)
     }
 
     /// Get a reference to the metadata attached to this workflow.

--- a/sayiir-core/src/workflow.rs
+++ b/sayiir-core/src/workflow.rs
@@ -1195,7 +1195,7 @@ impl SerializableContinuation {
     /// arrangement.
     #[must_use]
     #[allow(clippy::too_many_lines)]
-    pub fn compute_definition_hash(&self) -> String {
+    pub fn compute_definition_hash(&self) -> crate::DefinitionHash {
         #[allow(clippy::too_many_lines)]
         fn hash_continuation(cont: &SerializableContinuation, hasher: &mut Sha256) {
             match cont {
@@ -1344,8 +1344,7 @@ impl SerializableContinuation {
 
         let mut hasher = Sha256::new();
         hash_continuation(self, &mut hasher);
-        let result = hasher.finalize();
-        format!("{result:x}")
+        crate::DefinitionHash::from_hash(crate::Hash32::from_digest(hasher))
     }
 }
 
@@ -1361,7 +1360,7 @@ pub struct SerializedWorkflowState {
     pub workflow_id: String,
     /// SHA256 hash of the workflow definition structure.
     /// Used to detect version mismatches during deserialization.
-    pub definition_hash: String,
+    pub definition_hash: crate::DefinitionHash,
     /// The serializable continuation structure.
     pub continuation: SerializableContinuation,
 }
@@ -1548,7 +1547,7 @@ use crate::registry::TaskRegistry;
 
 /// A built workflow that can be executed.
 pub struct Workflow<C, Input, M = ()> {
-    pub(crate) definition_hash: String,
+    pub(crate) definition_hash: crate::DefinitionHash,
     pub(crate) context: WorkflowContext<C, M>,
     pub(crate) continuation: WorkflowContinuation,
     pub(crate) _phantom: PhantomData<Input>,
@@ -1567,7 +1566,7 @@ impl<C, Input, M> Workflow<C, Input, M> {
     /// as a version identifier. It can be used to detect when a serialized workflow
     /// state was created with a different workflow definition.
     #[must_use]
-    pub fn definition_hash(&self) -> &str {
+    pub fn definition_hash(&self) -> &crate::DefinitionHash {
         &self.definition_hash
     }
 
@@ -1673,7 +1672,7 @@ impl<C, Input, M> SerializableWorkflow<C, Input, M> {
 
     /// Get the definition hash.
     #[must_use]
-    pub fn definition_hash(&self) -> &str {
+    pub fn definition_hash(&self) -> &crate::DefinitionHash {
         self.inner.definition_hash()
     }
 
@@ -1731,7 +1730,7 @@ impl<C, Input, M> SerializableWorkflow<C, Input, M> {
     pub fn to_serializable(&self) -> SerializedWorkflowState {
         SerializedWorkflowState {
             workflow_id: self.inner.workflow_id().to_string(),
-            definition_hash: self.inner.definition_hash.clone(),
+            definition_hash: self.inner.definition_hash,
             continuation: self.inner.continuation().to_serializable(),
         }
     }
@@ -1751,8 +1750,8 @@ impl<C, Input, M> SerializableWorkflow<C, Input, M> {
     ) -> Result<WorkflowContinuation, crate::error::BuildError> {
         if state.definition_hash != self.inner.definition_hash {
             return Err(crate::error::BuildError::DefinitionMismatch {
-                expected: self.inner.definition_hash.clone(),
-                found: state.definition_hash.clone(),
+                expected: self.inner.definition_hash,
+                found: state.definition_hash,
             });
         }
         state.continuation.to_runnable(&self.registry)
@@ -2119,13 +2118,16 @@ mod tests {
         // Check workflow_id is set correctly
         assert_eq!(workflow.workflow_id(), "my-workflow-id");
 
-        // Definition hash should be non-empty
-        assert!(!workflow.definition_hash().is_empty());
+        // Definition hash should be non-zero
+        assert_ne!(
+            *workflow.definition_hash(),
+            crate::DefinitionHash::from_bytes([0u8; 32])
+        );
 
         // Serializable state should contain the same id and hash
         let state = workflow.to_serializable();
         assert_eq!(state.workflow_id, "my-workflow-id");
-        assert_eq!(state.definition_hash, workflow.definition_hash());
+        assert_eq!(&state.definition_hash, workflow.definition_hash());
     }
 
     #[test]
@@ -2167,7 +2169,7 @@ mod tests {
 
         // Create a state with wrong hash
         let mut state = workflow.to_serializable();
-        state.definition_hash = "wrong-hash".to_string();
+        state.definition_hash = crate::DefinitionHash::sha256(b"wrong-hash");
 
         // to_runnable should fail with DefinitionMismatch
         let result = workflow.to_runnable(&state);

--- a/sayiir-d1/src/snapshot_store.rs
+++ b/sayiir-d1/src/snapshot_store.rs
@@ -51,7 +51,7 @@ where
 
         let exec = self.exec();
         sqlx::query(upsert_sql.as_str())
-            .bind(&snapshot.instance_id) // ?1
+            .bind(&*snapshot.instance_id) // ?1
             .bind(status) // ?2
             .bind(snapshot.definition_hash.to_hex()) // ?3
             .bind(&task_id) // ?4
@@ -76,7 +76,7 @@ where
              )";
 
         sqlx::query(history_sql)
-            .bind(&snapshot.instance_id)
+            .bind(&*snapshot.instance_id)
             .bind(status)
             .bind(&task_id)
             .bind(&data)

--- a/sayiir-d1/src/snapshot_store.rs
+++ b/sayiir-d1/src/snapshot_store.rs
@@ -53,7 +53,7 @@ where
         sqlx::query(upsert_sql.as_str())
             .bind(&snapshot.instance_id) // ?1
             .bind(status) // ?2
-            .bind(&snapshot.definition_hash) // ?3
+            .bind(snapshot.definition_hash.to_hex()) // ?3
             .bind(&task_id) // ?4
             .bind(i64::from(task_count)) // ?5
             .bind(&data) // ?6

--- a/sayiir-d1/src/snapshot_store.rs
+++ b/sayiir-d1/src/snapshot_store.rs
@@ -15,7 +15,7 @@ where
     async fn save_snapshot(&self, snapshot: &WorkflowSnapshot) -> Result<(), BackendError> {
         let data = self.encode(snapshot)?;
         let status = snapshot.state.as_ref();
-        let task_id = snapshot.current_task_id().map(ToString::to_string);
+        let task_id = snapshot.current_task_id().map(|t| t.to_hex());
         let task_count = snapshot.completed_task_count();
         let error = snapshot.error_message().map(ToString::to_string);
         let terminal = snapshot.state.is_terminal();
@@ -90,12 +90,12 @@ where
     async fn save_task_result(
         &self,
         instance_id: &str,
-        task_id: &str,
+        task_id: &sayiir_core::TaskId,
         output: bytes::Bytes,
     ) -> Result<(), BackendError> {
         // Single-Worker: no concurrency, so sequential load → mutate → save is safe.
         let mut snapshot = self.load_snapshot(instance_id).await?;
-        snapshot.mark_task_completed(task_id.to_string(), output);
+        snapshot.mark_task_completed(*task_id, output);
         self.save_snapshot(&snapshot).await
     }
 

--- a/sayiir-node/src/backend.rs
+++ b/sayiir-node/src/backend.rs
@@ -172,7 +172,7 @@ impl SnapshotStore for BackendKind {
     async fn save_task_result(
         &self,
         instance_id: &str,
-        task_id: &str,
+        task_id: &sayiir_core::TaskId,
         output: bytes::Bytes,
     ) -> BResult<()> {
         dispatch!(self, |b| b
@@ -239,7 +239,7 @@ impl TaskClaimStore for BackendKind {
     async fn claim_task(
         &self,
         instance_id: &str,
-        task_id: &str,
+        task_id: &sayiir_core::TaskId,
         worker_id: &str,
         ttl: Option<chrono::Duration>,
     ) -> BResult<Option<TaskClaim>> {
@@ -251,7 +251,7 @@ impl TaskClaimStore for BackendKind {
     async fn release_task_claim(
         &self,
         instance_id: &str,
-        task_id: &str,
+        task_id: &sayiir_core::TaskId,
         worker_id: &str,
     ) -> BResult<()> {
         dispatch!(self, |b| b
@@ -262,7 +262,7 @@ impl TaskClaimStore for BackendKind {
     async fn extend_task_claim(
         &self,
         instance_id: &str,
-        task_id: &str,
+        task_id: &sayiir_core::TaskId,
         worker_id: &str,
         additional_duration: chrono::Duration,
     ) -> BResult<()> {
@@ -288,7 +288,7 @@ impl TaskResultStore for BackendKind {
     async fn load_task_result(
         &self,
         instance_id: &str,
-        task_id: &str,
+        task_id: &sayiir_core::TaskId,
     ) -> BResult<Option<bytes::Bytes>> {
         dispatch!(self, |b| b.load_task_result(instance_id, task_id).await)
     }

--- a/sayiir-node/src/durable_engine.rs
+++ b/sayiir-node/src/durable_engine.rs
@@ -456,7 +456,7 @@ fn make_task_executor<'a>(
                 workflow_id: Arc::clone(&wf_id),
                 instance_id: Arc::clone(&inst_id),
                 task_id: Arc::from(task_id),
-                metadata: continuation.build_task_metadata(task_id),
+                metadata: continuation.build_task_metadata(&sayiir_core::TaskId::from(task_id)),
                 workflow_metadata_json: workflow_metadata_json.clone(),
             };
             let registry_ref = Arc::clone(&registry_ref);

--- a/sayiir-node/src/durable_engine.rs
+++ b/sayiir-node/src/durable_engine.rs
@@ -143,7 +143,7 @@ impl NapiDurableEngine {
         task_registry: Object,
     ) -> Result<NapiWorkflowStatus> {
         let continuation = Arc::clone(&workflow.continuation);
-        let definition_hash = workflow.definition_hash.clone();
+        let definition_hash = workflow.definition_hash;
         let first_task = continuation.first_task_hint();
 
         tracing::info!(
@@ -239,7 +239,7 @@ impl NapiDurableEngine {
         task_registry: Object,
     ) -> Result<NapiWorkflowStatus> {
         let continuation = Arc::clone(&workflow.continuation);
-        let definition_hash = workflow.definition_hash.clone();
+        let definition_hash = workflow.definition_hash;
 
         tracing::info!(
             workflow_id = %workflow.workflow_id,

--- a/sayiir-node/src/durable_engine.rs
+++ b/sayiir-node/src/durable_engine.rs
@@ -178,7 +178,7 @@ impl NapiDurableEngine {
             self.runtime
                 .block_on(async {
                     let mut snapshot = match prepare_run(
-                        instance_id,
+                        &instance_id,
                         definition_hash,
                         input_bytes.clone(),
                         first_task,

--- a/sayiir-node/src/engine.rs
+++ b/sayiir-node/src/engine.rs
@@ -69,7 +69,7 @@ impl NapiWorkflowEngine {
                     workflow_id: Arc::clone(&workflow_id),
                     instance_id: Arc::clone(&workflow_id), // sync path: no instance_id
                     task_id: Arc::from(task_id),
-                    metadata: continuation.build_task_metadata(task_id),
+                    metadata: continuation.build_task_metadata(&sayiir_core::TaskId::from(task_id)),
                     workflow_metadata_json: workflow_metadata_json.clone(),
                 };
                 with_thread_local_task_context(task_ctx, || {

--- a/sayiir-node/src/flow.rs
+++ b/sayiir-node/src/flow.rs
@@ -38,6 +38,7 @@ pub struct NapiWorkflow {
     pub(crate) workflow_id: String,
     pub(crate) definition_hash: sayiir_core::DefinitionHash,
     pub(crate) continuation: Arc<WorkflowContinuation>,
+    pub(crate) task_index: Arc<sayiir_core::TaskIndex>,
     pub(crate) metadata_json: Option<String>,
 }
 
@@ -267,10 +268,12 @@ impl NapiFlowBuilder {
             "workflow built"
         );
 
+        let task_index = Arc::new(sayiir_core::TaskIndex::build(&continuation));
         Ok(NapiWorkflow {
             workflow_id: self.workflow_id.clone(),
             definition_hash,
             continuation: Arc::new(continuation),
+            task_index,
             metadata_json: self.metadata_json.clone(),
         })
     }

--- a/sayiir-node/src/flow.rs
+++ b/sayiir-node/src/flow.rs
@@ -36,7 +36,7 @@ pub struct NapiNodeInfo {
 #[napi]
 pub struct NapiWorkflow {
     pub(crate) workflow_id: String,
-    pub(crate) definition_hash: String,
+    pub(crate) definition_hash: sayiir_core::DefinitionHash,
     pub(crate) continuation: Arc<WorkflowContinuation>,
     pub(crate) metadata_json: Option<String>,
 }
@@ -49,8 +49,8 @@ impl NapiWorkflow {
     }
 
     #[napi(getter)]
-    pub fn definition_hash(&self) -> &str {
-        &self.definition_hash
+    pub fn definition_hash(&self) -> String {
+        self.definition_hash.to_hex()
     }
 
     #[napi(getter)]

--- a/sayiir-node/src/worker.rs
+++ b/sayiir-node/src/worker.rs
@@ -115,6 +115,7 @@ impl NapiWorker {
                     wf.definition_hash,
                     ExternalWorkflow {
                         continuation: Arc::clone(&wf.continuation),
+                        task_index: Arc::clone(&wf.task_index),
                         workflow_id: Arc::from(wf.workflow_id.as_str()),
                         metadata_json: wf.metadata_json.as_deref().map(Arc::from),
                     },

--- a/sayiir-node/src/worker.rs
+++ b/sayiir-node/src/worker.rs
@@ -112,7 +112,7 @@ impl NapiWorker {
             .iter()
             .map(|wf| {
                 (
-                    wf.definition_hash.clone(),
+                    wf.definition_hash,
                     ExternalWorkflow {
                         continuation: Arc::clone(&wf.continuation),
                         workflow_id: Arc::from(wf.workflow_id.as_str()),

--- a/sayiir-node/src/workflow_client.rs
+++ b/sayiir-node/src/workflow_client.rs
@@ -116,7 +116,7 @@ impl NapiWorkflowClient {
             self.runtime
                 .block_on(async {
                     match prepare_run(
-                        instance_id,
+                        &instance_id,
                         definition_hash,
                         input_bytes,
                         first_task,

--- a/sayiir-node/src/workflow_client.rs
+++ b/sayiir-node/src/workflow_client.rs
@@ -209,11 +209,15 @@ impl NapiWorkflowClient {
     /// the backend's history or cache.
     #[napi(js_name = "getTaskResult")]
     pub fn get_task_result(&self, instance_id: String, task_id: String) -> Result<Option<String>> {
-        let bytes = with_backend!(self, |backend| {
-            self.runtime
-                .block_on(backend.load_task_result(&instance_id, &task_id))
-                .map_err(exceptions::backend_err_to_napi)?
-        });
+        let bytes =
+            with_backend!(self, |backend| {
+                self.runtime
+                    .block_on(backend.load_task_result(
+                        &instance_id,
+                        &sayiir_core::TaskId::from(task_id.as_str()),
+                    ))
+                    .map_err(exceptions::backend_err_to_napi)?
+            });
         Ok(bytes.map(|b| String::from_utf8_lossy(&b).into_owned()))
     }
 

--- a/sayiir-node/src/workflow_client.rs
+++ b/sayiir-node/src/workflow_client.rs
@@ -89,7 +89,7 @@ impl NapiWorkflowClient {
         instance_id: String,
         input: Unknown,
     ) -> Result<NapiWorkflowStatus> {
-        let definition_hash = workflow.definition_hash.clone();
+        let definition_hash = workflow.definition_hash;
         let first_task = workflow.continuation.first_task_hint();
         let conflict_policy = self.conflict_policy;
 

--- a/sayiir-nodejs/__test__/delay-signal.test.ts
+++ b/sayiir-nodejs/__test__/delay-signal.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { createHash } from "node:crypto";
 import {
   task,
   flow,
@@ -7,6 +8,9 @@ import {
   sendSignal,
   InMemoryBackend,
 } from "../src/index.js";
+
+const taskIdHex = (name: string): string =>
+  createHash("sha256").update(name).digest("hex");
 
 describe("delay", () => {
   it("builds a workflow with a delay step", () => {
@@ -29,10 +33,12 @@ describe("delay", () => {
 
     const status = runDurableWorkflow(wf, "delay-1", 5, backend);
 
-    // Should hit the delay and return waiting with structured fields
+    // Should hit the delay and return waiting with structured fields.
+    // Identifiers are exposed as 32-byte SHA-256 hex at the FFI surface;
+    // the human-readable node id ("wait") only lives in the workflow definition.
     expect(status.status).toBe("waiting");
     if (status.status === "waiting") {
-      expect(status.delayId).toBe("wait");
+      expect(status.delayId).toBe(taskIdHex("wait"));
       expect(status.wakeAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
     }
   });
@@ -57,11 +63,13 @@ describe("signals", () => {
       .build();
     const backend = new InMemoryBackend();
 
-    // First run — should park at signal with structured fields
+    // First run — should park at signal with structured fields.
+    // `signalId` is the SHA-256 hex of the node id ("approval"); `signalName`
+    // remains the human-readable signal-channel name.
     const status1 = runDurableWorkflow(wf, "sig-1", 5, backend);
     expect(status1.status).toBe("awaiting_signal");
     if (status1.status === "awaiting_signal") {
-      expect(status1.signalId).toBe("approval");
+      expect(status1.signalId).toBe(taskIdHex("approval"));
       expect(status1.signalName).toBe("user_approval");
     }
 

--- a/sayiir-persistence/src/backend.rs
+++ b/sayiir-persistence/src/backend.rs
@@ -17,6 +17,16 @@ use sayiir_core::snapshot::{
 };
 use sayiir_core::task_claim::{AvailableTask, TaskClaim};
 
+/// Wire-side representation of a 32-byte SHA-256 hash.
+///
+/// The semantic newtypes [`sayiir_core::TaskId`] / [`sayiir_core::DefinitionHash`]
+/// don't cross this boundary as-is (would couple `sayiir-core` to nanoserde).
+/// Producers convert with `*hash.as_bytes()`; consumers wrap back with
+/// `TaskId::from_bytes(field)` / `DefinitionHash::from_bytes(field)`. The
+/// type-system guarantees live on either side of this alias — over the wire
+/// the payload is just 32 raw bytes.
+pub type HashBytes = [u8; 32];
+
 /// Routing-and-eligibility hint a producer attaches to a "task ready"
 /// wakeup. Workers consume it to:
 ///
@@ -26,16 +36,19 @@ use sayiir_core::task_claim::{AvailableTask, TaskClaim};
 /// * **Direct-claim** — call [`TaskClaimStore::find_hinted_task`] to skip
 ///   the full `find_available_tasks` scan on the happy path; the producer
 ///   already named the task that just became ready.
-///
 #[derive(Debug, Clone, PartialEq, Eq, nanoserde::SerBin, nanoserde::DeBin)]
 pub struct TaskWakeupHint {
-    /// Workflow instance the task belongs to.
+    /// Workflow instance the task belongs to (user-supplied, human-readable
+    /// — *not* a hash; this is the same string the user passes to
+    /// `runner.run("…")` and that appears in Postgres `instance_id` columns
+    /// and log spans).
     pub instance_id: String,
-    /// Task id that's claimable as of the producer's commit.
-    pub task_id: String,
-    /// `definition_hash` of the workflow — workers without this hash
-    /// registered can drop the wake without touching the DB.
-    pub definition_hash: String,
+    /// SHA-256 of the task node id — wraps to [`sayiir_core::TaskId`].
+    pub task_id: HashBytes,
+    /// SHA-256 of the workflow definition — wraps to [`sayiir_core::DefinitionHash`].
+    /// Workers without this definition registered drop the wake without
+    /// touching the DB.
+    pub definition_hash: HashBytes,
     /// Task tags. A worker can handle the task only if its tag set is a
     /// superset of `tags` (untagged tasks are claimable by anyone).
     pub tags: Vec<String>,
@@ -45,7 +58,7 @@ pub struct TaskWakeupHint {
 /// any breaking change to [`TaskWakeupHint`]'s field layout so decoders
 /// reject payloads they don't understand instead of silently
 /// misparsing them.
-const HINT_WIRE_VERSION: u8 = 1;
+const HINT_WIRE_VERSION: u8 = 2;
 
 impl TaskWakeupHint {
     /// Encode to a base64-wrapped binary blob, suitable for any text-only
@@ -97,8 +110,8 @@ mod hint_tests {
     fn sample() -> TaskWakeupHint {
         TaskWakeupHint {
             instance_id: "wf-abc-123".to_string(),
-            task_id: "step-1".to_string(),
-            definition_hash: "hash-xyz".to_string(),
+            task_id: [0x42; 32],
+            definition_hash: [0xab; 32],
             tags: vec!["gpu".to_string(), "cuda-12".to_string()],
         }
     }

--- a/sayiir-persistence/src/backend.rs
+++ b/sayiir-persistence/src/backend.rs
@@ -178,7 +178,7 @@ pub trait SnapshotStore: Send + Sync {
     fn save_task_result(
         &self,
         instance_id: &str,
-        task_id: &str,
+        task_id: &sayiir_core::TaskId,
         output: bytes::Bytes,
     ) -> impl Future<Output = Result<(), BackendError>> + Send;
 
@@ -262,7 +262,7 @@ pub trait SignalStore: SnapshotStore {
     fn check_and_cancel(
         &self,
         instance_id: &str,
-        interrupted_at_task: Option<&str>,
+        interrupted_at_task: Option<sayiir_core::TaskId>,
     ) -> impl Future<Output = Result<bool, BackendError>> + Send {
         async move {
             let Some(request) = self.get_signal(instance_id, SignalKind::Cancel).await? else {
@@ -272,11 +272,7 @@ pub trait SignalStore: SnapshotStore {
             if !snapshot.state.is_in_progress() {
                 return Ok(false);
             }
-            snapshot.mark_cancelled(
-                request.reason,
-                request.requested_by,
-                interrupted_at_task.map(String::from),
-            );
+            snapshot.mark_cancelled(request.reason, request.requested_by, interrupted_at_task);
             self.save_snapshot(&snapshot).await?;
             self.clear_signal(instance_id, SignalKind::Cancel).await?;
             Ok(true)
@@ -347,7 +343,7 @@ pub trait TaskClaimStore: Send + Sync {
     fn claim_task(
         &self,
         instance_id: &str,
-        task_id: &str,
+        task_id: &sayiir_core::TaskId,
         worker_id: &str,
         ttl: Option<Duration>,
     ) -> impl Future<Output = Result<Option<TaskClaim>, BackendError>> + Send;
@@ -356,7 +352,7 @@ pub trait TaskClaimStore: Send + Sync {
     fn release_task_claim(
         &self,
         instance_id: &str,
-        task_id: &str,
+        task_id: &sayiir_core::TaskId,
         worker_id: &str,
     ) -> impl Future<Output = Result<(), BackendError>> + Send;
 
@@ -364,7 +360,7 @@ pub trait TaskClaimStore: Send + Sync {
     fn extend_task_claim(
         &self,
         instance_id: &str,
-        task_id: &str,
+        task_id: &sayiir_core::TaskId,
         worker_id: &str,
         additional_duration: Duration,
     ) -> impl Future<Output = Result<(), BackendError>> + Send;
@@ -442,7 +438,7 @@ pub trait TaskResultStore: SnapshotStore {
     fn load_task_result(
         &self,
         instance_id: &str,
-        task_id: &str,
+        task_id: &sayiir_core::TaskId,
     ) -> impl Future<Output = Result<Option<bytes::Bytes>, BackendError>> + Send;
 }
 

--- a/sayiir-persistence/src/in_memory.rs
+++ b/sayiir-persistence/src/in_memory.rs
@@ -15,8 +15,11 @@ use std::sync::{Arc, RwLock};
 
 /// Signal requests indexed by workflow instance.
 type SignalsByInstance = HashMap<Arc<str>, HashMap<SignalKind, SignalRequest>>;
-/// FIFO event queues indexed by `(instance_id, signal_name)`.
-type EventsBySignal = HashMap<(Arc<str>, String), VecDeque<bytes::Bytes>>;
+/// FIFO event queues indexed by instance, then signal name.
+///
+/// Nested instead of tuple-keyed so reads can `Borrow`-lookup by `&str` without
+/// re-allocating an `Arc<str>` just to satisfy the key type.
+type EventsBySignal = HashMap<Arc<str>, HashMap<String, VecDeque<bytes::Bytes>>>;
 /// Cached task results for terminal workflows, indexed by instance.
 type TaskResultsByInstance = HashMap<Arc<str>, HashMap<sayiir_core::TaskId, TaskResult>>;
 
@@ -233,8 +236,13 @@ impl SignalStore for InMemoryBackend {
         payload: bytes::Bytes,
     ) -> Result<(), BackendError> {
         let mut events = self.events.write().map_err(Self::lock_error)?;
-        events
-            .entry((Arc::from(instance_id), signal_name.to_string()))
+        // Allocate Arc<str> only on first event for this instance.
+        let by_signal = match events.get_mut(instance_id) {
+            Some(m) => m,
+            None => events.entry(Arc::from(instance_id)).or_default(),
+        };
+        by_signal
+            .entry(signal_name.to_string())
             .or_default()
             .push_back(payload);
         Ok(())
@@ -246,11 +254,16 @@ impl SignalStore for InMemoryBackend {
         signal_name: &str,
     ) -> Result<Option<bytes::Bytes>, BackendError> {
         let mut events = self.events.write().map_err(Self::lock_error)?;
-        let key = (Arc::<str>::from(instance_id), signal_name.to_string());
-        let payload = events.get_mut(&key).and_then(VecDeque::pop_front);
+        let Some(by_signal) = events.get_mut(instance_id) else {
+            return Ok(None);
+        };
+        let payload = by_signal.get_mut(signal_name).and_then(VecDeque::pop_front);
         // Clean up empty queues
-        if events.get(&key).is_some_and(VecDeque::is_empty) {
-            events.remove(&key);
+        if by_signal.get(signal_name).is_some_and(VecDeque::is_empty) {
+            by_signal.remove(signal_name);
+        }
+        if by_signal.is_empty() {
+            events.remove(instance_id);
         }
         Ok(payload)
     }
@@ -525,8 +538,11 @@ impl TaskClaimStore for InMemoryBackend {
                             },
                         ..
                     } => {
-                        let key = (instance_id.clone(), signal_name.clone());
-                        if events.get(&key).is_some_and(|q| !q.is_empty()) {
+                        let has_payload = events
+                            .get(&**instance_id)
+                            .and_then(|m| m.get(signal_name))
+                            .is_some_and(|q| !q.is_empty());
+                        if has_payload {
                             // Signal arrived — advance
                             signal_advances.push((
                                 instance_id.clone(),
@@ -571,14 +587,19 @@ impl TaskClaimStore for InMemoryBackend {
             {
                 let mut events = self.events.write().map_err(Self::lock_error)?;
                 for (instance_id, signal_name, next_task_id) in &signal_advances {
-                    let key = (instance_id.clone(), signal_name.clone());
                     let payload = events
-                        .get_mut(&key)
+                        .get_mut(&**instance_id)
+                        .and_then(|m| m.get_mut(signal_name))
                         .and_then(VecDeque::pop_front)
                         .unwrap_or_default();
                     // Clean up empty queues
-                    if events.get(&key).is_some_and(VecDeque::is_empty) {
-                        events.remove(&key);
+                    if let Some(by_signal) = events.get_mut(&**instance_id) {
+                        if by_signal.get(signal_name).is_some_and(VecDeque::is_empty) {
+                            by_signal.remove(signal_name);
+                        }
+                        if by_signal.is_empty() {
+                            events.remove(&**instance_id);
+                        }
                     }
                     if let Some(snapshot) = snapshots.get_mut(instance_id) {
                         // Store signal payload as a task result so the next step can use it

--- a/sayiir-persistence/src/in_memory.rs
+++ b/sayiir-persistence/src/in_memory.rs
@@ -28,7 +28,7 @@ pub struct InMemoryBackend {
     events: Arc<RwLock<HashMap<(String, String), VecDeque<bytes::Bytes>>>>,
     /// Cached task results for workflows that have transitioned to terminal states
     /// (Completed/Failed), where `completed_tasks` is no longer in the snapshot.
-    task_results_cache: Arc<RwLock<HashMap<String, HashMap<String, TaskResult>>>>,
+    task_results_cache: Arc<RwLock<HashMap<String, HashMap<sayiir_core::TaskId, TaskResult>>>>,
 }
 
 impl InMemoryBackend {
@@ -37,7 +37,8 @@ impl InMemoryBackend {
         Default::default()
     }
 
-    fn claim_key(instance_id: &str, task_id: &str) -> String {
+    fn claim_key(instance_id: &str, task_id: &sayiir_core::TaskId) -> String {
+        // TaskId Display = 64-char hex.
         format!("{}:{}", instance_id, task_id)
     }
 
@@ -73,7 +74,7 @@ impl SnapshotStore for InMemoryBackend {
     async fn save_task_result(
         &self,
         instance_id: &str,
-        task_id: &str,
+        task_id: &sayiir_core::TaskId,
         output: bytes::Bytes,
     ) -> Result<(), BackendError> {
         let mut snapshots = self.snapshots.write().map_err(Self::lock_error)?;
@@ -82,7 +83,7 @@ impl SnapshotStore for InMemoryBackend {
             .get_mut(instance_id)
             .ok_or_else(|| BackendError::NotFound(instance_id.to_string()))?;
 
-        snapshot.mark_task_completed(task_id.to_string(), output);
+        snapshot.mark_task_completed(*task_id, output);
         Ok(())
     }
 
@@ -120,7 +121,7 @@ impl TaskResultStore for InMemoryBackend {
     async fn load_task_result(
         &self,
         instance_id: &str,
-        task_id: &str,
+        task_id: &sayiir_core::TaskId,
     ) -> Result<Option<bytes::Bytes>, BackendError> {
         let snapshots = self.snapshots.read().map_err(Self::lock_error)?;
         let snapshot = snapshots
@@ -252,7 +253,7 @@ impl SignalStore for InMemoryBackend {
     async fn check_and_cancel(
         &self,
         instance_id: &str,
-        interrupted_at_task: Option<&str>,
+        interrupted_at_task: Option<sayiir_core::TaskId>,
     ) -> Result<bool, BackendError> {
         let request = {
             let signals = self.signals.read().map_err(Self::lock_error)?;
@@ -273,11 +274,7 @@ impl SignalStore for InMemoryBackend {
             if !snapshot.state.is_in_progress() {
                 return Ok(false);
             }
-            snapshot.mark_cancelled(
-                request.reason,
-                request.requested_by,
-                interrupted_at_task.map(String::from),
-            );
+            snapshot.mark_cancelled(request.reason, request.requested_by, interrupted_at_task);
         }
 
         {
@@ -369,7 +366,7 @@ impl TaskClaimStore for InMemoryBackend {
     async fn claim_task(
         &self,
         instance_id: &str,
-        task_id: &str,
+        task_id: &sayiir_core::TaskId,
         worker_id: &str,
         ttl: Option<Duration>,
     ) -> Result<Option<TaskClaim>, BackendError> {
@@ -388,7 +385,7 @@ impl TaskClaimStore for InMemoryBackend {
         // Create new claim
         let claim = TaskClaim::new(
             instance_id.to_string(),
-            task_id.to_string(),
+            *task_id,
             worker_id.to_string(),
             ttl,
         );
@@ -399,7 +396,7 @@ impl TaskClaimStore for InMemoryBackend {
     async fn release_task_claim(
         &self,
         instance_id: &str,
-        task_id: &str,
+        task_id: &sayiir_core::TaskId,
         worker_id: &str,
     ) -> Result<(), BackendError> {
         let key = Self::claim_key(instance_id, task_id);
@@ -425,7 +422,7 @@ impl TaskClaimStore for InMemoryBackend {
     async fn extend_task_claim(
         &self,
         instance_id: &str,
-        task_id: &str,
+        task_id: &sayiir_core::TaskId,
         worker_id: &str,
         additional_duration: Duration,
     ) -> Result<(), BackendError> {
@@ -471,12 +468,13 @@ impl TaskClaimStore for InMemoryBackend {
         }
 
         // Collect delay-expired workflows that need position advancement
-        let mut delay_advances: Vec<(String, String)> = Vec::new();
-        let mut delay_completions: Vec<(String, String)> = Vec::new();
+        let mut delay_advances: Vec<(String, sayiir_core::TaskId)> = Vec::new();
+        let mut delay_completions: Vec<(String, sayiir_core::TaskId)> = Vec::new();
         // Signal-related advancements: (instance_id, signal_name, next_task_id_or_none)
-        let mut signal_advances: Vec<(String, String, Option<String>)> = Vec::new();
+        let mut signal_advances: Vec<(String, String, Option<sayiir_core::TaskId>)> = Vec::new();
         // Signal timeout expirations: (instance_id, signal_id, next_task_id_or_none)
-        let mut signal_timeout_advances: Vec<(String, String, Option<String>)> = Vec::new();
+        let mut signal_timeout_advances: Vec<(String, String, Option<sayiir_core::TaskId>)> =
+            Vec::new();
 
         {
             let snapshots = self.snapshots.read().map_err(Self::lock_error)?;
@@ -511,9 +509,9 @@ impl TaskClaimStore for InMemoryBackend {
                         ..
                     } if Utc::now() >= *wake_at => {
                         if let Some(next_id) = next_task_id {
-                            delay_advances.push((instance_id.clone(), next_id.clone()));
+                            delay_advances.push((instance_id.clone(), *next_id));
                         } else {
-                            delay_completions.push((instance_id.clone(), delay_id.clone()));
+                            delay_completions.push((instance_id.clone(), *delay_id));
                         }
                     }
                     WorkflowSnapshotState::InProgress {
@@ -532,14 +530,14 @@ impl TaskClaimStore for InMemoryBackend {
                             signal_advances.push((
                                 instance_id.clone(),
                                 signal_name.clone(),
-                                next_task_id.clone(),
+                                *next_task_id,
                             ));
                         } else if wake_at.is_some_and(|wt| Utc::now() >= wt) {
                             // Timeout expired — advance with None payload
                             signal_timeout_advances.push((
                                 instance_id.clone(),
                                 signal_name.clone(),
-                                next_task_id.clone(),
+                                *next_task_id,
                             ));
                         }
                     }
@@ -558,7 +556,7 @@ impl TaskClaimStore for InMemoryBackend {
             for (instance_id, next_task_id) in &delay_advances {
                 if let Some(snapshot) = snapshots.get_mut(instance_id) {
                     snapshot.update_position(ExecutionPosition::AtTask {
-                        task_id: next_task_id.clone(),
+                        task_id: *next_task_id,
                     });
                 }
             }
@@ -583,14 +581,18 @@ impl TaskClaimStore for InMemoryBackend {
                     }
                     if let Some(snapshot) = snapshots.get_mut(instance_id) {
                         // Store signal payload as a task result so the next step can use it
-                        snapshot.mark_task_completed(signal_name.clone(), payload);
+                        snapshot.mark_task_completed(
+                            sayiir_core::TaskId::from(signal_name.as_str()),
+                            payload,
+                        );
                         if let Some(next_id) = next_task_id {
-                            snapshot.update_position(ExecutionPosition::AtTask {
-                                task_id: next_id.clone(),
-                            });
+                            snapshot
+                                .update_position(ExecutionPosition::AtTask { task_id: *next_id });
                         } else {
                             let output = snapshot
-                                .get_task_result_bytes(signal_name)
+                                .get_task_result_bytes(&sayiir_core::TaskId::from(
+                                    signal_name.as_str(),
+                                ))
                                 .unwrap_or_default();
                             snapshot.mark_completed(output);
                         }
@@ -600,11 +602,12 @@ impl TaskClaimStore for InMemoryBackend {
             // Handle signal timeouts (advance with empty payload)
             for (instance_id, signal_name, next_task_id) in &signal_timeout_advances {
                 if let Some(snapshot) = snapshots.get_mut(instance_id) {
-                    snapshot.mark_task_completed(signal_name.clone(), bytes::Bytes::new());
+                    snapshot.mark_task_completed(
+                        sayiir_core::TaskId::from(signal_name.as_str()),
+                        bytes::Bytes::new(),
+                    );
                     if let Some(next_id) = next_task_id {
-                        snapshot.update_position(ExecutionPosition::AtTask {
-                            task_id: next_id.clone(),
-                        });
+                        snapshot.update_position(ExecutionPosition::AtTask { task_id: *next_id });
                     } else {
                         snapshot.mark_completed(bytes::Bytes::new());
                     }
@@ -669,7 +672,7 @@ impl TaskClaimStore for InMemoryBackend {
                     if let Some(input_bytes) = input {
                         available.push(AvailableTask {
                             instance_id: instance_id.clone(),
-                            task_id: task_id.clone(),
+                            task_id: *task_id,
                             input: input_bytes,
                             workflow_definition_hash: snapshot.definition_hash,
                             trace_parent: None,
@@ -788,7 +791,7 @@ mod tests {
         let claim = backend
             .claim_task(
                 "workflow-1",
-                "task-1",
+                &sayiir_core::TaskId::from("task-1"),
                 "worker-1",
                 Some(Duration::seconds(300)),
             )
@@ -798,7 +801,7 @@ mod tests {
         assert!(claim.is_some());
         let claim = claim.unwrap();
         assert_eq!(claim.instance_id, "workflow-1");
-        assert_eq!(claim.task_id, "task-1");
+        assert_eq!(claim.task_id, sayiir_core::TaskId::from("task-1"));
         assert_eq!(claim.worker_id, "worker-1");
         assert!(claim.expires_at.is_some());
     }
@@ -811,7 +814,7 @@ mod tests {
         let claim1 = backend
             .claim_task(
                 "workflow-1",
-                "task-1",
+                &sayiir_core::TaskId::from("task-1"),
                 "worker-1",
                 Some(Duration::seconds(300)),
             )
@@ -823,7 +826,7 @@ mod tests {
         let claim2 = backend
             .claim_task(
                 "workflow-1",
-                "task-1",
+                &sayiir_core::TaskId::from("task-1"),
                 "worker-2",
                 Some(Duration::seconds(300)),
             )
@@ -840,7 +843,7 @@ mod tests {
         let claim1 = backend
             .claim_task(
                 "workflow-1",
-                "task-1",
+                &sayiir_core::TaskId::from("task-1"),
                 "worker-1",
                 Some(Duration::seconds(0)),
             )
@@ -852,7 +855,7 @@ mod tests {
         let claim2 = backend
             .claim_task(
                 "workflow-1",
-                "task-1",
+                &sayiir_core::TaskId::from("task-1"),
                 "worker-2",
                 Some(Duration::seconds(300)),
             )
@@ -868,7 +871,12 @@ mod tests {
         let backend = InMemoryBackend::new();
 
         let claim = backend
-            .claim_task("workflow-1", "task-1", "worker-1", None)
+            .claim_task(
+                "workflow-1",
+                &sayiir_core::TaskId::from("task-1"),
+                "worker-1",
+                None,
+            )
             .await
             .unwrap();
 
@@ -886,7 +894,7 @@ mod tests {
         backend
             .claim_task(
                 "workflow-1",
-                "task-1",
+                &sayiir_core::TaskId::from("task-1"),
                 "worker-1",
                 Some(Duration::seconds(300)),
             )
@@ -895,7 +903,11 @@ mod tests {
 
         // Release it
         let result = backend
-            .release_task_claim("workflow-1", "task-1", "worker-1")
+            .release_task_claim(
+                "workflow-1",
+                &sayiir_core::TaskId::from("task-1"),
+                "worker-1",
+            )
             .await;
         assert!(result.is_ok());
 
@@ -903,7 +915,7 @@ mod tests {
         let claim = backend
             .claim_task(
                 "workflow-1",
-                "task-1",
+                &sayiir_core::TaskId::from("task-1"),
                 "worker-2",
                 Some(Duration::seconds(300)),
             )
@@ -920,7 +932,7 @@ mod tests {
         backend
             .claim_task(
                 "workflow-1",
-                "task-1",
+                &sayiir_core::TaskId::from("task-1"),
                 "worker-1",
                 Some(Duration::seconds(300)),
             )
@@ -929,7 +941,11 @@ mod tests {
 
         // Try to release as worker-2
         let result = backend
-            .release_task_claim("workflow-1", "task-1", "worker-2")
+            .release_task_claim(
+                "workflow-1",
+                &sayiir_core::TaskId::from("task-1"),
+                "worker-2",
+            )
             .await;
         assert!(matches!(result, Err(BackendError::Backend(_))));
     }
@@ -939,7 +955,11 @@ mod tests {
         let backend = InMemoryBackend::new();
 
         let result = backend
-            .release_task_claim("workflow-1", "task-1", "worker-1")
+            .release_task_claim(
+                "workflow-1",
+                &sayiir_core::TaskId::from("task-1"),
+                "worker-1",
+            )
             .await;
         assert!(matches!(result, Err(BackendError::NotFound(_))));
     }
@@ -952,7 +972,7 @@ mod tests {
         let claim = backend
             .claim_task(
                 "workflow-1",
-                "task-1",
+                &sayiir_core::TaskId::from("task-1"),
                 "worker-1",
                 Some(Duration::seconds(10)),
             )
@@ -963,13 +983,18 @@ mod tests {
 
         // Extend it
         backend
-            .extend_task_claim("workflow-1", "task-1", "worker-1", Duration::seconds(300))
+            .extend_task_claim(
+                "workflow-1",
+                &sayiir_core::TaskId::from("task-1"),
+                "worker-1",
+                Duration::seconds(300),
+            )
             .await
             .unwrap();
 
         // Verify extension by checking internal state
         let claims = backend.claims.read().unwrap();
-        let key = InMemoryBackend::claim_key("workflow-1", "task-1");
+        let key = InMemoryBackend::claim_key("workflow-1", &sayiir_core::TaskId::from("task-1"));
         let extended_claim = claims.get(&key).unwrap();
         assert!(extended_claim.expires_at.unwrap() > original_expiry);
     }
@@ -982,7 +1007,7 @@ mod tests {
         backend
             .claim_task(
                 "workflow-1",
-                "task-1",
+                &sayiir_core::TaskId::from("task-1"),
                 "worker-1",
                 Some(Duration::seconds(300)),
             )
@@ -991,7 +1016,12 @@ mod tests {
 
         // Try to extend as worker-2
         let result = backend
-            .extend_task_claim("workflow-1", "task-1", "worker-2", Duration::seconds(300))
+            .extend_task_claim(
+                "workflow-1",
+                &sayiir_core::TaskId::from("task-1"),
+                "worker-2",
+                Duration::seconds(300),
+            )
             .await;
         assert!(matches!(result, Err(BackendError::Backend(_))));
     }
@@ -1001,7 +1031,12 @@ mod tests {
         let backend = InMemoryBackend::new();
 
         let result = backend
-            .extend_task_claim("workflow-1", "task-1", "worker-1", Duration::seconds(300))
+            .extend_task_claim(
+                "workflow-1",
+                &sayiir_core::TaskId::from("task-1"),
+                "worker-1",
+                Duration::seconds(300),
+            )
             .await;
         assert!(matches!(result, Err(BackendError::NotFound(_))));
     }
@@ -1012,18 +1047,28 @@ mod tests {
 
         // Claim a task with no TTL
         backend
-            .claim_task("workflow-1", "task-1", "worker-1", None)
+            .claim_task(
+                "workflow-1",
+                &sayiir_core::TaskId::from("task-1"),
+                "worker-1",
+                None,
+            )
             .await
             .unwrap();
 
         // Extending should succeed but not change anything (expires_at stays None)
         backend
-            .extend_task_claim("workflow-1", "task-1", "worker-1", Duration::seconds(300))
+            .extend_task_claim(
+                "workflow-1",
+                &sayiir_core::TaskId::from("task-1"),
+                "worker-1",
+                Duration::seconds(300),
+            )
             .await
             .unwrap();
 
         let claims = backend.claims.read().unwrap();
-        let key = InMemoryBackend::claim_key("workflow-1", "task-1");
+        let key = InMemoryBackend::claim_key("workflow-1", &sayiir_core::TaskId::from("task-1"));
         let claim = claims.get(&key).unwrap();
         assert!(claim.expires_at.is_none());
     }
@@ -1298,7 +1343,7 @@ mod tests {
             .unwrap();
 
         let result = backend
-            .check_and_cancel("test-123", Some("task-1"))
+            .check_and_cancel("test-123", Some(sayiir_core::TaskId::from("task-1")))
             .await
             .unwrap();
         assert!(
@@ -1323,7 +1368,10 @@ mod tests {
         };
         assert_eq!(reason, &Some("Timeout".to_string()));
         assert_eq!(cancelled_by, &Some("system".to_string()));
-        assert_eq!(interrupted_at_task, &Some("task-1".to_string()));
+        assert_eq!(
+            interrupted_at_task,
+            &Some(sayiir_core::TaskId::from("task-1"))
+        );
 
         assert!(
             backend
@@ -1389,13 +1437,13 @@ mod tests {
 
         let mut snapshot1 = WorkflowSnapshot::new("workflow-1".to_string(), "hash-abc".into());
         snapshot1.update_position(ExecutionPosition::AtTask {
-            task_id: "task-1".to_string(),
+            task_id: sayiir_core::TaskId::from("task-1"),
         });
         backend.save_snapshot(&snapshot1).await.unwrap();
 
         let mut snapshot2 = WorkflowSnapshot::new("workflow-2".to_string(), "hash-abc".into());
         snapshot2.update_position(ExecutionPosition::AtTask {
-            task_id: "task-2".to_string(),
+            task_id: sayiir_core::TaskId::from("task-2"),
         });
         backend.save_snapshot(&snapshot2).await.unwrap();
 
@@ -1519,10 +1567,16 @@ mod tests {
         let backend = InMemoryBackend::new();
         let mut snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".into());
         snapshot.update_position(ExecutionPosition::AtTask {
-            task_id: "task-3".to_string(),
+            task_id: sayiir_core::TaskId::from("task-3"),
         });
-        snapshot.mark_task_completed("task-1".to_string(), bytes::Bytes::from("out1"));
-        snapshot.mark_task_completed("task-2".to_string(), bytes::Bytes::from("out2"));
+        snapshot.mark_task_completed(
+            sayiir_core::TaskId::from("task-1"),
+            bytes::Bytes::from("out1"),
+        );
+        snapshot.mark_task_completed(
+            sayiir_core::TaskId::from("task-2"),
+            bytes::Bytes::from("out2"),
+        );
         backend.save_snapshot(&snapshot).await.unwrap();
 
         backend
@@ -1548,13 +1602,16 @@ mod tests {
         };
 
         assert_eq!(completed_tasks.len(), 2);
-        assert!(completed_tasks.contains_key("task-1"));
-        assert!(completed_tasks.contains_key("task-2"));
+        assert!(completed_tasks.contains_key(&sayiir_core::TaskId::from("task-1")));
+        assert!(completed_tasks.contains_key(&sayiir_core::TaskId::from("task-2")));
         assert!(matches!(
             position,
-            ExecutionPosition::AtTask { task_id } if task_id == "task-3"
+            ExecutionPosition::AtTask { task_id } if *task_id == sayiir_core::TaskId::from("task-3")
         ));
-        assert_eq!(last_completed_task_id, &Some("task-2".to_string()));
+        assert_eq!(
+            last_completed_task_id,
+            &Some(sayiir_core::TaskId::from("task-2"))
+        );
     }
 
     // ========================================================================
@@ -1566,9 +1623,12 @@ mod tests {
         let backend = InMemoryBackend::new();
         let mut snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".into());
         snapshot.update_position(ExecutionPosition::AtTask {
-            task_id: "task-2".to_string(),
+            task_id: sayiir_core::TaskId::from("task-2"),
         });
-        snapshot.mark_task_completed("task-1".to_string(), bytes::Bytes::from("out1"));
+        snapshot.mark_task_completed(
+            sayiir_core::TaskId::from("task-1"),
+            bytes::Bytes::from("out1"),
+        );
         snapshot.mark_paused(&PauseRequest::new(
             Some("maintenance".to_string()),
             Some("ops".to_string()),
@@ -1593,10 +1653,13 @@ mod tests {
         };
         assert!(matches!(
             position,
-            ExecutionPosition::AtTask { task_id } if task_id == "task-2"
+            ExecutionPosition::AtTask { task_id } if *task_id == sayiir_core::TaskId::from("task-2")
         ));
-        assert!(completed_tasks.contains_key("task-1"));
-        assert_eq!(last_completed_task_id, &Some("task-1".to_string()));
+        assert!(completed_tasks.contains_key(&sayiir_core::TaskId::from("task-1")));
+        assert_eq!(
+            last_completed_task_id,
+            &Some(sayiir_core::TaskId::from("task-1"))
+        );
 
         // Verify persisted state matches
         let loaded = backend.load_snapshot("test-123").await.unwrap();
@@ -1667,7 +1730,7 @@ mod tests {
 
         // check_and_cancel should process the cancel signal
         let cancelled = backend
-            .check_and_cancel("test-123", Some("task-1"))
+            .check_and_cancel("test-123", Some(sayiir_core::TaskId::from("task-1")))
             .await
             .unwrap();
         assert!(cancelled, "cancel should succeed");
@@ -1744,7 +1807,7 @@ mod tests {
             bytes::Bytes::from(vec![1]),
         );
         snapshot1.update_position(ExecutionPosition::AtTask {
-            task_id: "task-1".to_string(),
+            task_id: sayiir_core::TaskId::from("task-1"),
         });
         backend.save_snapshot(&snapshot1).await.unwrap();
 
@@ -1754,7 +1817,7 @@ mod tests {
             bytes::Bytes::from(vec![2]),
         );
         snapshot2.update_position(ExecutionPosition::AtTask {
-            task_id: "task-2".to_string(),
+            task_id: sayiir_core::TaskId::from("task-2"),
         });
         backend.save_snapshot(&snapshot2).await.unwrap();
 
@@ -1867,12 +1930,15 @@ mod tests {
         // Park at a delay that expires in the future
         let wake_at = Utc::now() + chrono::Duration::hours(1);
         snapshot.update_position(ExecutionPosition::AtDelay {
-            delay_id: "wait_1h".to_string(),
+            delay_id: sayiir_core::TaskId::from("wait_1h"),
             entered_at: Utc::now(),
             wake_at,
-            next_task_id: Some("next_step".to_string()),
+            next_task_id: Some(sayiir_core::TaskId::from("next_step")),
         });
-        snapshot.mark_task_completed("wait_1h".to_string(), bytes::Bytes::from(vec![42]));
+        snapshot.mark_task_completed(
+            sayiir_core::TaskId::from("wait_1h"),
+            bytes::Bytes::from(vec![42]),
+        );
         backend.save_snapshot(&snapshot).await.unwrap();
 
         let tasks = backend
@@ -1897,12 +1963,15 @@ mod tests {
         // Park at a delay that has already expired
         let wake_at = Utc::now() - chrono::Duration::seconds(1);
         snapshot.update_position(ExecutionPosition::AtDelay {
-            delay_id: "wait_done".to_string(),
+            delay_id: sayiir_core::TaskId::from("wait_done"),
             entered_at: Utc::now() - chrono::Duration::seconds(2),
             wake_at,
-            next_task_id: Some("process".to_string()),
+            next_task_id: Some(sayiir_core::TaskId::from("process")),
         });
-        snapshot.mark_task_completed("wait_done".to_string(), bytes::Bytes::from(vec![42]));
+        snapshot.mark_task_completed(
+            sayiir_core::TaskId::from("wait_done"),
+            bytes::Bytes::from(vec![42]),
+        );
         backend.save_snapshot(&snapshot).await.unwrap();
 
         let tasks = backend
@@ -1913,7 +1982,7 @@ mod tests {
         // The delay has expired, so the position should have been advanced to "process"
         assert_eq!(tasks.len(), 1);
         assert_eq!(tasks[0].instance_id, "workflow-1");
-        assert_eq!(tasks[0].task_id, "process");
+        assert_eq!(tasks[0].task_id, sayiir_core::TaskId::from("process"));
 
         // Verify position was advanced in the snapshot
         let loaded = backend.load_snapshot("workflow-1").await.unwrap();
@@ -1922,7 +1991,7 @@ mod tests {
                 position: ExecutionPosition::AtTask { task_id },
                 ..
             } => {
-                assert_eq!(task_id, "process");
+                assert_eq!(*task_id, sayiir_core::TaskId::from("process"));
             }
             other => panic!("Expected AtTask position, got {other:?}"),
         }
@@ -1940,12 +2009,15 @@ mod tests {
         // Park at a delay that has expired AND has no next task (delay is last node)
         let wake_at = Utc::now() - chrono::Duration::seconds(1);
         snapshot.update_position(ExecutionPosition::AtDelay {
-            delay_id: "final_wait".to_string(),
+            delay_id: sayiir_core::TaskId::from("final_wait"),
             entered_at: Utc::now() - chrono::Duration::seconds(2),
             wake_at,
             next_task_id: None,
         });
-        snapshot.mark_task_completed("final_wait".to_string(), bytes::Bytes::from(vec![42]));
+        snapshot.mark_task_completed(
+            sayiir_core::TaskId::from("final_wait"),
+            bytes::Bytes::from(vec![42]),
+        );
         backend.save_snapshot(&snapshot).await.unwrap();
 
         let tasks = backend
@@ -1981,7 +2053,7 @@ mod tests {
                 WorkflowSnapshot::with_initial_input(id.to_string(), "hash".into(), input.clone());
             snapshot.task_priority = Some(priority);
             snapshot.update_position(ExecutionPosition::AtTask {
-                task_id: "task-a".to_string(),
+                task_id: sayiir_core::TaskId::from("task-a"),
             });
             backend.save_snapshot(&snapshot).await.unwrap();
         }
@@ -2010,7 +2082,7 @@ mod tests {
         );
         high.task_priority = Some(1);
         high.update_position(ExecutionPosition::AtTask {
-            task_id: "task-a".to_string(),
+            task_id: sayiir_core::TaskId::from("task-a"),
         });
         // updated_at stays at "now"
         backend.save_snapshot(&high).await.unwrap();
@@ -2023,7 +2095,7 @@ mod tests {
         );
         low.task_priority = Some(5);
         low.update_position(ExecutionPosition::AtTask {
-            task_id: "task-a".to_string(),
+            task_id: sayiir_core::TaskId::from("task-a"),
         });
         // Simulate long wait: push updated_at 10 minutes into the past.
         low.updated_at = (chrono::Utc::now().timestamp() - 600) as u64;
@@ -2056,7 +2128,7 @@ mod tests {
             WorkflowSnapshot::with_initial_input("wf-1".to_string(), "hash".into(), input);
         snapshot.task_priority = Some(3);
         snapshot.update_position(ExecutionPosition::AtTask {
-            task_id: "task-a".to_string(),
+            task_id: sayiir_core::TaskId::from("task-a"),
         });
         backend.save_snapshot(&snapshot).await.unwrap();
 
@@ -2082,7 +2154,7 @@ mod tests {
             bytes::Bytes::from("1"),
         );
         snap1.update_position(ExecutionPosition::AtTask {
-            task_id: "t1".into(),
+            task_id: sayiir_core::TaskId::from("t1"),
         });
         snap1.task_tags = vec!["gpu".into()];
         backend.save_snapshot(&snap1).await.unwrap();
@@ -2094,7 +2166,7 @@ mod tests {
             bytes::Bytes::from("2"),
         );
         snap2.update_position(ExecutionPosition::AtTask {
-            task_id: "t2".into(),
+            task_id: sayiir_core::TaskId::from("t2"),
         });
         snap2.task_tags = vec!["cpu".into()];
         backend.save_snapshot(&snap2).await.unwrap();
@@ -2118,7 +2190,7 @@ mod tests {
             bytes::Bytes::from("1"),
         );
         snap1.update_position(ExecutionPosition::AtTask {
-            task_id: "t1".into(),
+            task_id: sayiir_core::TaskId::from("t1"),
         });
         snap1.task_tags = vec!["gpu".into()];
         backend.save_snapshot(&snap1).await.unwrap();
@@ -2129,7 +2201,7 @@ mod tests {
             bytes::Bytes::from("2"),
         );
         snap2.update_position(ExecutionPosition::AtTask {
-            task_id: "t2".into(),
+            task_id: sayiir_core::TaskId::from("t2"),
         });
         backend.save_snapshot(&snap2).await.unwrap();
 
@@ -2152,7 +2224,7 @@ mod tests {
             bytes::Bytes::from("1"),
         );
         snap.update_position(ExecutionPosition::AtTask {
-            task_id: "t1".into(),
+            task_id: sayiir_core::TaskId::from("t1"),
         });
         backend.save_snapshot(&snap).await.unwrap();
 
@@ -2227,10 +2299,16 @@ mod tests {
     async fn test_load_task_result_in_progress() {
         let backend = InMemoryBackend::new();
         let mut snapshot = WorkflowSnapshot::new("wf-1".into(), "hash".into());
-        snapshot.mark_task_completed("task-1".into(), bytes::Bytes::from("out1"));
+        snapshot.mark_task_completed(
+            sayiir_core::TaskId::from("task-1"),
+            bytes::Bytes::from("out1"),
+        );
         backend.save_snapshot(&snapshot).await.unwrap();
 
-        let result = backend.load_task_result("wf-1", "task-1").await.unwrap();
+        let result = backend
+            .load_task_result("wf-1", &sayiir_core::TaskId::from("task-1"))
+            .await
+            .unwrap();
         assert_eq!(result, Some(bytes::Bytes::from("out1")));
     }
 
@@ -2241,7 +2319,7 @@ mod tests {
         backend.save_snapshot(&snapshot).await.unwrap();
 
         let result = backend
-            .load_task_result("wf-1", "no-such-task")
+            .load_task_result("wf-1", &sayiir_core::TaskId::from("no-such-task"))
             .await
             .unwrap();
         assert!(result.is_none());
@@ -2250,7 +2328,9 @@ mod tests {
     #[tokio::test]
     async fn test_load_task_result_nonexistent_instance() {
         let backend = InMemoryBackend::new();
-        let result = backend.load_task_result("no-such-wf", "task-1").await;
+        let result = backend
+            .load_task_result("no-such-wf", &sayiir_core::TaskId::from("task-1"))
+            .await;
         assert!(matches!(result, Err(BackendError::NotFound(_))));
     }
 
@@ -2260,7 +2340,10 @@ mod tests {
 
         // Create workflow with a completed task
         let mut snapshot = WorkflowSnapshot::new("wf-1".into(), "hash".into());
-        snapshot.mark_task_completed("task-1".into(), bytes::Bytes::from("out1"));
+        snapshot.mark_task_completed(
+            sayiir_core::TaskId::from("task-1"),
+            bytes::Bytes::from("out1"),
+        );
         backend.save_snapshot(&snapshot).await.unwrap();
 
         // Complete the workflow — save_snapshot caches the task results
@@ -2268,7 +2351,10 @@ mod tests {
         backend.save_snapshot(&snapshot).await.unwrap();
 
         // Task result should still be accessible from cache
-        let result = backend.load_task_result("wf-1", "task-1").await.unwrap();
+        let result = backend
+            .load_task_result("wf-1", &sayiir_core::TaskId::from("task-1"))
+            .await
+            .unwrap();
         assert_eq!(result, Some(bytes::Bytes::from("out1")));
     }
 
@@ -2277,13 +2363,19 @@ mod tests {
         let backend = InMemoryBackend::new();
 
         let mut snapshot = WorkflowSnapshot::new("wf-1".into(), "hash".into());
-        snapshot.mark_task_completed("task-1".into(), bytes::Bytes::from("out1"));
+        snapshot.mark_task_completed(
+            sayiir_core::TaskId::from("task-1"),
+            bytes::Bytes::from("out1"),
+        );
         backend.save_snapshot(&snapshot).await.unwrap();
 
         snapshot.mark_failed("boom".into());
         backend.save_snapshot(&snapshot).await.unwrap();
 
-        let result = backend.load_task_result("wf-1", "task-1").await.unwrap();
+        let result = backend
+            .load_task_result("wf-1", &sayiir_core::TaskId::from("task-1"))
+            .await
+            .unwrap();
         assert_eq!(result, Some(bytes::Bytes::from("out1")));
     }
 
@@ -2292,7 +2384,10 @@ mod tests {
         let backend = InMemoryBackend::new();
 
         let mut snapshot = WorkflowSnapshot::new("wf-1".into(), "hash".into());
-        snapshot.mark_task_completed("task-1".into(), bytes::Bytes::from("out1"));
+        snapshot.mark_task_completed(
+            sayiir_core::TaskId::from("task-1"),
+            bytes::Bytes::from("out1"),
+        );
         backend.save_snapshot(&snapshot).await.unwrap();
 
         snapshot.mark_completed(bytes::Bytes::from("final"));
@@ -2301,7 +2396,9 @@ mod tests {
         // Delete should clean both snapshot and cache
         backend.delete_snapshot("wf-1").await.unwrap();
 
-        let result = backend.load_task_result("wf-1", "task-1").await;
+        let result = backend
+            .load_task_result("wf-1", &sayiir_core::TaskId::from("task-1"))
+            .await;
         assert!(matches!(result, Err(BackendError::NotFound(_))));
     }
 }

--- a/sayiir-persistence/src/in_memory.rs
+++ b/sayiir-persistence/src/in_memory.rs
@@ -13,6 +13,13 @@ use sayiir_core::task_claim::{AvailableTask, TaskClaim};
 use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, RwLock};
 
+/// Signal requests indexed by workflow instance.
+type SignalsByInstance = HashMap<Arc<str>, HashMap<SignalKind, SignalRequest>>;
+/// FIFO event queues indexed by `(instance_id, signal_name)`.
+type EventsBySignal = HashMap<(Arc<str>, String), VecDeque<bytes::Bytes>>;
+/// Cached task results for terminal workflows, indexed by instance.
+type TaskResultsByInstance = HashMap<Arc<str>, HashMap<sayiir_core::TaskId, TaskResult>>;
+
 /// In-memory backend that stores snapshots in a HashMap.
 ///
 /// This implementation is thread-safe and suitable for testing.
@@ -20,15 +27,14 @@ use std::sync::{Arc, RwLock};
 /// a more durable storage backend (Redis, PostgreSQL, etc.).
 #[derive(Clone, Default)]
 pub struct InMemoryBackend {
-    snapshots: Arc<RwLock<HashMap<String, WorkflowSnapshot>>>,
+    snapshots: Arc<RwLock<HashMap<Arc<str>, WorkflowSnapshot>>>,
     claims: Arc<RwLock<HashMap<String, TaskClaim>>>, // Key: "{instance_id}:{task_id}"
-    signals: Arc<RwLock<HashMap<String, HashMap<SignalKind, SignalRequest>>>>,
+    signals: Arc<RwLock<SignalsByInstance>>,
     /// Buffered external events per `(instance_id, signal_name)`, FIFO order.
-    #[allow(clippy::type_complexity)]
-    events: Arc<RwLock<HashMap<(String, String), VecDeque<bytes::Bytes>>>>,
+    events: Arc<RwLock<EventsBySignal>>,
     /// Cached task results for workflows that have transitioned to terminal states
     /// (Completed/Failed), where `completed_tasks` is no longer in the snapshot.
-    task_results_cache: Arc<RwLock<HashMap<String, HashMap<sayiir_core::TaskId, TaskResult>>>>,
+    task_results_cache: Arc<RwLock<TaskResultsByInstance>>,
 }
 
 impl InMemoryBackend {
@@ -109,7 +115,7 @@ impl SnapshotStore for InMemoryBackend {
 
     async fn list_snapshots(&self) -> Result<Vec<String>, BackendError> {
         let snapshots = self.snapshots.read().map_err(Self::lock_error)?;
-        Ok(snapshots.keys().cloned().collect())
+        Ok(snapshots.keys().map(|k| k.to_string()).collect())
     }
 }
 
@@ -194,7 +200,7 @@ impl SignalStore for InMemoryBackend {
 
         let mut signals = self.signals.write().map_err(Self::lock_error)?;
         signals
-            .entry(instance_id.to_string())
+            .entry(Arc::from(instance_id))
             .or_default()
             .insert(kind, request);
         Ok(())
@@ -228,7 +234,7 @@ impl SignalStore for InMemoryBackend {
     ) -> Result<(), BackendError> {
         let mut events = self.events.write().map_err(Self::lock_error)?;
         events
-            .entry((instance_id.to_string(), signal_name.to_string()))
+            .entry((Arc::from(instance_id), signal_name.to_string()))
             .or_default()
             .push_back(payload);
         Ok(())
@@ -240,7 +246,7 @@ impl SignalStore for InMemoryBackend {
         signal_name: &str,
     ) -> Result<Option<bytes::Bytes>, BackendError> {
         let mut events = self.events.write().map_err(Self::lock_error)?;
-        let key = (instance_id.to_string(), signal_name.to_string());
+        let key = (Arc::<str>::from(instance_id), signal_name.to_string());
         let payload = events.get_mut(&key).and_then(VecDeque::pop_front);
         // Clean up empty queues
         if events.get(&key).is_some_and(VecDeque::is_empty) {
@@ -383,12 +389,7 @@ impl TaskClaimStore for InMemoryBackend {
         }
 
         // Create new claim
-        let claim = TaskClaim::new(
-            instance_id.to_string(),
-            *task_id,
-            worker_id.to_string(),
-            ttl,
-        );
+        let claim = TaskClaim::new(instance_id, *task_id, worker_id.to_string(), ttl);
         claims.insert(key, claim.clone());
         Ok(Some(claim))
     }
@@ -468,12 +469,12 @@ impl TaskClaimStore for InMemoryBackend {
         }
 
         // Collect delay-expired workflows that need position advancement
-        let mut delay_advances: Vec<(String, sayiir_core::TaskId)> = Vec::new();
-        let mut delay_completions: Vec<(String, sayiir_core::TaskId)> = Vec::new();
+        let mut delay_advances: Vec<(Arc<str>, sayiir_core::TaskId)> = Vec::new();
+        let mut delay_completions: Vec<(Arc<str>, sayiir_core::TaskId)> = Vec::new();
         // Signal-related advancements: (instance_id, signal_name, next_task_id_or_none)
-        let mut signal_advances: Vec<(String, String, Option<sayiir_core::TaskId>)> = Vec::new();
+        let mut signal_advances: Vec<(Arc<str>, String, Option<sayiir_core::TaskId>)> = Vec::new();
         // Signal timeout expirations: (instance_id, signal_id, next_task_id_or_none)
-        let mut signal_timeout_advances: Vec<(String, String, Option<sayiir_core::TaskId>)> =
+        let mut signal_timeout_advances: Vec<(Arc<str>, String, Option<sayiir_core::TaskId>)> =
             Vec::new();
 
         {
@@ -486,13 +487,13 @@ impl TaskClaimStore for InMemoryBackend {
                     continue;
                 }
                 if signals
-                    .get(instance_id.as_str())
+                    .get(&**instance_id)
                     .is_some_and(|m| m.contains_key(&SignalKind::Cancel))
                 {
                     continue;
                 }
                 if signals
-                    .get(instance_id.as_str())
+                    .get(&**instance_id)
                     .is_some_and(|m| m.contains_key(&SignalKind::Pause))
                 {
                     continue;
@@ -627,7 +628,7 @@ impl TaskClaimStore for InMemoryBackend {
             }
 
             // Skip workflows with pending cancellation or pause requests
-            if let Some(instance_signals) = signals.get(instance_id.as_str())
+            if let Some(instance_signals) = signals.get(&**instance_id)
                 && (instance_signals.contains_key(&SignalKind::Cancel)
                     || instance_signals.contains_key(&SignalKind::Pause))
             {
@@ -729,7 +730,7 @@ mod tests {
     #[tokio::test]
     async fn test_save_and_load() {
         let backend = InMemoryBackend::new();
-        let snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".into());
+        let snapshot = WorkflowSnapshot::new("test-123", "hash-abc".into());
 
         backend.save_snapshot(&snapshot).await.unwrap();
         let loaded = backend.load_snapshot("test-123").await.unwrap();
@@ -748,7 +749,7 @@ mod tests {
     #[tokio::test]
     async fn test_delete() {
         let backend = InMemoryBackend::new();
-        let snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".into());
+        let snapshot = WorkflowSnapshot::new("test-123", "hash-abc".into());
 
         backend.save_snapshot(&snapshot).await.unwrap();
         backend.delete_snapshot("test-123").await.unwrap();
@@ -762,17 +763,11 @@ mod tests {
         let backend = InMemoryBackend::new();
 
         backend
-            .save_snapshot(&WorkflowSnapshot::new(
-                "test-1".to_string(),
-                "hash-1".into(),
-            ))
+            .save_snapshot(&WorkflowSnapshot::new("test-1", "hash-1".into()))
             .await
             .unwrap();
         backend
-            .save_snapshot(&WorkflowSnapshot::new(
-                "test-2".to_string(),
-                "hash-2".into(),
-            ))
+            .save_snapshot(&WorkflowSnapshot::new("test-2", "hash-2".into()))
             .await
             .unwrap();
 
@@ -800,7 +795,7 @@ mod tests {
 
         assert!(claim.is_some());
         let claim = claim.unwrap();
-        assert_eq!(claim.instance_id, "workflow-1");
+        assert_eq!(&*claim.instance_id, "workflow-1");
         assert_eq!(claim.task_id, sayiir_core::TaskId::from("task-1"));
         assert_eq!(claim.worker_id, "worker-1");
         assert!(claim.expires_at.is_some());
@@ -1076,7 +1071,7 @@ mod tests {
     #[tokio::test]
     async fn test_store_signal_cancel_success() {
         let backend = InMemoryBackend::new();
-        let snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".into());
+        let snapshot = WorkflowSnapshot::new("test-123", "hash-abc".into());
         backend.save_snapshot(&snapshot).await.unwrap();
 
         let result = backend
@@ -1121,7 +1116,7 @@ mod tests {
     #[tokio::test]
     async fn test_store_signal_cancel_completed_workflow() {
         let backend = InMemoryBackend::new();
-        let mut snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".into());
+        let mut snapshot = WorkflowSnapshot::new("test-123", "hash-abc".into());
         snapshot.mark_completed(bytes::Bytes::from("result"));
         backend.save_snapshot(&snapshot).await.unwrap();
 
@@ -1141,7 +1136,7 @@ mod tests {
     #[tokio::test]
     async fn test_store_signal_cancel_failed_workflow() {
         let backend = InMemoryBackend::new();
-        let mut snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".into());
+        let mut snapshot = WorkflowSnapshot::new("test-123", "hash-abc".into());
         snapshot.mark_failed("Some error".to_string());
         backend.save_snapshot(&snapshot).await.unwrap();
 
@@ -1161,7 +1156,7 @@ mod tests {
     #[tokio::test]
     async fn test_store_signal_cancel_already_cancelled_idempotent() {
         let backend = InMemoryBackend::new();
-        let mut snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".into());
+        let mut snapshot = WorkflowSnapshot::new("test-123", "hash-abc".into());
         snapshot.mark_cancelled(Some("First cancel".to_string()), None, None);
         backend.save_snapshot(&snapshot).await.unwrap();
 
@@ -1195,7 +1190,7 @@ mod tests {
     #[tokio::test]
     async fn test_clear_signal_cancel() {
         let backend = InMemoryBackend::new();
-        let snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".into());
+        let snapshot = WorkflowSnapshot::new("test-123", "hash-abc".into());
         backend.save_snapshot(&snapshot).await.unwrap();
 
         backend
@@ -1234,7 +1229,7 @@ mod tests {
     #[tokio::test]
     async fn test_store_signal_pause_completed_workflow() {
         let backend = InMemoryBackend::new();
-        let mut snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".into());
+        let mut snapshot = WorkflowSnapshot::new("test-123", "hash-abc".into());
         snapshot.mark_completed(bytes::Bytes::from("result"));
         backend.save_snapshot(&snapshot).await.unwrap();
 
@@ -1254,7 +1249,7 @@ mod tests {
     #[tokio::test]
     async fn test_store_signal_pause_failed_workflow() {
         let backend = InMemoryBackend::new();
-        let mut snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".into());
+        let mut snapshot = WorkflowSnapshot::new("test-123", "hash-abc".into());
         snapshot.mark_failed("Some error".to_string());
         backend.save_snapshot(&snapshot).await.unwrap();
 
@@ -1274,7 +1269,7 @@ mod tests {
     #[tokio::test]
     async fn test_store_signal_pause_cancelled_workflow() {
         let backend = InMemoryBackend::new();
-        let mut snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".into());
+        let mut snapshot = WorkflowSnapshot::new("test-123", "hash-abc".into());
         snapshot.mark_cancelled(Some("done".to_string()), None, None);
         backend.save_snapshot(&snapshot).await.unwrap();
 
@@ -1294,7 +1289,7 @@ mod tests {
     #[tokio::test]
     async fn test_store_signal_pause_already_paused_idempotent() {
         let backend = InMemoryBackend::new();
-        let mut snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".into());
+        let mut snapshot = WorkflowSnapshot::new("test-123", "hash-abc".into());
         snapshot.mark_paused(&PauseRequest::new(Some("first".to_string()), None));
         backend.save_snapshot(&snapshot).await.unwrap();
 
@@ -1330,7 +1325,7 @@ mod tests {
     #[tokio::test]
     async fn test_check_and_cancel_success() {
         let backend = InMemoryBackend::new();
-        let snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".into());
+        let snapshot = WorkflowSnapshot::new("test-123", "hash-abc".into());
         backend.save_snapshot(&snapshot).await.unwrap();
 
         backend
@@ -1386,7 +1381,7 @@ mod tests {
     #[tokio::test]
     async fn test_check_and_cancel_no_request() {
         let backend = InMemoryBackend::new();
-        let snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".into());
+        let snapshot = WorkflowSnapshot::new("test-123", "hash-abc".into());
         backend.save_snapshot(&snapshot).await.unwrap();
 
         let result = backend.check_and_cancel("test-123", None).await.unwrap();
@@ -1405,7 +1400,7 @@ mod tests {
     #[tokio::test]
     async fn test_check_and_cancel_not_in_progress() {
         let backend = InMemoryBackend::new();
-        let mut snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".into());
+        let mut snapshot = WorkflowSnapshot::new("test-123", "hash-abc".into());
         snapshot.mark_completed(bytes::Bytes::from("done"));
         backend.save_snapshot(&snapshot).await.unwrap();
 
@@ -1413,7 +1408,7 @@ mod tests {
         {
             let mut signals = backend.signals.write().unwrap();
             signals
-                .entry("test-123".to_string())
+                .entry(Arc::from("test-123"))
                 .or_default()
                 .insert(SignalKind::Cancel, SignalRequest::new(None, None));
         }
@@ -1435,13 +1430,13 @@ mod tests {
     async fn test_find_available_tasks_skips_cancelled_workflows() {
         let backend = InMemoryBackend::new();
 
-        let mut snapshot1 = WorkflowSnapshot::new("workflow-1".to_string(), "hash-abc".into());
+        let mut snapshot1 = WorkflowSnapshot::new("workflow-1", "hash-abc".into());
         snapshot1.update_position(ExecutionPosition::AtTask {
             task_id: sayiir_core::TaskId::from("task-1"),
         });
         backend.save_snapshot(&snapshot1).await.unwrap();
 
-        let mut snapshot2 = WorkflowSnapshot::new("workflow-2".to_string(), "hash-abc".into());
+        let mut snapshot2 = WorkflowSnapshot::new("workflow-2", "hash-abc".into());
         snapshot2.update_position(ExecutionPosition::AtTask {
             task_id: sayiir_core::TaskId::from("task-2"),
         });
@@ -1462,7 +1457,7 @@ mod tests {
             .unwrap();
 
         assert!(
-            !tasks.iter().any(|t| t.instance_id == "workflow-1"),
+            !tasks.iter().any(|t| &*t.instance_id == "workflow-1"),
             "workflow with pending cancellation should be skipped"
         );
     }
@@ -1474,7 +1469,7 @@ mod tests {
     #[tokio::test]
     async fn test_check_and_pause_success() {
         let backend = InMemoryBackend::new();
-        let snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".into());
+        let snapshot = WorkflowSnapshot::new("test-123", "hash-abc".into());
         backend.save_snapshot(&snapshot).await.unwrap();
 
         backend
@@ -1517,7 +1512,7 @@ mod tests {
     #[tokio::test]
     async fn test_check_and_pause_no_request() {
         let backend = InMemoryBackend::new();
-        let snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".into());
+        let snapshot = WorkflowSnapshot::new("test-123", "hash-abc".into());
         backend.save_snapshot(&snapshot).await.unwrap();
 
         let result = backend.check_and_pause("test-123").await.unwrap();
@@ -1536,7 +1531,7 @@ mod tests {
     #[tokio::test]
     async fn test_check_and_pause_not_in_progress() {
         let backend = InMemoryBackend::new();
-        let mut snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".into());
+        let mut snapshot = WorkflowSnapshot::new("test-123", "hash-abc".into());
         snapshot.mark_completed(bytes::Bytes::from("done"));
         backend.save_snapshot(&snapshot).await.unwrap();
 
@@ -1544,7 +1539,7 @@ mod tests {
         {
             let mut signals = backend.signals.write().unwrap();
             signals
-                .entry("test-123".to_string())
+                .entry(Arc::from("test-123"))
                 .or_default()
                 .insert(SignalKind::Pause, SignalRequest::new(None, None));
         }
@@ -1565,7 +1560,7 @@ mod tests {
     #[tokio::test]
     async fn test_check_and_pause_preserves_position() {
         let backend = InMemoryBackend::new();
-        let mut snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".into());
+        let mut snapshot = WorkflowSnapshot::new("test-123", "hash-abc".into());
         snapshot.update_position(ExecutionPosition::AtTask {
             task_id: sayiir_core::TaskId::from("task-3"),
         });
@@ -1621,7 +1616,7 @@ mod tests {
     #[tokio::test]
     async fn test_unpause_success() {
         let backend = InMemoryBackend::new();
-        let mut snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".into());
+        let mut snapshot = WorkflowSnapshot::new("test-123", "hash-abc".into());
         snapshot.update_position(ExecutionPosition::AtTask {
             task_id: sayiir_core::TaskId::from("task-2"),
         });
@@ -1669,7 +1664,7 @@ mod tests {
     #[tokio::test]
     async fn test_unpause_not_paused_errors() {
         let backend = InMemoryBackend::new();
-        let snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".into());
+        let snapshot = WorkflowSnapshot::new("test-123", "hash-abc".into());
         backend.save_snapshot(&snapshot).await.unwrap();
 
         let result = backend.unpause("test-123").await;
@@ -1682,7 +1677,7 @@ mod tests {
     #[tokio::test]
     async fn test_unpause_completed_errors() {
         let backend = InMemoryBackend::new();
-        let mut snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".into());
+        let mut snapshot = WorkflowSnapshot::new("test-123", "hash-abc".into());
         snapshot.mark_completed(bytes::Bytes::from("done"));
         backend.save_snapshot(&snapshot).await.unwrap();
 
@@ -1707,7 +1702,7 @@ mod tests {
     #[tokio::test]
     async fn test_cancel_and_pause_simultaneously_cancel_wins() {
         let backend = InMemoryBackend::new();
-        let snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".into());
+        let snapshot = WorkflowSnapshot::new("test-123", "hash-abc".into());
         backend.save_snapshot(&snapshot).await.unwrap();
 
         // Store both signals
@@ -1749,7 +1744,7 @@ mod tests {
     #[tokio::test]
     async fn test_cancel_signal_independent_of_pause_signal() {
         let backend = InMemoryBackend::new();
-        let snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".into());
+        let snapshot = WorkflowSnapshot::new("test-123", "hash-abc".into());
         backend.save_snapshot(&snapshot).await.unwrap();
 
         // Store both signals
@@ -1802,7 +1797,7 @@ mod tests {
         let backend = InMemoryBackend::new();
 
         let mut snapshot1 = WorkflowSnapshot::with_initial_input(
-            "workflow-1".to_string(),
+            "workflow-1",
             "hash-abc".into(),
             bytes::Bytes::from(vec![1]),
         );
@@ -1812,7 +1807,7 @@ mod tests {
         backend.save_snapshot(&snapshot1).await.unwrap();
 
         let mut snapshot2 = WorkflowSnapshot::with_initial_input(
-            "workflow-2".to_string(),
+            "workflow-2",
             "hash-abc".into(),
             bytes::Bytes::from(vec![2]),
         );
@@ -1837,11 +1832,11 @@ mod tests {
             .unwrap();
 
         assert!(
-            !tasks.iter().any(|t| t.instance_id == "workflow-1"),
+            !tasks.iter().any(|t| &*t.instance_id == "workflow-1"),
             "workflow with pending pause should be skipped"
         );
         assert!(
-            tasks.iter().any(|t| t.instance_id == "workflow-2"),
+            tasks.iter().any(|t| &*t.instance_id == "workflow-2"),
             "workflow without signals should be available"
         );
     }
@@ -1853,7 +1848,7 @@ mod tests {
     #[tokio::test]
     async fn test_delete_snapshot_leaves_orphaned_signals() {
         let backend = InMemoryBackend::new();
-        let snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".into());
+        let snapshot = WorkflowSnapshot::new("test-123", "hash-abc".into());
         backend.save_snapshot(&snapshot).await.unwrap();
 
         backend
@@ -1882,7 +1877,7 @@ mod tests {
     #[tokio::test]
     async fn test_store_signal_overwrites_previous() {
         let backend = InMemoryBackend::new();
-        let snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".into());
+        let snapshot = WorkflowSnapshot::new("test-123", "hash-abc".into());
         backend.save_snapshot(&snapshot).await.unwrap();
 
         backend
@@ -1923,7 +1918,7 @@ mod tests {
         let backend = InMemoryBackend::new();
 
         let mut snapshot = WorkflowSnapshot::with_initial_input(
-            "workflow-1".to_string(),
+            "workflow-1",
             "hash-abc".into(),
             bytes::Bytes::from(vec![42]),
         );
@@ -1956,7 +1951,7 @@ mod tests {
         let backend = InMemoryBackend::new();
 
         let mut snapshot = WorkflowSnapshot::with_initial_input(
-            "workflow-1".to_string(),
+            "workflow-1",
             "hash-abc".into(),
             bytes::Bytes::from(vec![42]),
         );
@@ -1981,7 +1976,7 @@ mod tests {
 
         // The delay has expired, so the position should have been advanced to "process"
         assert_eq!(tasks.len(), 1);
-        assert_eq!(tasks[0].instance_id, "workflow-1");
+        assert_eq!(&*tasks[0].instance_id, "workflow-1");
         assert_eq!(tasks[0].task_id, sayiir_core::TaskId::from("process"));
 
         // Verify position was advanced in the snapshot
@@ -2002,7 +1997,7 @@ mod tests {
         let backend = InMemoryBackend::new();
 
         let mut snapshot = WorkflowSnapshot::with_initial_input(
-            "workflow-1".to_string(),
+            "workflow-1",
             "hash-abc".into(),
             bytes::Bytes::from(vec![42]),
         );
@@ -2050,7 +2045,7 @@ mod tests {
         // wf-low (priority 5), wf-normal (priority 3), wf-high (priority 1)
         for (id, priority) in [("wf-low", 5u8), ("wf-normal", 3), ("wf-high", 1)] {
             let mut snapshot =
-                WorkflowSnapshot::with_initial_input(id.to_string(), "hash".into(), input.clone());
+                WorkflowSnapshot::with_initial_input(id, "hash".into(), input.clone());
             snapshot.task_priority = Some(priority);
             snapshot.update_position(ExecutionPosition::AtTask {
                 task_id: sayiir_core::TaskId::from("task-a"),
@@ -2064,9 +2059,9 @@ mod tests {
             .unwrap();
 
         assert_eq!(tasks.len(), 3);
-        assert_eq!(tasks[0].instance_id, "wf-high");
-        assert_eq!(tasks[1].instance_id, "wf-normal");
-        assert_eq!(tasks[2].instance_id, "wf-low");
+        assert_eq!(&*tasks[0].instance_id, "wf-high");
+        assert_eq!(&*tasks[1].instance_id, "wf-normal");
+        assert_eq!(&*tasks[2].instance_id, "wf-low");
     }
 
     #[tokio::test]
@@ -2075,11 +2070,8 @@ mod tests {
         let input = bytes::Bytes::from("input");
 
         // Fresh high-priority workflow (priority 1).
-        let mut high = WorkflowSnapshot::with_initial_input(
-            "wf-high".to_string(),
-            "hash".into(),
-            input.clone(),
-        );
+        let mut high =
+            WorkflowSnapshot::with_initial_input("wf-high", "hash".into(), input.clone());
         high.task_priority = Some(1);
         high.update_position(ExecutionPosition::AtTask {
             task_id: sayiir_core::TaskId::from("task-a"),
@@ -2088,11 +2080,7 @@ mod tests {
         backend.save_snapshot(&high).await.unwrap();
 
         // Low-priority workflow (priority 5) that has been waiting a long time.
-        let mut low = WorkflowSnapshot::with_initial_input(
-            "wf-low".to_string(),
-            "hash".into(),
-            input.clone(),
-        );
+        let mut low = WorkflowSnapshot::with_initial_input("wf-low", "hash".into(), input.clone());
         low.task_priority = Some(5);
         low.update_position(ExecutionPosition::AtTask {
             task_id: sayiir_core::TaskId::from("task-a"),
@@ -2113,10 +2101,10 @@ mod tests {
 
         assert_eq!(tasks.len(), 2);
         assert_eq!(
-            tasks[0].instance_id, "wf-low",
+            &*tasks[0].instance_id, "wf-low",
             "aged low-priority task should be promoted ahead of fresh high-priority task"
         );
-        assert_eq!(tasks[1].instance_id, "wf-high");
+        assert_eq!(&*tasks[1].instance_id, "wf-high");
     }
 
     #[tokio::test]
@@ -2124,8 +2112,7 @@ mod tests {
         let backend = InMemoryBackend::new();
         let input = bytes::Bytes::from("input");
 
-        let mut snapshot =
-            WorkflowSnapshot::with_initial_input("wf-1".to_string(), "hash".into(), input);
+        let mut snapshot = WorkflowSnapshot::with_initial_input("wf-1", "hash".into(), input);
         snapshot.task_priority = Some(3);
         snapshot.update_position(ExecutionPosition::AtTask {
             task_id: sayiir_core::TaskId::from("task-a"),
@@ -2148,11 +2135,8 @@ mod tests {
         let backend = InMemoryBackend::new();
 
         // Task tagged ["gpu"]
-        let mut snap1 = WorkflowSnapshot::with_initial_input(
-            "wf-gpu".into(),
-            "h1".into(),
-            bytes::Bytes::from("1"),
-        );
+        let mut snap1 =
+            WorkflowSnapshot::with_initial_input("wf-gpu", "h1".into(), bytes::Bytes::from("1"));
         snap1.update_position(ExecutionPosition::AtTask {
             task_id: sayiir_core::TaskId::from("t1"),
         });
@@ -2160,11 +2144,8 @@ mod tests {
         backend.save_snapshot(&snap1).await.unwrap();
 
         // Task tagged ["cpu"]
-        let mut snap2 = WorkflowSnapshot::with_initial_input(
-            "wf-cpu".into(),
-            "h1".into(),
-            bytes::Bytes::from("2"),
-        );
+        let mut snap2 =
+            WorkflowSnapshot::with_initial_input("wf-cpu", "h1".into(), bytes::Bytes::from("2"));
         snap2.update_position(ExecutionPosition::AtTask {
             task_id: sayiir_core::TaskId::from("t2"),
         });
@@ -2177,29 +2158,23 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(tasks.len(), 1);
-        assert_eq!(tasks[0].instance_id, "wf-gpu");
+        assert_eq!(&*tasks[0].instance_id, "wf-gpu");
     }
 
     #[tokio::test]
     async fn test_find_available_tasks_untagged_worker_accepts_all() {
         let backend = InMemoryBackend::new();
 
-        let mut snap1 = WorkflowSnapshot::with_initial_input(
-            "wf-tagged".into(),
-            "h1".into(),
-            bytes::Bytes::from("1"),
-        );
+        let mut snap1 =
+            WorkflowSnapshot::with_initial_input("wf-tagged", "h1".into(), bytes::Bytes::from("1"));
         snap1.update_position(ExecutionPosition::AtTask {
             task_id: sayiir_core::TaskId::from("t1"),
         });
         snap1.task_tags = vec!["gpu".into()];
         backend.save_snapshot(&snap1).await.unwrap();
 
-        let mut snap2 = WorkflowSnapshot::with_initial_input(
-            "wf-plain".into(),
-            "h1".into(),
-            bytes::Bytes::from("2"),
-        );
+        let mut snap2 =
+            WorkflowSnapshot::with_initial_input("wf-plain", "h1".into(), bytes::Bytes::from("2"));
         snap2.update_position(ExecutionPosition::AtTask {
             task_id: sayiir_core::TaskId::from("t2"),
         });
@@ -2218,11 +2193,8 @@ mod tests {
         let backend = InMemoryBackend::new();
 
         // Untagged task
-        let mut snap = WorkflowSnapshot::with_initial_input(
-            "wf-plain".into(),
-            "h1".into(),
-            bytes::Bytes::from("1"),
-        );
+        let mut snap =
+            WorkflowSnapshot::with_initial_input("wf-plain", "h1".into(), bytes::Bytes::from("1"));
         snap.update_position(ExecutionPosition::AtTask {
             task_id: sayiir_core::TaskId::from("t1"),
         });
@@ -2234,7 +2206,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(tasks.len(), 1);
-        assert_eq!(tasks[0].instance_id, "wf-plain");
+        assert_eq!(&*tasks[0].instance_id, "wf-plain");
     }
 
     // ── Event queue (send_event / consume_event) ────────────────────────
@@ -2298,7 +2270,7 @@ mod tests {
     #[tokio::test]
     async fn test_load_task_result_in_progress() {
         let backend = InMemoryBackend::new();
-        let mut snapshot = WorkflowSnapshot::new("wf-1".into(), "hash".into());
+        let mut snapshot = WorkflowSnapshot::new("wf-1", "hash".into());
         snapshot.mark_task_completed(
             sayiir_core::TaskId::from("task-1"),
             bytes::Bytes::from("out1"),
@@ -2315,7 +2287,7 @@ mod tests {
     #[tokio::test]
     async fn test_load_task_result_not_found() {
         let backend = InMemoryBackend::new();
-        let snapshot = WorkflowSnapshot::new("wf-1".into(), "hash".into());
+        let snapshot = WorkflowSnapshot::new("wf-1", "hash".into());
         backend.save_snapshot(&snapshot).await.unwrap();
 
         let result = backend
@@ -2339,7 +2311,7 @@ mod tests {
         let backend = InMemoryBackend::new();
 
         // Create workflow with a completed task
-        let mut snapshot = WorkflowSnapshot::new("wf-1".into(), "hash".into());
+        let mut snapshot = WorkflowSnapshot::new("wf-1", "hash".into());
         snapshot.mark_task_completed(
             sayiir_core::TaskId::from("task-1"),
             bytes::Bytes::from("out1"),
@@ -2362,7 +2334,7 @@ mod tests {
     async fn test_load_task_result_after_failure() {
         let backend = InMemoryBackend::new();
 
-        let mut snapshot = WorkflowSnapshot::new("wf-1".into(), "hash".into());
+        let mut snapshot = WorkflowSnapshot::new("wf-1", "hash".into());
         snapshot.mark_task_completed(
             sayiir_core::TaskId::from("task-1"),
             bytes::Bytes::from("out1"),
@@ -2383,7 +2355,7 @@ mod tests {
     async fn test_delete_cleans_task_results_cache() {
         let backend = InMemoryBackend::new();
 
-        let mut snapshot = WorkflowSnapshot::new("wf-1".into(), "hash".into());
+        let mut snapshot = WorkflowSnapshot::new("wf-1", "hash".into());
         snapshot.mark_task_completed(
             sayiir_core::TaskId::from("task-1"),
             bytes::Bytes::from("out1"),

--- a/sayiir-persistence/src/in_memory.rs
+++ b/sayiir-persistence/src/in_memory.rs
@@ -671,7 +671,7 @@ impl TaskClaimStore for InMemoryBackend {
                             instance_id: instance_id.clone(),
                             task_id: task_id.clone(),
                             input: input_bytes,
-                            workflow_definition_hash: snapshot.definition_hash.clone(),
+                            workflow_definition_hash: snapshot.definition_hash,
                             trace_parent: None,
                         });
 
@@ -726,7 +726,7 @@ mod tests {
     #[tokio::test]
     async fn test_save_and_load() {
         let backend = InMemoryBackend::new();
-        let snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".to_string());
+        let snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".into());
 
         backend.save_snapshot(&snapshot).await.unwrap();
         let loaded = backend.load_snapshot("test-123").await.unwrap();
@@ -745,7 +745,7 @@ mod tests {
     #[tokio::test]
     async fn test_delete() {
         let backend = InMemoryBackend::new();
-        let snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".to_string());
+        let snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".into());
 
         backend.save_snapshot(&snapshot).await.unwrap();
         backend.delete_snapshot("test-123").await.unwrap();
@@ -761,14 +761,14 @@ mod tests {
         backend
             .save_snapshot(&WorkflowSnapshot::new(
                 "test-1".to_string(),
-                "hash-1".to_string(),
+                "hash-1".into(),
             ))
             .await
             .unwrap();
         backend
             .save_snapshot(&WorkflowSnapshot::new(
                 "test-2".to_string(),
-                "hash-2".to_string(),
+                "hash-2".into(),
             ))
             .await
             .unwrap();
@@ -1031,7 +1031,7 @@ mod tests {
     #[tokio::test]
     async fn test_store_signal_cancel_success() {
         let backend = InMemoryBackend::new();
-        let snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".to_string());
+        let snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".into());
         backend.save_snapshot(&snapshot).await.unwrap();
 
         let result = backend
@@ -1076,7 +1076,7 @@ mod tests {
     #[tokio::test]
     async fn test_store_signal_cancel_completed_workflow() {
         let backend = InMemoryBackend::new();
-        let mut snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".to_string());
+        let mut snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".into());
         snapshot.mark_completed(bytes::Bytes::from("result"));
         backend.save_snapshot(&snapshot).await.unwrap();
 
@@ -1096,7 +1096,7 @@ mod tests {
     #[tokio::test]
     async fn test_store_signal_cancel_failed_workflow() {
         let backend = InMemoryBackend::new();
-        let mut snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".to_string());
+        let mut snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".into());
         snapshot.mark_failed("Some error".to_string());
         backend.save_snapshot(&snapshot).await.unwrap();
 
@@ -1116,7 +1116,7 @@ mod tests {
     #[tokio::test]
     async fn test_store_signal_cancel_already_cancelled_idempotent() {
         let backend = InMemoryBackend::new();
-        let mut snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".to_string());
+        let mut snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".into());
         snapshot.mark_cancelled(Some("First cancel".to_string()), None, None);
         backend.save_snapshot(&snapshot).await.unwrap();
 
@@ -1150,7 +1150,7 @@ mod tests {
     #[tokio::test]
     async fn test_clear_signal_cancel() {
         let backend = InMemoryBackend::new();
-        let snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".to_string());
+        let snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".into());
         backend.save_snapshot(&snapshot).await.unwrap();
 
         backend
@@ -1189,7 +1189,7 @@ mod tests {
     #[tokio::test]
     async fn test_store_signal_pause_completed_workflow() {
         let backend = InMemoryBackend::new();
-        let mut snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".to_string());
+        let mut snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".into());
         snapshot.mark_completed(bytes::Bytes::from("result"));
         backend.save_snapshot(&snapshot).await.unwrap();
 
@@ -1209,7 +1209,7 @@ mod tests {
     #[tokio::test]
     async fn test_store_signal_pause_failed_workflow() {
         let backend = InMemoryBackend::new();
-        let mut snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".to_string());
+        let mut snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".into());
         snapshot.mark_failed("Some error".to_string());
         backend.save_snapshot(&snapshot).await.unwrap();
 
@@ -1229,7 +1229,7 @@ mod tests {
     #[tokio::test]
     async fn test_store_signal_pause_cancelled_workflow() {
         let backend = InMemoryBackend::new();
-        let mut snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".to_string());
+        let mut snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".into());
         snapshot.mark_cancelled(Some("done".to_string()), None, None);
         backend.save_snapshot(&snapshot).await.unwrap();
 
@@ -1249,7 +1249,7 @@ mod tests {
     #[tokio::test]
     async fn test_store_signal_pause_already_paused_idempotent() {
         let backend = InMemoryBackend::new();
-        let mut snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".to_string());
+        let mut snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".into());
         snapshot.mark_paused(&PauseRequest::new(Some("first".to_string()), None));
         backend.save_snapshot(&snapshot).await.unwrap();
 
@@ -1285,7 +1285,7 @@ mod tests {
     #[tokio::test]
     async fn test_check_and_cancel_success() {
         let backend = InMemoryBackend::new();
-        let snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".to_string());
+        let snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".into());
         backend.save_snapshot(&snapshot).await.unwrap();
 
         backend
@@ -1338,7 +1338,7 @@ mod tests {
     #[tokio::test]
     async fn test_check_and_cancel_no_request() {
         let backend = InMemoryBackend::new();
-        let snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".to_string());
+        let snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".into());
         backend.save_snapshot(&snapshot).await.unwrap();
 
         let result = backend.check_and_cancel("test-123", None).await.unwrap();
@@ -1357,7 +1357,7 @@ mod tests {
     #[tokio::test]
     async fn test_check_and_cancel_not_in_progress() {
         let backend = InMemoryBackend::new();
-        let mut snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".to_string());
+        let mut snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".into());
         snapshot.mark_completed(bytes::Bytes::from("done"));
         backend.save_snapshot(&snapshot).await.unwrap();
 
@@ -1387,13 +1387,13 @@ mod tests {
     async fn test_find_available_tasks_skips_cancelled_workflows() {
         let backend = InMemoryBackend::new();
 
-        let mut snapshot1 = WorkflowSnapshot::new("workflow-1".to_string(), "hash-abc".to_string());
+        let mut snapshot1 = WorkflowSnapshot::new("workflow-1".to_string(), "hash-abc".into());
         snapshot1.update_position(ExecutionPosition::AtTask {
             task_id: "task-1".to_string(),
         });
         backend.save_snapshot(&snapshot1).await.unwrap();
 
-        let mut snapshot2 = WorkflowSnapshot::new("workflow-2".to_string(), "hash-abc".to_string());
+        let mut snapshot2 = WorkflowSnapshot::new("workflow-2".to_string(), "hash-abc".into());
         snapshot2.update_position(ExecutionPosition::AtTask {
             task_id: "task-2".to_string(),
         });
@@ -1426,7 +1426,7 @@ mod tests {
     #[tokio::test]
     async fn test_check_and_pause_success() {
         let backend = InMemoryBackend::new();
-        let snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".to_string());
+        let snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".into());
         backend.save_snapshot(&snapshot).await.unwrap();
 
         backend
@@ -1469,7 +1469,7 @@ mod tests {
     #[tokio::test]
     async fn test_check_and_pause_no_request() {
         let backend = InMemoryBackend::new();
-        let snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".to_string());
+        let snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".into());
         backend.save_snapshot(&snapshot).await.unwrap();
 
         let result = backend.check_and_pause("test-123").await.unwrap();
@@ -1488,7 +1488,7 @@ mod tests {
     #[tokio::test]
     async fn test_check_and_pause_not_in_progress() {
         let backend = InMemoryBackend::new();
-        let mut snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".to_string());
+        let mut snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".into());
         snapshot.mark_completed(bytes::Bytes::from("done"));
         backend.save_snapshot(&snapshot).await.unwrap();
 
@@ -1517,7 +1517,7 @@ mod tests {
     #[tokio::test]
     async fn test_check_and_pause_preserves_position() {
         let backend = InMemoryBackend::new();
-        let mut snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".to_string());
+        let mut snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".into());
         snapshot.update_position(ExecutionPosition::AtTask {
             task_id: "task-3".to_string(),
         });
@@ -1564,7 +1564,7 @@ mod tests {
     #[tokio::test]
     async fn test_unpause_success() {
         let backend = InMemoryBackend::new();
-        let mut snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".to_string());
+        let mut snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".into());
         snapshot.update_position(ExecutionPosition::AtTask {
             task_id: "task-2".to_string(),
         });
@@ -1606,7 +1606,7 @@ mod tests {
     #[tokio::test]
     async fn test_unpause_not_paused_errors() {
         let backend = InMemoryBackend::new();
-        let snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".to_string());
+        let snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".into());
         backend.save_snapshot(&snapshot).await.unwrap();
 
         let result = backend.unpause("test-123").await;
@@ -1619,7 +1619,7 @@ mod tests {
     #[tokio::test]
     async fn test_unpause_completed_errors() {
         let backend = InMemoryBackend::new();
-        let mut snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".to_string());
+        let mut snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".into());
         snapshot.mark_completed(bytes::Bytes::from("done"));
         backend.save_snapshot(&snapshot).await.unwrap();
 
@@ -1644,7 +1644,7 @@ mod tests {
     #[tokio::test]
     async fn test_cancel_and_pause_simultaneously_cancel_wins() {
         let backend = InMemoryBackend::new();
-        let snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".to_string());
+        let snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".into());
         backend.save_snapshot(&snapshot).await.unwrap();
 
         // Store both signals
@@ -1686,7 +1686,7 @@ mod tests {
     #[tokio::test]
     async fn test_cancel_signal_independent_of_pause_signal() {
         let backend = InMemoryBackend::new();
-        let snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".to_string());
+        let snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".into());
         backend.save_snapshot(&snapshot).await.unwrap();
 
         // Store both signals
@@ -1740,7 +1740,7 @@ mod tests {
 
         let mut snapshot1 = WorkflowSnapshot::with_initial_input(
             "workflow-1".to_string(),
-            "hash-abc".to_string(),
+            "hash-abc".into(),
             bytes::Bytes::from(vec![1]),
         );
         snapshot1.update_position(ExecutionPosition::AtTask {
@@ -1750,7 +1750,7 @@ mod tests {
 
         let mut snapshot2 = WorkflowSnapshot::with_initial_input(
             "workflow-2".to_string(),
-            "hash-abc".to_string(),
+            "hash-abc".into(),
             bytes::Bytes::from(vec![2]),
         );
         snapshot2.update_position(ExecutionPosition::AtTask {
@@ -1790,7 +1790,7 @@ mod tests {
     #[tokio::test]
     async fn test_delete_snapshot_leaves_orphaned_signals() {
         let backend = InMemoryBackend::new();
-        let snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".to_string());
+        let snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".into());
         backend.save_snapshot(&snapshot).await.unwrap();
 
         backend
@@ -1819,7 +1819,7 @@ mod tests {
     #[tokio::test]
     async fn test_store_signal_overwrites_previous() {
         let backend = InMemoryBackend::new();
-        let snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".to_string());
+        let snapshot = WorkflowSnapshot::new("test-123".to_string(), "hash-abc".into());
         backend.save_snapshot(&snapshot).await.unwrap();
 
         backend
@@ -1861,7 +1861,7 @@ mod tests {
 
         let mut snapshot = WorkflowSnapshot::with_initial_input(
             "workflow-1".to_string(),
-            "hash-abc".to_string(),
+            "hash-abc".into(),
             bytes::Bytes::from(vec![42]),
         );
         // Park at a delay that expires in the future
@@ -1891,7 +1891,7 @@ mod tests {
 
         let mut snapshot = WorkflowSnapshot::with_initial_input(
             "workflow-1".to_string(),
-            "hash-abc".to_string(),
+            "hash-abc".into(),
             bytes::Bytes::from(vec![42]),
         );
         // Park at a delay that has already expired
@@ -1934,7 +1934,7 @@ mod tests {
 
         let mut snapshot = WorkflowSnapshot::with_initial_input(
             "workflow-1".to_string(),
-            "hash-abc".to_string(),
+            "hash-abc".into(),
             bytes::Bytes::from(vec![42]),
         );
         // Park at a delay that has expired AND has no next task (delay is last node)
@@ -1977,11 +1977,8 @@ mod tests {
         // Create three workflows with different priorities:
         // wf-low (priority 5), wf-normal (priority 3), wf-high (priority 1)
         for (id, priority) in [("wf-low", 5u8), ("wf-normal", 3), ("wf-high", 1)] {
-            let mut snapshot = WorkflowSnapshot::with_initial_input(
-                id.to_string(),
-                "hash".to_string(),
-                input.clone(),
-            );
+            let mut snapshot =
+                WorkflowSnapshot::with_initial_input(id.to_string(), "hash".into(), input.clone());
             snapshot.task_priority = Some(priority);
             snapshot.update_position(ExecutionPosition::AtTask {
                 task_id: "task-a".to_string(),
@@ -2008,7 +2005,7 @@ mod tests {
         // Fresh high-priority workflow (priority 1).
         let mut high = WorkflowSnapshot::with_initial_input(
             "wf-high".to_string(),
-            "hash".to_string(),
+            "hash".into(),
             input.clone(),
         );
         high.task_priority = Some(1);
@@ -2021,7 +2018,7 @@ mod tests {
         // Low-priority workflow (priority 5) that has been waiting a long time.
         let mut low = WorkflowSnapshot::with_initial_input(
             "wf-low".to_string(),
-            "hash".to_string(),
+            "hash".into(),
             input.clone(),
         );
         low.task_priority = Some(5);
@@ -2056,7 +2053,7 @@ mod tests {
         let input = bytes::Bytes::from("input");
 
         let mut snapshot =
-            WorkflowSnapshot::with_initial_input("wf-1".to_string(), "hash".to_string(), input);
+            WorkflowSnapshot::with_initial_input("wf-1".to_string(), "hash".into(), input);
         snapshot.task_priority = Some(3);
         snapshot.update_position(ExecutionPosition::AtTask {
             task_id: "task-a".to_string(),

--- a/sayiir-persistence/src/lib.rs
+++ b/sayiir-persistence/src/lib.rs
@@ -30,7 +30,7 @@
 //! let backend = InMemoryBackend::new();
 //!
 //! // Save a snapshot
-//! let snapshot = WorkflowSnapshot::new("instance-123".to_string(), "hash-abc".to_string());
+//! let snapshot = WorkflowSnapshot::new("instance-123", sayiir_core::DefinitionHash::from("hash-abc"));
 //! backend.save_snapshot(&snapshot).await?;
 //!
 //! // Load it back

--- a/sayiir-persistence/src/lifecycle.rs
+++ b/sayiir-persistence/src/lifecycle.rs
@@ -39,9 +39,9 @@ pub enum RunConflict {
     /// The existing snapshot was produced from a different workflow definition.
     DefinitionMismatch {
         /// Definition hash the caller expected.
-        expected: String,
+        expected: sayiir_core::DefinitionHash,
         /// Definition hash actually stored.
-        found: String,
+        found: sayiir_core::DefinitionHash,
     },
     /// Backend I/O error.
     Backend(BackendError),
@@ -107,7 +107,7 @@ impl std::error::Error for RunConflict {
 /// or backend I/O failures.
 pub async fn prepare_run<B>(
     instance_id: String,
-    definition_hash: String,
+    definition_hash: sayiir_core::DefinitionHash,
     input_bytes: Bytes,
     first_task: TaskHint,
     backend: &B,

--- a/sayiir-persistence/src/lifecycle.rs
+++ b/sayiir-persistence/src/lifecycle.rs
@@ -34,6 +34,8 @@ pub enum PrepareRunOutcome {
 /// Reasons [`prepare_run`] may reject a call.
 #[derive(Debug)]
 pub enum RunConflict {
+    /// The supplied `instance_id` failed the API-boundary length check.
+    InvalidInstanceId(sayiir_core::InvalidInstanceId),
     /// `Fail` policy and the instance id is already in use.
     AlreadyExists(String),
     /// The existing snapshot was produced from a different workflow definition.
@@ -53,12 +55,19 @@ impl From<BackendError> for RunConflict {
     }
 }
 
+impl From<sayiir_core::InvalidInstanceId> for RunConflict {
+    fn from(e: sayiir_core::InvalidInstanceId) -> Self {
+        Self::InvalidInstanceId(e)
+    }
+}
+
 impl std::fmt::Display for RunConflict {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // Names are the canonical strum-serialized forms, which both the
         // Rust `ConflictPolicy::*` variants and the JS `conflictPolicy:`
         // engine option accept.
         match self {
+            Self::InvalidInstanceId(e) => std::fmt::Display::fmt(e, f),
             Self::AlreadyExists(id) => write!(
                 f,
                 "Workflow instance '{id}' already exists. Use conflict policy 'use_existing' or 'terminate_existing' to override, or resume() instead.",
@@ -75,6 +84,7 @@ impl std::fmt::Display for RunConflict {
 impl std::error::Error for RunConflict {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
+            Self::InvalidInstanceId(e) => Some(e),
             Self::Backend(e) => Some(e),
             _ => None,
         }
@@ -116,6 +126,7 @@ pub async fn prepare_run<B>(
 where
     B: SnapshotStore + SignalStore,
 {
+    sayiir_core::validate_instance_id(instance_id)?;
     match backend.load_snapshot(instance_id).await {
         Ok(existing) => {
             if existing.definition_hash != definition_hash {

--- a/sayiir-persistence/src/lifecycle.rs
+++ b/sayiir-persistence/src/lifecycle.rs
@@ -151,7 +151,7 @@ where
     let mut snapshot =
         WorkflowSnapshot::with_initial_input(instance_id, definition_hash, input_bytes);
     snapshot.update_position(ExecutionPosition::AtTask {
-        task_id: first_task.id.clone(),
+        task_id: first_task.id,
     });
     snapshot.set_task_hint(&first_task);
     backend.save_snapshot(&snapshot).await?;

--- a/sayiir-persistence/src/lifecycle.rs
+++ b/sayiir-persistence/src/lifecycle.rs
@@ -106,7 +106,7 @@ impl std::error::Error for RunConflict {
 /// Returns [`RunConflict`] for policy rejections, definition mismatches,
 /// or backend I/O failures.
 pub async fn prepare_run<B>(
-    instance_id: String,
+    instance_id: &str,
     definition_hash: sayiir_core::DefinitionHash,
     input_bytes: Bytes,
     first_task: TaskHint,
@@ -116,7 +116,7 @@ pub async fn prepare_run<B>(
 where
     B: SnapshotStore + SignalStore,
 {
-    match backend.load_snapshot(&instance_id).await {
+    match backend.load_snapshot(instance_id).await {
         Ok(existing) => {
             if existing.definition_hash != definition_hash {
                 return Err(RunConflict::DefinitionMismatch {
@@ -125,7 +125,9 @@ where
                 });
             }
             match conflict_policy {
-                ConflictPolicy::Fail => return Err(RunConflict::AlreadyExists(instance_id)),
+                ConflictPolicy::Fail => {
+                    return Err(RunConflict::AlreadyExists(instance_id.to_string()));
+                }
                 ConflictPolicy::UseExisting => {
                     let output = existing.state.completed_output().cloned();
                     return Ok(PrepareRunOutcome::ExistingStatus(
@@ -134,13 +136,11 @@ where
                     ));
                 }
                 ConflictPolicy::TerminateExisting => {
-                    backend.delete_snapshot(&instance_id).await?;
+                    backend.delete_snapshot(instance_id).await?;
                     backend
-                        .clear_signal(&instance_id, SignalKind::Cancel)
+                        .clear_signal(instance_id, SignalKind::Cancel)
                         .await?;
-                    backend
-                        .clear_signal(&instance_id, SignalKind::Pause)
-                        .await?;
+                    backend.clear_signal(instance_id, SignalKind::Pause).await?;
                 }
             }
         }

--- a/sayiir-postgres/benches/postgres.rs
+++ b/sayiir-postgres/benches/postgres.rs
@@ -130,7 +130,7 @@ fn fork_join(n_branches: usize) -> WorkflowContinuation {
 fn snapshot_with_tasks(n: usize) -> WorkflowSnapshot {
     let input = encode(0);
     let mut snapshot =
-        WorkflowSnapshot::with_initial_input("bench-inst".into(), "bench-hash".into(), input);
+        WorkflowSnapshot::with_initial_input("bench-inst", "bench-hash".into(), input);
     for i in 0..n {
         snapshot.mark_task_completed(
             sayiir_core::TaskId::from(format!("task_{i}").as_str()),
@@ -213,7 +213,7 @@ fn checkpointing(c: &mut Criterion) {
     group.bench_function("linear_5_tasks", |b| {
         b.to_async(rt).iter(|| async {
             let mut snapshot = WorkflowSnapshot::with_initial_input(
-                "bench-ckpt".into(),
+                "bench-ckpt",
                 "bench-hash".into(),
                 input.clone(),
             );

--- a/sayiir-postgres/benches/postgres.rs
+++ b/sayiir-postgres/benches/postgres.rs
@@ -132,7 +132,10 @@ fn snapshot_with_tasks(n: usize) -> WorkflowSnapshot {
     let mut snapshot =
         WorkflowSnapshot::with_initial_input("bench-inst".into(), "bench-hash".into(), input);
     for i in 0..n {
-        snapshot.mark_task_completed(format!("task_{i}"), encode(i as u32));
+        snapshot.mark_task_completed(
+            sayiir_core::TaskId::from(format!("task_{i}").as_str()),
+            encode(i as u32),
+        );
     }
     snapshot
 }

--- a/sayiir-postgres/migrations/009_task_id_bytea.sql
+++ b/sayiir-postgres/migrations/009_task_id_bytea.sql
@@ -1,0 +1,72 @@
+-- Migrate task identifier columns from hex-encoded TEXT to raw BYTEA.
+--
+-- The runtime now uses fixed-size 32-byte SHA-256 hashes (`TaskId`,
+-- `DefinitionHash`) for all internal task / workflow-definition identifiers.
+-- Storing them as hex-encoded TEXT doubled the on-disk size and forced a
+-- per-bind `to_hex()` allocation on every write. Switching the columns to
+-- BYTEA halves the storage, makes index leaves twice as dense, and lets the
+-- application bind raw byte slices with zero allocation.
+--
+-- Column-by-column conversion:
+--   - `task_id` / `current_task_id` were the user-facing task name as plain
+--     text (e.g. `"step1"`, `"approval"`). The new runtime expects 32 bytes
+--     of `sha256(name)`, so we hash the existing values in place.
+--   - `definition_hash` was already a hex SHA-256 string (computed by
+--     `compute_definition_hash`), so we just decode the hex back to bytes.
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+-- sayiir_workflow_snapshots ----------------------------------------------------
+ALTER TABLE sayiir_workflow_snapshots
+    ALTER COLUMN definition_hash TYPE BYTEA
+        USING CASE WHEN definition_hash IS NULL THEN NULL
+                   ELSE decode(definition_hash, 'hex') END;
+
+ALTER TABLE sayiir_workflow_snapshots
+    ALTER COLUMN current_task_id TYPE BYTEA
+        USING CASE WHEN current_task_id IS NULL THEN NULL
+                   ELSE digest(current_task_id, 'sha256') END;
+
+-- sayiir_workflow_snapshot_history --------------------------------------------
+ALTER TABLE sayiir_workflow_snapshot_history
+    ALTER COLUMN current_task_id TYPE BYTEA
+        USING CASE WHEN current_task_id IS NULL THEN NULL
+                   ELSE digest(current_task_id, 'sha256') END;
+
+-- sayiir_workflow_tasks -------------------------------------------------------
+ALTER TABLE sayiir_workflow_tasks
+    ALTER COLUMN task_id TYPE BYTEA
+        USING digest(task_id, 'sha256');
+
+-- sayiir_task_claims ----------------------------------------------------------
+ALTER TABLE sayiir_task_claims
+    ALTER COLUMN task_id TYPE BYTEA
+        USING digest(task_id, 'sha256');
+
+-- Indexes on the converted columns rebuild automatically when the column type
+-- changes. The B-tree on BYTEA uses raw byte ordering, which is equivalent to
+-- the prior TEXT ordering for hex strings.
+
+-- Convenience view for ops / debugging: render binary ids as lowercase hex
+-- so engineers can keep doing `WHERE task_id = '9deb65b8...'` against a view.
+CREATE OR REPLACE VIEW sayiir_workflow_snapshots_hex AS
+SELECT
+    instance_id,
+    status,
+    encode(definition_hash, 'hex') AS definition_hash,
+    encode(current_task_id, 'hex') AS current_task_id,
+    completed_task_count,
+    error,
+    started_at,
+    completed_at,
+    updated_at
+FROM sayiir_workflow_snapshots;
+
+CREATE OR REPLACE VIEW sayiir_task_claims_hex AS
+SELECT
+    instance_id,
+    encode(task_id, 'hex') AS task_id,
+    worker_id,
+    claimed_at,
+    expires_at
+FROM sayiir_task_claims;

--- a/sayiir-postgres/src/lib.rs
+++ b/sayiir-postgres/src/lib.rs
@@ -39,7 +39,7 @@
 //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 //! let backend = PostgresBackend::<JsonCodec>::connect("postgresql://localhost/sayiir").await?;
 //!
-//! let snapshot = WorkflowSnapshot::new("order-123".to_string(), "hash-abc".to_string());
+//! let snapshot = WorkflowSnapshot::new("order-123", sayiir_core::DefinitionHash::from("hash-abc"));
 //! backend.save_snapshot(&snapshot).await?;
 //!
 //! let loaded = backend.load_snapshot("order-123").await?;

--- a/sayiir-postgres/src/signal_store.rs
+++ b/sayiir-postgres/src/signal_store.rs
@@ -191,7 +191,7 @@ where
     async fn check_and_cancel(
         &self,
         instance_id: &str,
-        interrupted_at_task: Option<&str>,
+        interrupted_at_task: Option<sayiir_core::TaskId>,
     ) -> Result<bool, BackendError> {
         tracing::debug!("checking for cancel signal");
         let mut tx = self.pool.begin().await.map_err(PgError)?;
@@ -233,7 +233,7 @@ where
 
         let reason: Option<String> = signal_row.get("reason");
         let requested_by: Option<String> = signal_row.get("requested_by");
-        snapshot.mark_cancelled(reason, requested_by, interrupted_at_task.map(String::from));
+        snapshot.mark_cancelled(reason, requested_by, interrupted_at_task);
 
         let data = self.encode(&snapshot)?;
         let status = snapshot.state.as_ref();
@@ -333,7 +333,7 @@ where
 
         let data = self.encode(&snapshot)?;
         let status = snapshot.state.as_ref();
-        let task_id = snapshot.current_task_id().map(ToString::to_string);
+        let task_id = snapshot.current_task_id().map(|t| t.to_hex());
         let task_count = snapshot.completed_task_count();
         let pos_kind = snapshot.position_kind();
         let wake_at = snapshot.delay_wake_at();
@@ -402,7 +402,7 @@ where
 
         let data = self.encode(&snapshot)?;
         let status = snapshot.state.as_ref();
-        let task_id = snapshot.current_task_id().map(ToString::to_string);
+        let task_id = snapshot.current_task_id().map(|t| t.to_hex());
         let task_count = snapshot.completed_task_count();
         let pos_kind = snapshot.position_kind();
         let wake_at = snapshot.delay_wake_at();

--- a/sayiir-postgres/src/signal_store.rs
+++ b/sayiir-postgres/src/signal_store.rs
@@ -333,7 +333,8 @@ where
 
         let data = self.encode(&snapshot)?;
         let status = snapshot.state.as_ref();
-        let task_id = snapshot.current_task_id().map(|t| t.to_hex());
+        let task_id_bytes: Option<[u8; 32]> = snapshot.current_task_id().map(|t| *t.as_bytes());
+        let task_id: Option<&[u8]> = task_id_bytes.as_ref().map(<[u8; 32]>::as_slice);
         let task_count = snapshot.completed_task_count();
         let pos_kind = snapshot.position_kind();
         let wake_at = snapshot.delay_wake_at();
@@ -347,7 +348,7 @@ where
         )
         .bind(&data)
         .bind(status)
-        .bind(&task_id)
+        .bind(task_id)
         .bind(task_count)
         .bind(pos_kind)
         .bind(wake_at)
@@ -402,7 +403,8 @@ where
 
         let data = self.encode(&snapshot)?;
         let status = snapshot.state.as_ref();
-        let task_id = snapshot.current_task_id().map(|t| t.to_hex());
+        let task_id_bytes: Option<[u8; 32]> = snapshot.current_task_id().map(|t| *t.as_bytes());
+        let task_id: Option<&[u8]> = task_id_bytes.as_ref().map(<[u8; 32]>::as_slice);
         let task_count = snapshot.completed_task_count();
         let pos_kind = snapshot.position_kind();
         let wake_at = snapshot.delay_wake_at();
@@ -416,7 +418,7 @@ where
         )
         .bind(&data)
         .bind(status)
-        .bind(&task_id)
+        .bind(task_id)
         .bind(task_count)
         .bind(pos_kind)
         .bind(wake_at)

--- a/sayiir-postgres/src/snapshot_store.rs
+++ b/sayiir-postgres/src/snapshot_store.rs
@@ -82,7 +82,7 @@ where
         )
         .bind(&snapshot.instance_id) // $1
         .bind(status) // $2
-        .bind(&snapshot.definition_hash) // $3
+        .bind(snapshot.definition_hash.to_hex()) // $3
         .bind(&task_id) // $4
         .bind(task_count) // $5
         .bind(&data) // $6

--- a/sayiir-postgres/src/snapshot_store.rs
+++ b/sayiir-postgres/src/snapshot_store.rs
@@ -81,7 +81,7 @@ where
                 updated_at = now()
              RETURNING history_version",
         )
-        .bind(&snapshot.instance_id) // $1
+        .bind(&*snapshot.instance_id) // $1
         .bind(status) // $2
         .bind(snapshot.definition_hash.to_hex()) // $3
         .bind(&task_id) // $4
@@ -106,7 +106,7 @@ where
                 (instance_id, version, status, current_task_id, data)
              VALUES ($1, $2, $3, $4, $5)",
         )
-        .bind(&snapshot.instance_id)
+        .bind(&*snapshot.instance_id)
         .bind(history_version)
         .bind(status)
         .bind(&task_id)
@@ -129,7 +129,7 @@ where
                     END,
                     started_at = COALESCE(sayiir_workflow_tasks.started_at, now())",
             )
-            .bind(&snapshot.instance_id)
+            .bind(&*snapshot.instance_id)
             .bind(tid)
             .execute(&mut *tx)
             .await
@@ -149,7 +149,7 @@ where
             )
             .bind(terminal_status)
             .bind(&error)
-            .bind(&snapshot.instance_id)
+            .bind(&*snapshot.instance_id)
             .execute(&mut *tx)
             .await
             .map_err(PgError)?;

--- a/sayiir-postgres/src/snapshot_store.rs
+++ b/sayiir-postgres/src/snapshot_store.rs
@@ -31,7 +31,7 @@ where
         tracing::debug!("saving snapshot");
         let data = self.encode(snapshot)?;
         let status = snapshot.state.as_ref();
-        let task_id = snapshot.current_task_id().map(ToString::to_string);
+        let task_id = snapshot.current_task_id().map(|t| t.to_hex());
         let task_count = snapshot.completed_task_count();
         let error = snapshot.error_message().map(ToString::to_string);
         let terminal = snapshot.state.is_terminal();
@@ -170,7 +170,7 @@ where
     async fn save_task_result(
         &self,
         instance_id: &str,
-        task_id: &str,
+        task_id: &sayiir_core::TaskId,
         output: bytes::Bytes,
     ) -> Result<(), BackendError> {
         tracing::debug!("saving task result");
@@ -188,11 +188,11 @@ where
 
         let raw: &[u8] = row.get("data");
         let mut snapshot = self.decode(raw)?;
-        snapshot.mark_task_completed(task_id.to_string(), output);
+        snapshot.mark_task_completed(*task_id, output);
 
         let data = self.encode(&snapshot)?;
         let status = snapshot.state.as_ref();
-        let current = snapshot.current_task_id().map(ToString::to_string);
+        let current = snapshot.current_task_id().map(|t| t.to_hex());
         let task_count = snapshot.completed_task_count();
 
         sqlx::query(
@@ -218,7 +218,7 @@ where
                 status = 'completed', completed_at = now(), error = NULL",
         )
         .bind(instance_id)
-        .bind(task_id)
+        .bind(task_id.to_hex())
         .execute(&mut *tx)
         .await
         .map_err(PgError)?;

--- a/sayiir-postgres/src/snapshot_store.rs
+++ b/sayiir-postgres/src/snapshot_store.rs
@@ -31,7 +31,8 @@ where
         tracing::debug!("saving snapshot");
         let data = self.encode(snapshot)?;
         let status = snapshot.state.as_ref();
-        let task_id = snapshot.current_task_id().map(|t| t.to_hex());
+        let task_id_bytes: Option<[u8; 32]> = snapshot.current_task_id().map(|t| *t.as_bytes());
+        let task_id: Option<&[u8]> = task_id_bytes.as_ref().map(<[u8; 32]>::as_slice);
         let task_count = snapshot.completed_task_count();
         let error = snapshot.error_message().map(ToString::to_string);
         let terminal = snapshot.state.is_terminal();
@@ -83,8 +84,8 @@ where
         )
         .bind(&*snapshot.instance_id) // $1
         .bind(status) // $2
-        .bind(snapshot.definition_hash.to_hex()) // $3
-        .bind(&task_id) // $4
+        .bind(snapshot.definition_hash.as_bytes().as_slice()) // $3
+        .bind(task_id) // $4
         .bind(task_count) // $5
         .bind(&data) // $6
         .bind(&error) // $7
@@ -109,7 +110,7 @@ where
         .bind(&*snapshot.instance_id)
         .bind(history_version)
         .bind(status)
-        .bind(&task_id)
+        .bind(task_id)
         .bind(&data)
         .execute(&mut *tx)
         .await
@@ -118,7 +119,7 @@ where
         // --- Maintain sayiir_workflow_tasks lifecycle ---
 
         // If at a task, mark it as active
-        if let Some(ref tid) = task_id {
+        if let Some(tid) = task_id {
             sqlx::query(
                 "INSERT INTO sayiir_workflow_tasks (instance_id, task_id, status, started_at)
                  VALUES ($1, $2, 'active', now())
@@ -192,7 +193,8 @@ where
 
         let data = self.encode(&snapshot)?;
         let status = snapshot.state.as_ref();
-        let current = snapshot.current_task_id().map(|t| t.to_hex());
+        let current_bytes: Option<[u8; 32]> = snapshot.current_task_id().map(|t| *t.as_bytes());
+        let current: Option<&[u8]> = current_bytes.as_ref().map(<[u8; 32]>::as_slice);
         let task_count = snapshot.completed_task_count();
 
         sqlx::query(
@@ -203,7 +205,7 @@ where
         )
         .bind(&data)
         .bind(status)
-        .bind(&current)
+        .bind(current)
         .bind(task_count)
         .bind(instance_id)
         .execute(&mut *tx)
@@ -218,7 +220,7 @@ where
                 status = 'completed', completed_at = now(), error = NULL",
         )
         .bind(instance_id)
-        .bind(task_id.to_hex())
+        .bind(task_id.as_bytes().as_slice())
         .execute(&mut *tx)
         .await
         .map_err(PgError)?;

--- a/sayiir-postgres/src/task_claim_store.rs
+++ b/sayiir-postgres/src/task_claim_store.rs
@@ -424,9 +424,20 @@ where
         else {
             return Ok(None);
         };
-        // hint.task_id is the wire-format String (hex of the TaskId).
-        let Some(hint_task_id) = sayiir_core::TaskId::from_hex(&hint.task_id).ok() else {
-            return Ok(None);
+        // hint.task_id is the wire-format String (hex of the TaskId), coming
+        // from a NOTIFY payload — treat malformed hex as a stale/garbage hint
+        // (skip + log) rather than a hard error: the timer-tick fallback will
+        // pick up the task on the next sweep.
+        let hint_task_id = match sayiir_core::TaskId::from_hex(&hint.task_id) {
+            Ok(id) => id,
+            Err(e) => {
+                tracing::warn!(
+                    hint_task_id = %hint.task_id,
+                    error = %e,
+                    "ignoring NOTIFY hint with invalid task_id hex",
+                );
+                return Ok(None);
+            }
         };
         if *task_id != hint_task_id || completed_tasks.contains_key(task_id) {
             return Ok(None);

--- a/sayiir-postgres/src/task_claim_store.rs
+++ b/sayiir-postgres/src/task_claim_store.rs
@@ -75,7 +75,7 @@ where
         .map_err(PgError)?;
 
         Ok(row.map(|r| TaskClaim {
-            instance_id: r.get("instance_id"),
+            instance_id: std::sync::Arc::from(r.get::<&str, _>("instance_id")),
             task_id: sayiir_core::TaskId::from_hex(r.get::<&str, _>("task_id")).unwrap_or_default(),
             worker_id: r.get("worker_id"),
             claimed_at: r.get::<i64, _>("claimed_epoch").cast_unsigned(),

--- a/sayiir-postgres/src/task_claim_store.rs
+++ b/sayiir-postgres/src/task_claim_store.rs
@@ -48,7 +48,7 @@ where
     async fn claim_task(
         &self,
         instance_id: &str,
-        task_id: &str,
+        task_id: &sayiir_core::TaskId,
         worker_id: &str,
         ttl: Option<Duration>,
     ) -> Result<Option<TaskClaim>, BackendError> {
@@ -67,7 +67,7 @@ where
                        EXTRACT(EPOCH FROM expires_at)::BIGINT AS expires_epoch",
         )
         .bind(instance_id)
-        .bind(task_id)
+        .bind(task_id.to_hex())
         .bind(worker_id)
         .bind(expires_at)
         .fetch_optional(&self.pool)
@@ -76,7 +76,7 @@ where
 
         Ok(row.map(|r| TaskClaim {
             instance_id: r.get("instance_id"),
-            task_id: r.get("task_id"),
+            task_id: sayiir_core::TaskId::from_hex(r.get::<&str, _>("task_id")).unwrap_or_default(),
             worker_id: r.get("worker_id"),
             claimed_at: r.get::<i64, _>("claimed_epoch").cast_unsigned(),
             expires_at: r
@@ -94,7 +94,7 @@ where
     async fn release_task_claim(
         &self,
         instance_id: &str,
-        task_id: &str,
+        task_id: &sayiir_core::TaskId,
         worker_id: &str,
     ) -> Result<(), BackendError> {
         tracing::debug!("releasing task claim");
@@ -103,7 +103,7 @@ where
             "SELECT worker_id FROM sayiir_task_claims WHERE instance_id = $1 AND task_id = $2",
         )
         .bind(instance_id)
-        .bind(task_id)
+        .bind(task_id.to_hex())
         .fetch_optional(&self.pool)
         .await
         .map_err(PgError)?
@@ -121,7 +121,7 @@ where
              WHERE instance_id = $1 AND task_id = $2 AND worker_id = $3",
         )
         .bind(instance_id)
-        .bind(task_id)
+        .bind(task_id.to_hex())
         .bind(worker_id)
         .execute(&self.pool)
         .await
@@ -139,7 +139,7 @@ where
     async fn extend_task_claim(
         &self,
         instance_id: &str,
-        task_id: &str,
+        task_id: &sayiir_core::TaskId,
         worker_id: &str,
         additional_duration: Duration,
     ) -> Result<(), BackendError> {
@@ -149,7 +149,7 @@ where
              WHERE instance_id = $1 AND task_id = $2",
         )
         .bind(instance_id)
-        .bind(task_id)
+        .bind(task_id.to_hex())
         .fetch_optional(&self.pool)
         .await
         .map_err(PgError)?
@@ -175,7 +175,7 @@ where
             )
             .bind(new_exp)
             .bind(instance_id)
-            .bind(task_id)
+            .bind(task_id.to_hex())
             .execute(&self.pool)
             .await
             .map_err(PgError)?;
@@ -289,7 +289,7 @@ where
                         },
                     ..
                 } if Utc::now() >= *wake_at => {
-                    if let Some(next_id) = next_task_id.clone() {
+                    if let Some(next_id) = *next_task_id {
                         snapshot.update_position(ExecutionPosition::AtTask { task_id: next_id });
                         self.save_snapshot(&snapshot).await?;
 
@@ -412,13 +412,17 @@ where
         else {
             return Ok(None);
         };
-        if task_id != &hint.task_id || completed_tasks.contains_key(task_id) {
+        // hint.task_id is the wire-format String (hex of the TaskId).
+        let Some(hint_task_id) = sayiir_core::TaskId::from_hex(&hint.task_id).ok() else {
+            return Ok(None);
+        };
+        if *task_id != hint_task_id || completed_tasks.contains_key(task_id) {
             return Ok(None);
         }
 
         Ok(build_available_task(
             &snapshot,
-            &hint.task_id,
+            &hint_task_id,
             completed_tasks,
         ))
     }
@@ -427,8 +431,11 @@ where
 /// Build an [`AvailableTask`] from a snapshot at a task position.
 fn build_available_task(
     snapshot: &WorkflowSnapshot,
-    task_id: &str,
-    completed_tasks: &std::collections::HashMap<String, sayiir_core::snapshot::TaskResult>,
+    task_id: &sayiir_core::TaskId,
+    completed_tasks: &std::collections::HashMap<
+        sayiir_core::TaskId,
+        sayiir_core::snapshot::TaskResult,
+    >,
 ) -> Option<AvailableTask> {
     let input = if completed_tasks.is_empty() {
         snapshot.initial_input_bytes()
@@ -438,7 +445,7 @@ fn build_available_task(
 
     input.map(|input_bytes| AvailableTask {
         instance_id: snapshot.instance_id.clone(),
-        task_id: task_id.to_string(),
+        task_id: *task_id,
         input: input_bytes,
         workflow_definition_hash: snapshot.definition_hash,
         trace_parent: snapshot.trace_parent.clone(),

--- a/sayiir-postgres/src/task_claim_store.rs
+++ b/sayiir-postgres/src/task_claim_store.rs
@@ -67,7 +67,7 @@ where
                        EXTRACT(EPOCH FROM expires_at)::BIGINT AS expires_epoch",
         )
         .bind(instance_id)
-        .bind(task_id.to_hex())
+        .bind(task_id.as_bytes().as_slice())
         .bind(worker_id)
         .bind(expires_at)
         .fetch_optional(&self.pool)
@@ -75,13 +75,13 @@ where
         .map_err(PgError)?;
 
         row.map(|r| {
-            let task_id_hex: &str = r.get("task_id");
-            // Fail loudly on invalid hex rather than silently coercing to
-            // TaskId::default() — a malformed task_id column means data
-            // corruption and would otherwise cause incorrect claim ownership.
-            let task_id = sayiir_core::TaskId::from_hex(task_id_hex).map_err(|e| {
+            let task_id_bytes: &[u8] = r.get("task_id");
+            // Fail loudly on a malformed (wrong-length) task_id column —
+            // silently defaulting would cause incorrect claim ownership.
+            let task_id = sayiir_core::TaskId::from_slice(task_id_bytes).map_err(|e| {
                 BackendError::Backend(format!(
-                    "invalid task_id hex in sayiir_task_claims: {task_id_hex:?}: {e}"
+                    "invalid task_id bytes in sayiir_task_claims (len={}): {e}",
+                    task_id_bytes.len(),
                 ))
             })?;
             Ok(TaskClaim {
@@ -115,7 +115,7 @@ where
             "SELECT worker_id FROM sayiir_task_claims WHERE instance_id = $1 AND task_id = $2",
         )
         .bind(instance_id)
-        .bind(task_id.to_hex())
+        .bind(task_id.as_bytes().as_slice())
         .fetch_optional(&self.pool)
         .await
         .map_err(PgError)?
@@ -133,7 +133,7 @@ where
              WHERE instance_id = $1 AND task_id = $2 AND worker_id = $3",
         )
         .bind(instance_id)
-        .bind(task_id.to_hex())
+        .bind(task_id.as_bytes().as_slice())
         .bind(worker_id)
         .execute(&self.pool)
         .await
@@ -161,7 +161,7 @@ where
              WHERE instance_id = $1 AND task_id = $2",
         )
         .bind(instance_id)
-        .bind(task_id.to_hex())
+        .bind(task_id.as_bytes().as_slice())
         .fetch_optional(&self.pool)
         .await
         .map_err(PgError)?
@@ -187,7 +187,7 @@ where
             )
             .bind(new_exp)
             .bind(instance_id)
-            .bind(task_id.to_hex())
+            .bind(task_id.as_bytes().as_slice())
             .execute(&self.pool)
             .await
             .map_err(PgError)?;
@@ -378,7 +378,9 @@ where
         fields(
             db.system = "postgresql",
             instance_id = %hint.instance_id,
-            task_id = %hint.task_id,
+            // Display via the `TaskId` newtype so the span field renders as
+            // 64-char hex like every other task_id log line.
+            task_id = %sayiir_core::TaskId::from_bytes(hint.task_id),
         ),
         err(level = tracing::Level::ERROR),
     )]
@@ -403,7 +405,7 @@ where
         );
         let row = sqlx::query(&query)
             .bind(&hint.instance_id)
-            .bind(&hint.task_id)
+            .bind(hint.task_id.as_slice())
             .fetch_optional(&self.pool)
             .await
             .map_err(PgError)?;
@@ -424,21 +426,8 @@ where
         else {
             return Ok(None);
         };
-        // hint.task_id is the wire-format String (hex of the TaskId), coming
-        // from a NOTIFY payload — treat malformed hex as a stale/garbage hint
-        // (skip + log) rather than a hard error: the timer-tick fallback will
-        // pick up the task on the next sweep.
-        let hint_task_id = match sayiir_core::TaskId::from_hex(&hint.task_id) {
-            Ok(id) => id,
-            Err(e) => {
-                tracing::warn!(
-                    hint_task_id = %hint.task_id,
-                    error = %e,
-                    "ignoring NOTIFY hint with invalid task_id hex",
-                );
-                return Ok(None);
-            }
-        };
+        // hint.task_id is 32 raw bytes from the NOTIFY payload — wrap and compare.
+        let hint_task_id = sayiir_core::TaskId::from_bytes(hint.task_id);
         if *task_id != hint_task_id || completed_tasks.contains_key(task_id) {
             return Ok(None);
         }

--- a/sayiir-postgres/src/task_claim_store.rs
+++ b/sayiir-postgres/src/task_claim_store.rs
@@ -361,7 +361,7 @@ fn build_available_task(
         instance_id: snapshot.instance_id.clone(),
         task_id: task_id.to_string(),
         input: input_bytes,
-        workflow_definition_hash: snapshot.definition_hash.clone(),
+        workflow_definition_hash: snapshot.definition_hash,
         trace_parent: snapshot.trace_parent.clone(),
     })
 }

--- a/sayiir-postgres/src/task_claim_store.rs
+++ b/sayiir-postgres/src/task_claim_store.rs
@@ -74,15 +74,27 @@ where
         .await
         .map_err(PgError)?;
 
-        Ok(row.map(|r| TaskClaim {
-            instance_id: std::sync::Arc::from(r.get::<&str, _>("instance_id")),
-            task_id: sayiir_core::TaskId::from_hex(r.get::<&str, _>("task_id")).unwrap_or_default(),
-            worker_id: r.get("worker_id"),
-            claimed_at: r.get::<i64, _>("claimed_epoch").cast_unsigned(),
-            expires_at: r
-                .get::<Option<i64>, _>("expires_epoch")
-                .map(i64::cast_unsigned),
-        }))
+        row.map(|r| {
+            let task_id_hex: &str = r.get("task_id");
+            // Fail loudly on invalid hex rather than silently coercing to
+            // TaskId::default() — a malformed task_id column means data
+            // corruption and would otherwise cause incorrect claim ownership.
+            let task_id = sayiir_core::TaskId::from_hex(task_id_hex).map_err(|e| {
+                BackendError::Backend(format!(
+                    "invalid task_id hex in sayiir_task_claims: {task_id_hex:?}: {e}"
+                ))
+            })?;
+            Ok(TaskClaim {
+                instance_id: std::sync::Arc::from(r.get::<&str, _>("instance_id")),
+                task_id,
+                worker_id: r.get("worker_id"),
+                claimed_at: r.get::<i64, _>("claimed_epoch").cast_unsigned(),
+                expires_at: r
+                    .get::<Option<i64>, _>("expires_epoch")
+                    .map(i64::cast_unsigned),
+            })
+        })
+        .transpose()
     }
 
     #[tracing::instrument(

--- a/sayiir-postgres/src/task_result_store.rs
+++ b/sayiir-postgres/src/task_result_store.rs
@@ -29,7 +29,7 @@ where
     async fn load_task_result(
         &self,
         instance_id: &str,
-        task_id: &str,
+        task_id: &sayiir_core::TaskId,
     ) -> Result<Option<bytes::Bytes>, BackendError> {
         let snapshot = self.load_snapshot(instance_id).await?;
 

--- a/sayiir-postgres/src/wakeup.rs
+++ b/sayiir-postgres/src/wakeup.rs
@@ -80,8 +80,8 @@ fn build_hint(snapshot: &sayiir_core::snapshot::WorkflowSnapshot) -> Option<Task
     let task_id = snapshot.current_task_id()?;
     Some(TaskWakeupHint {
         instance_id: snapshot.instance_id.to_string(),
-        task_id: task_id.to_string(),
-        definition_hash: snapshot.definition_hash.to_hex(),
+        task_id: *task_id.as_bytes(),
+        definition_hash: *snapshot.definition_hash.as_bytes(),
         tags: snapshot.current_task_tags().to_vec(),
     })
 }

--- a/sayiir-postgres/src/wakeup.rs
+++ b/sayiir-postgres/src/wakeup.rs
@@ -81,7 +81,7 @@ fn build_hint(snapshot: &sayiir_core::snapshot::WorkflowSnapshot) -> Option<Task
     Some(TaskWakeupHint {
         instance_id: snapshot.instance_id.clone(),
         task_id: task_id.to_string(),
-        definition_hash: snapshot.definition_hash.clone(),
+        definition_hash: snapshot.definition_hash.to_hex(),
         tags: snapshot.current_task_tags().to_vec(),
     })
 }

--- a/sayiir-postgres/src/wakeup.rs
+++ b/sayiir-postgres/src/wakeup.rs
@@ -79,7 +79,7 @@ pub(crate) async fn emit_task_ready(
 fn build_hint(snapshot: &sayiir_core::snapshot::WorkflowSnapshot) -> Option<TaskWakeupHint> {
     let task_id = snapshot.current_task_id()?;
     Some(TaskWakeupHint {
-        instance_id: snapshot.instance_id.clone(),
+        instance_id: snapshot.instance_id.to_string(),
         task_id: task_id.to_string(),
         definition_hash: snapshot.definition_hash.to_hex(),
         tags: snapshot.current_task_tags().to_vec(),

--- a/sayiir-postgres/tests/integration.rs
+++ b/sayiir-postgres/tests/integration.rs
@@ -1049,7 +1049,10 @@ async fn find_hinted_task_returns_available_task() {
         .expect("hinted task should still be eligible");
     assert_eq!(task.instance_id, "wf-hint-found");
     assert_eq!(task.task_id, "first");
-    assert_eq!(task.workflow_definition_hash, sayiir_core::DefinitionHash::from("h"));
+    assert_eq!(
+        task.workflow_definition_hash,
+        sayiir_core::DefinitionHash::from("h")
+    );
 }
 
 /// `find_hinted_task` must return `None` when the snapshot already

--- a/sayiir-postgres/tests/integration.rs
+++ b/sayiir-postgres/tests/integration.rs
@@ -51,12 +51,12 @@ async fn setup() -> (
 #[tokio::test]
 async fn save_and_load_snapshot() {
     let (_c, backend) = setup().await;
-    let snapshot = WorkflowSnapshot::new("test-1".into(), "hash-1".into());
+    let snapshot = WorkflowSnapshot::new("test-1", "hash-1".into());
 
     backend.save_snapshot(&snapshot).await.unwrap();
     let loaded = backend.load_snapshot("test-1").await.unwrap();
 
-    assert_eq!(loaded.instance_id, "test-1");
+    assert_eq!(&*loaded.instance_id, "test-1");
     assert_eq!(
         loaded.definition_hash,
         sayiir_core::DefinitionHash::from("hash-1")
@@ -74,7 +74,7 @@ async fn load_not_found() {
 #[tokio::test]
 async fn save_snapshot_overwrites() {
     let (_c, backend) = setup().await;
-    let mut snapshot = WorkflowSnapshot::new("test-1".into(), "hash-1".into());
+    let mut snapshot = WorkflowSnapshot::new("test-1", "hash-1".into());
     backend.save_snapshot(&snapshot).await.unwrap();
 
     snapshot.update_position(ExecutionPosition::AtTask {
@@ -98,7 +98,7 @@ async fn save_snapshot_overwrites() {
 #[tokio::test]
 async fn delete_snapshot() {
     let (_c, backend) = setup().await;
-    let snapshot = WorkflowSnapshot::new("test-1".into(), "hash-1".into());
+    let snapshot = WorkflowSnapshot::new("test-1", "hash-1".into());
     backend.save_snapshot(&snapshot).await.unwrap();
 
     backend.delete_snapshot("test-1").await.unwrap();
@@ -118,11 +118,11 @@ async fn list_snapshots() {
     let (_c, backend) = setup().await;
 
     backend
-        .save_snapshot(&WorkflowSnapshot::new("wf-1".into(), "h".into()))
+        .save_snapshot(&WorkflowSnapshot::new("wf-1", "h".into()))
         .await
         .unwrap();
     backend
-        .save_snapshot(&WorkflowSnapshot::new("wf-2".into(), "h".into()))
+        .save_snapshot(&WorkflowSnapshot::new("wf-2", "h".into()))
         .await
         .unwrap();
 
@@ -134,7 +134,7 @@ async fn list_snapshots() {
 #[tokio::test]
 async fn save_task_result() {
     let (_c, backend) = setup().await;
-    let mut snapshot = WorkflowSnapshot::new("wf-1".into(), "hash-1".into());
+    let mut snapshot = WorkflowSnapshot::new("wf-1", "hash-1".into());
     snapshot.update_position(ExecutionPosition::AtTask {
         task_id: sayiir_core::TaskId::from("task-1"),
     });
@@ -160,7 +160,7 @@ async fn save_task_result() {
 #[tokio::test]
 async fn store_and_get_cancel_signal() {
     let (_c, backend) = setup().await;
-    let snapshot = WorkflowSnapshot::new("wf-1".into(), "hash-1".into());
+    let snapshot = WorkflowSnapshot::new("wf-1", "hash-1".into());
     backend.save_snapshot(&snapshot).await.unwrap();
 
     backend
@@ -198,7 +198,7 @@ async fn store_signal_on_nonexistent_workflow() {
 #[tokio::test]
 async fn store_cancel_on_completed_workflow() {
     let (_c, backend) = setup().await;
-    let mut snapshot = WorkflowSnapshot::new("wf-1".into(), "hash-1".into());
+    let mut snapshot = WorkflowSnapshot::new("wf-1", "hash-1".into());
     snapshot.mark_completed(Bytes::from("result"));
     backend.save_snapshot(&snapshot).await.unwrap();
 
@@ -211,7 +211,7 @@ async fn store_cancel_on_completed_workflow() {
 #[tokio::test]
 async fn store_pause_on_completed_workflow() {
     let (_c, backend) = setup().await;
-    let mut snapshot = WorkflowSnapshot::new("wf-1".into(), "hash-1".into());
+    let mut snapshot = WorkflowSnapshot::new("wf-1", "hash-1".into());
     snapshot.mark_completed(Bytes::from("result"));
     backend.save_snapshot(&snapshot).await.unwrap();
 
@@ -224,7 +224,7 @@ async fn store_pause_on_completed_workflow() {
 #[tokio::test]
 async fn clear_signal() {
     let (_c, backend) = setup().await;
-    let snapshot = WorkflowSnapshot::new("wf-1".into(), "hash-1".into());
+    let snapshot = WorkflowSnapshot::new("wf-1", "hash-1".into());
     backend.save_snapshot(&snapshot).await.unwrap();
 
     backend
@@ -263,7 +263,7 @@ async fn get_signal_returns_none_when_absent() {
 #[tokio::test]
 async fn check_and_cancel_success() {
     let (_c, backend) = setup().await;
-    let snapshot = WorkflowSnapshot::new("wf-1".into(), "hash-1".into());
+    let snapshot = WorkflowSnapshot::new("wf-1", "hash-1".into());
     backend.save_snapshot(&snapshot).await.unwrap();
 
     backend
@@ -299,7 +299,7 @@ async fn check_and_cancel_success() {
 #[tokio::test]
 async fn check_and_cancel_no_signal() {
     let (_c, backend) = setup().await;
-    let snapshot = WorkflowSnapshot::new("wf-1".into(), "hash-1".into());
+    let snapshot = WorkflowSnapshot::new("wf-1", "hash-1".into());
     backend.save_snapshot(&snapshot).await.unwrap();
 
     let cancelled = backend.check_and_cancel("wf-1", None).await.unwrap();
@@ -312,7 +312,7 @@ async fn check_and_cancel_no_signal() {
 #[tokio::test]
 async fn check_and_pause_success() {
     let (_c, backend) = setup().await;
-    let snapshot = WorkflowSnapshot::new("wf-1".into(), "hash-1".into());
+    let snapshot = WorkflowSnapshot::new("wf-1", "hash-1".into());
     backend.save_snapshot(&snapshot).await.unwrap();
 
     backend
@@ -338,7 +338,7 @@ async fn check_and_pause_success() {
 #[tokio::test]
 async fn unpause_success() {
     let (_c, backend) = setup().await;
-    let snapshot = WorkflowSnapshot::new("wf-1".into(), "hash-1".into());
+    let snapshot = WorkflowSnapshot::new("wf-1", "hash-1".into());
     backend.save_snapshot(&snapshot).await.unwrap();
 
     // Pause it first
@@ -378,7 +378,7 @@ async fn claim_task_success() {
 
     assert!(claim.is_some());
     let claim = claim.unwrap();
-    assert_eq!(claim.instance_id, "wf-1");
+    assert_eq!(&*claim.instance_id, "wf-1");
     assert_eq!(claim.task_id, sayiir_core::TaskId::from("task-1"));
     assert_eq!(claim.worker_id, "worker-1");
     assert!(claim.expires_at.is_some());
@@ -585,11 +585,8 @@ async fn extend_task_claim_wrong_worker() {
 async fn find_available_tasks_basic() {
     let (_c, backend) = setup().await;
 
-    let mut snapshot = WorkflowSnapshot::with_initial_input(
-        "wf-1".into(),
-        "hash-1".into(),
-        Bytes::from(r#""input""#),
-    );
+    let mut snapshot =
+        WorkflowSnapshot::with_initial_input("wf-1", "hash-1".into(), Bytes::from(r#""input""#));
     snapshot.update_position(ExecutionPosition::AtTask {
         task_id: sayiir_core::TaskId::from("task-1"),
     });
@@ -600,7 +597,7 @@ async fn find_available_tasks_basic() {
         .await
         .unwrap();
     assert_eq!(tasks.len(), 1);
-    assert_eq!(tasks[0].instance_id, "wf-1");
+    assert_eq!(&*tasks[0].instance_id, "wf-1");
     assert_eq!(tasks[0].task_id, sayiir_core::TaskId::from("task-1"));
 }
 
@@ -609,11 +606,8 @@ async fn find_available_tasks_skips_cancelled() {
     let (_c, backend) = setup().await;
 
     // Workflow 1: in-progress with pending cancel signal
-    let mut snapshot1 = WorkflowSnapshot::with_initial_input(
-        "wf-1".into(),
-        "hash-1".into(),
-        Bytes::from(r#""input""#),
-    );
+    let mut snapshot1 =
+        WorkflowSnapshot::with_initial_input("wf-1", "hash-1".into(), Bytes::from(r#""input""#));
     snapshot1.update_position(ExecutionPosition::AtTask {
         task_id: sayiir_core::TaskId::from("task-1"),
     });
@@ -624,11 +618,8 @@ async fn find_available_tasks_skips_cancelled() {
         .unwrap();
 
     // Workflow 2: in-progress, no signals
-    let mut snapshot2 = WorkflowSnapshot::with_initial_input(
-        "wf-2".into(),
-        "hash-1".into(),
-        Bytes::from(r#""input""#),
-    );
+    let mut snapshot2 =
+        WorkflowSnapshot::with_initial_input("wf-2", "hash-1".into(), Bytes::from(r#""input""#));
     snapshot2.update_position(ExecutionPosition::AtTask {
         task_id: sayiir_core::TaskId::from("task-2"),
     });
@@ -638,15 +629,15 @@ async fn find_available_tasks_skips_cancelled() {
         .find_available_tasks("worker-1", 10, chrono::Duration::seconds(300), &[])
         .await
         .unwrap();
-    assert!(!tasks.iter().any(|t| t.instance_id == "wf-1"));
-    assert!(tasks.iter().any(|t| t.instance_id == "wf-2"));
+    assert!(!tasks.iter().any(|t| &*t.instance_id == "wf-1"));
+    assert!(tasks.iter().any(|t| &*t.instance_id == "wf-2"));
 }
 
 #[tokio::test]
 async fn find_available_tasks_skips_completed() {
     let (_c, backend) = setup().await;
 
-    let mut snapshot = WorkflowSnapshot::new("wf-1".into(), "hash-1".into());
+    let mut snapshot = WorkflowSnapshot::new("wf-1", "hash-1".into());
     snapshot.mark_completed(Bytes::from("done"));
     backend.save_snapshot(&snapshot).await.unwrap();
 
@@ -665,7 +656,7 @@ async fn find_available_tasks_filters_by_worker_tags() {
 
     // Task tagged ["gpu"]
     let mut snap1 =
-        WorkflowSnapshot::with_initial_input("wf-gpu".into(), "h1".into(), Bytes::from(r#""1""#));
+        WorkflowSnapshot::with_initial_input("wf-gpu", "h1".into(), Bytes::from(r#""1""#));
     snap1.update_position(ExecutionPosition::AtTask {
         task_id: sayiir_core::TaskId::from("t1"),
     });
@@ -674,7 +665,7 @@ async fn find_available_tasks_filters_by_worker_tags() {
 
     // Task tagged ["cpu"]
     let mut snap2 =
-        WorkflowSnapshot::with_initial_input("wf-cpu".into(), "h1".into(), Bytes::from(r#""2""#));
+        WorkflowSnapshot::with_initial_input("wf-cpu", "h1".into(), Bytes::from(r#""2""#));
     snap2.update_position(ExecutionPosition::AtTask {
         task_id: sayiir_core::TaskId::from("t2"),
     });
@@ -687,18 +678,15 @@ async fn find_available_tasks_filters_by_worker_tags() {
         .await
         .unwrap();
     assert_eq!(tasks.len(), 1);
-    assert_eq!(tasks[0].instance_id, "wf-gpu");
+    assert_eq!(&*tasks[0].instance_id, "wf-gpu");
 }
 
 #[tokio::test]
 async fn find_available_tasks_untagged_worker_accepts_all() {
     let (_c, backend) = setup().await;
 
-    let mut snap1 = WorkflowSnapshot::with_initial_input(
-        "wf-tagged".into(),
-        "h1".into(),
-        Bytes::from(r#""1""#),
-    );
+    let mut snap1 =
+        WorkflowSnapshot::with_initial_input("wf-tagged", "h1".into(), Bytes::from(r#""1""#));
     snap1.update_position(ExecutionPosition::AtTask {
         task_id: sayiir_core::TaskId::from("t1"),
     });
@@ -706,7 +694,7 @@ async fn find_available_tasks_untagged_worker_accepts_all() {
     backend.save_snapshot(&snap1).await.unwrap();
 
     let mut snap2 =
-        WorkflowSnapshot::with_initial_input("wf-plain".into(), "h1".into(), Bytes::from(r#""2""#));
+        WorkflowSnapshot::with_initial_input("wf-plain", "h1".into(), Bytes::from(r#""2""#));
     snap2.update_position(ExecutionPosition::AtTask {
         task_id: sayiir_core::TaskId::from("t2"),
     });
@@ -726,7 +714,7 @@ async fn find_available_tasks_untagged_tasks_accepted_by_tagged_worker() {
 
     // Untagged task
     let mut snap =
-        WorkflowSnapshot::with_initial_input("wf-plain".into(), "h1".into(), Bytes::from(r#""1""#));
+        WorkflowSnapshot::with_initial_input("wf-plain", "h1".into(), Bytes::from(r#""1""#));
     snap.update_position(ExecutionPosition::AtTask {
         task_id: sayiir_core::TaskId::from("t1"),
     });
@@ -738,7 +726,7 @@ async fn find_available_tasks_untagged_tasks_accepted_by_tagged_worker() {
         .await
         .unwrap();
     assert_eq!(tasks.len(), 1);
-    assert_eq!(tasks[0].instance_id, "wf-plain");
+    assert_eq!(&*tasks[0].instance_id, "wf-plain");
 }
 
 #[tokio::test]
@@ -747,7 +735,7 @@ async fn find_available_tasks_multi_tag_subset() {
 
     // Task requiring ["gpu", "cuda"]
     let mut snap1 =
-        WorkflowSnapshot::with_initial_input("wf-multi".into(), "h1".into(), Bytes::from(r#""1""#));
+        WorkflowSnapshot::with_initial_input("wf-multi", "h1".into(), Bytes::from(r#""1""#));
     snap1.update_position(ExecutionPosition::AtTask {
         task_id: sayiir_core::TaskId::from("t1"),
     });
@@ -755,11 +743,8 @@ async fn find_available_tasks_multi_tag_subset() {
     backend.save_snapshot(&snap1).await.unwrap();
 
     // Task requiring only ["gpu"]
-    let mut snap2 = WorkflowSnapshot::with_initial_input(
-        "wf-single".into(),
-        "h1".into(),
-        Bytes::from(r#""2""#),
-    );
+    let mut snap2 =
+        WorkflowSnapshot::with_initial_input("wf-single", "h1".into(), Bytes::from(r#""2""#));
     snap2.update_position(ExecutionPosition::AtTask {
         task_id: sayiir_core::TaskId::from("t2"),
     });
@@ -772,7 +757,7 @@ async fn find_available_tasks_multi_tag_subset() {
         .await
         .unwrap();
     assert_eq!(tasks.len(), 1);
-    assert_eq!(tasks[0].instance_id, "wf-single");
+    assert_eq!(&*tasks[0].instance_id, "wf-single");
 
     // Worker with ["gpu","cuda","fast"] can run both (superset of both)
     let tasks = backend
@@ -791,11 +776,8 @@ async fn find_available_tasks_multi_tag_subset() {
 async fn find_available_tasks_tags_persist_through_save_load() {
     let (_c, backend) = setup().await;
 
-    let mut snap = WorkflowSnapshot::with_initial_input(
-        "wf-persist".into(),
-        "h1".into(),
-        Bytes::from(r#""1""#),
-    );
+    let mut snap =
+        WorkflowSnapshot::with_initial_input("wf-persist", "h1".into(), Bytes::from(r#""1""#));
     snap.update_position(ExecutionPosition::AtTask {
         task_id: sayiir_core::TaskId::from("t1"),
     });
@@ -816,7 +798,7 @@ async fn find_available_tasks_disjoint_tags_no_match() {
 
     // Task tagged ["cpu"]
     let mut snap =
-        WorkflowSnapshot::with_initial_input("wf-cpu".into(), "h1".into(), Bytes::from(r#""1""#));
+        WorkflowSnapshot::with_initial_input("wf-cpu", "h1".into(), Bytes::from(r#""1""#));
     snap.update_position(ExecutionPosition::AtTask {
         task_id: sayiir_core::TaskId::from("t1"),
     });
@@ -836,7 +818,7 @@ async fn find_available_tasks_disjoint_tags_no_match() {
 #[tokio::test]
 async fn load_task_result_in_progress() {
     let (_c, backend) = setup().await;
-    let mut snapshot = WorkflowSnapshot::new("wf-1".into(), "hash-1".into());
+    let mut snapshot = WorkflowSnapshot::new("wf-1", "hash-1".into());
     snapshot.mark_task_completed(
         sayiir_core::TaskId::from("task-1"),
         Bytes::from(r#""out1""#),
@@ -853,7 +835,7 @@ async fn load_task_result_in_progress() {
 #[tokio::test]
 async fn load_task_result_not_found() {
     let (_c, backend) = setup().await;
-    let snapshot = WorkflowSnapshot::new("wf-1".into(), "hash-1".into());
+    let snapshot = WorkflowSnapshot::new("wf-1", "hash-1".into());
     backend.save_snapshot(&snapshot).await.unwrap();
 
     let result = backend
@@ -877,7 +859,7 @@ async fn load_task_result_after_completion() {
     let (_c, backend) = setup().await;
 
     // Create workflow with a completed task
-    let mut snapshot = WorkflowSnapshot::new("wf-1".into(), "hash-1".into());
+    let mut snapshot = WorkflowSnapshot::new("wf-1", "hash-1".into());
     snapshot.mark_task_completed(
         sayiir_core::TaskId::from("task-1"),
         Bytes::from(r#""out1""#),
@@ -905,14 +887,14 @@ async fn works_on_minimum_pg_version() {
     let (_c, backend) = setup_with(MIN_PG_VERSION).await;
 
     // Snapshot CRUD
-    let snapshot = WorkflowSnapshot::new("min-pg-1".into(), "hash".into());
+    let snapshot = WorkflowSnapshot::new("min-pg-1", "hash".into());
     backend.save_snapshot(&snapshot).await.unwrap();
     let loaded = backend.load_snapshot("min-pg-1").await.unwrap();
-    assert_eq!(loaded.instance_id, "min-pg-1");
+    assert_eq!(&*loaded.instance_id, "min-pg-1");
     backend.delete_snapshot("min-pg-1").await.unwrap();
 
     // Signals
-    let snapshot = WorkflowSnapshot::new("min-pg-2".into(), "hash".into());
+    let snapshot = WorkflowSnapshot::new("min-pg-2", "hash".into());
     backend.save_snapshot(&snapshot).await.unwrap();
     backend
         .store_signal(
@@ -969,7 +951,7 @@ async fn save_snapshot_emits_notify_only_when_poll_eligible() {
     listener.listen("sayiir_task_ready").await.unwrap();
 
     // 1) Fresh NotStarted snapshot — must not notify.
-    let snapshot = WorkflowSnapshot::new("wf-notify".into(), "h".into());
+    let snapshot = WorkflowSnapshot::new("wf-notify", "h".into());
     backend.save_snapshot(&snapshot).await.unwrap();
     let no_notify = tokio::time::timeout(Duration::from_millis(150), listener.recv()).await;
     assert!(
@@ -993,7 +975,7 @@ async fn save_snapshot_emits_notify_only_when_poll_eligible() {
     assert_eq!(notif.channel(), "sayiir_task_ready");
     let hint = sayiir_persistence::TaskWakeupHint::decode(notif.payload())
         .expect("payload must decode to a TaskWakeupHint");
-    assert_eq!(hint.instance_id, "wf-notify");
+    assert_eq!(&*hint.instance_id, "wf-notify");
     assert_eq!(hint.task_id, "step-1");
     assert_eq!(hint.definition_hash, "h");
 
@@ -1027,7 +1009,7 @@ async fn wait_for_wakeup_returns_on_notify() {
 
     let producer = tokio::spawn(async move {
         sleep(Duration::from_millis(150)).await;
-        let mut snapshot = WorkflowSnapshot::new("wf-wake".into(), "h".into());
+        let mut snapshot = WorkflowSnapshot::new("wf-wake", "h".into());
         snapshot.update_position(ExecutionPosition::AtTask {
             task_id: sayiir_core::TaskId::from("step-1"),
         });
@@ -1090,7 +1072,7 @@ async fn wait_for_wakeup_delivers_parsed_hint() {
 
     let producer = tokio::spawn(async move {
         sleep(Duration::from_millis(100)).await;
-        let mut snapshot = WorkflowSnapshot::new("wf-hinted".into(), "h-xyz".into());
+        let mut snapshot = WorkflowSnapshot::new("wf-hinted", "h-xyz".into());
         snapshot.update_position(ExecutionPosition::AtTask {
             task_id: sayiir_core::TaskId::from("task-a"),
         });
@@ -1104,7 +1086,7 @@ async fn wait_for_wakeup_delivers_parsed_hint() {
         .expect("expected a hint from the NOTIFY");
     producer.await.unwrap();
 
-    assert_eq!(hint.instance_id, "wf-hinted");
+    assert_eq!(&*hint.instance_id, "wf-hinted");
     assert_eq!(hint.task_id, "task-a");
     assert_eq!(hint.definition_hash, "h-xyz");
 }
@@ -1117,7 +1099,7 @@ async fn find_hinted_task_returns_available_task() {
 
     let (_c, backend) = setup().await;
     let mut snapshot = WorkflowSnapshot::with_initial_input(
-        "wf-hint-found".into(),
+        "wf-hint-found",
         "h".into(),
         Bytes::from_static(b"\"input\""),
     );
@@ -1137,7 +1119,7 @@ async fn find_hinted_task_returns_available_task() {
         .await
         .unwrap()
         .expect("hinted task should still be eligible");
-    assert_eq!(task.instance_id, "wf-hint-found");
+    assert_eq!(&*task.instance_id, "wf-hint-found");
     assert_eq!(task.task_id, sayiir_core::TaskId::from("first"));
     assert_eq!(
         task.workflow_definition_hash,
@@ -1153,7 +1135,7 @@ async fn find_hinted_task_returns_none_when_stale() {
     use sayiir_persistence::TaskWakeupHint;
 
     let (_c, backend) = setup().await;
-    let mut snapshot = WorkflowSnapshot::new("wf-stale".into(), "h".into());
+    let mut snapshot = WorkflowSnapshot::new("wf-stale", "h".into());
     snapshot.update_position(ExecutionPosition::AtTask {
         task_id: sayiir_core::TaskId::from("second"),
     });
@@ -1177,7 +1159,7 @@ async fn find_hinted_task_returns_none_when_claimed() {
     use sayiir_persistence::TaskWakeupHint;
 
     let (_c, backend) = setup().await;
-    let mut snapshot = WorkflowSnapshot::new("wf-claimed".into(), "h".into());
+    let mut snapshot = WorkflowSnapshot::new("wf-claimed", "h".into());
     snapshot.update_position(ExecutionPosition::AtTask {
         task_id: sayiir_core::TaskId::from("first"),
     });

--- a/sayiir-postgres/tests/integration.rs
+++ b/sayiir-postgres/tests/integration.rs
@@ -976,8 +976,14 @@ async fn save_snapshot_emits_notify_only_when_poll_eligible() {
     let hint = sayiir_persistence::TaskWakeupHint::decode(notif.payload())
         .expect("payload must decode to a TaskWakeupHint");
     assert_eq!(&*hint.instance_id, "wf-notify");
-    assert_eq!(hint.task_id, "step-1");
-    assert_eq!(hint.definition_hash, "h");
+    assert_eq!(
+        hint.task_id,
+        *sayiir_core::TaskId::from("step-1").as_bytes()
+    );
+    assert_eq!(
+        hint.definition_hash,
+        *sayiir_core::DefinitionHash::from("h").as_bytes()
+    );
 
     // 3) Terminal completion — must not notify.
     let mut snapshot = backend.load_snapshot("wf-notify").await.unwrap();
@@ -1087,8 +1093,14 @@ async fn wait_for_wakeup_delivers_parsed_hint() {
     producer.await.unwrap();
 
     assert_eq!(&*hint.instance_id, "wf-hinted");
-    assert_eq!(hint.task_id, "task-a");
-    assert_eq!(hint.definition_hash, "h-xyz");
+    assert_eq!(
+        hint.task_id,
+        *sayiir_core::TaskId::from("task-a").as_bytes()
+    );
+    assert_eq!(
+        hint.definition_hash,
+        *sayiir_core::DefinitionHash::from("h-xyz").as_bytes()
+    );
 }
 
 /// `find_hinted_task` must return an `AvailableTask` when the snapshot
@@ -1110,8 +1122,8 @@ async fn find_hinted_task_returns_available_task() {
 
     let hint = TaskWakeupHint {
         instance_id: "wf-hint-found".into(),
-        task_id: sayiir_core::TaskId::from("first").to_hex(),
-        definition_hash: "h".into(),
+        task_id: *sayiir_core::TaskId::from("first").as_bytes(),
+        definition_hash: *sayiir_core::DefinitionHash::from("h").as_bytes(),
         tags: vec![],
     };
     let task = backend
@@ -1144,8 +1156,8 @@ async fn find_hinted_task_returns_none_when_stale() {
     // Hint targets a task the workflow is no longer at — should be skipped.
     let hint = TaskWakeupHint {
         instance_id: "wf-stale".into(),
-        task_id: sayiir_core::TaskId::from("first").to_hex(),
-        definition_hash: "h".into(),
+        task_id: *sayiir_core::TaskId::from("first").as_bytes(),
+        definition_hash: *sayiir_core::DefinitionHash::from("h").as_bytes(),
         tags: vec![],
     };
     assert!(backend.find_hinted_task(&hint).await.unwrap().is_none());
@@ -1178,8 +1190,8 @@ async fn find_hinted_task_returns_none_when_claimed() {
 
     let hint = TaskWakeupHint {
         instance_id: "wf-claimed".into(),
-        task_id: sayiir_core::TaskId::from("first").to_hex(),
-        definition_hash: "h".into(),
+        task_id: *sayiir_core::TaskId::from("first").as_bytes(),
+        definition_hash: *sayiir_core::DefinitionHash::from("h").as_bytes(),
         tags: vec![],
     };
     assert!(backend.find_hinted_task(&hint).await.unwrap().is_none());

--- a/sayiir-postgres/tests/integration.rs
+++ b/sayiir-postgres/tests/integration.rs
@@ -78,7 +78,7 @@ async fn save_snapshot_overwrites() {
     backend.save_snapshot(&snapshot).await.unwrap();
 
     snapshot.update_position(ExecutionPosition::AtTask {
-        task_id: "step-2".into(),
+        task_id: sayiir_core::TaskId::from("step-2"),
     });
     backend.save_snapshot(&snapshot).await.unwrap();
 
@@ -86,7 +86,9 @@ async fn save_snapshot_overwrites() {
     match &loaded.state {
         sayiir_core::snapshot::WorkflowSnapshotState::InProgress { position, .. } => match position
         {
-            ExecutionPosition::AtTask { task_id } => assert_eq!(task_id, "step-2"),
+            ExecutionPosition::AtTask { task_id } => {
+                assert_eq!(*task_id, sayiir_core::TaskId::from("step-2"))
+            }
             other => panic!("expected AtTask, got {other:?}"),
         },
         other => panic!("expected InProgress, got {other:?}"),
@@ -134,17 +136,21 @@ async fn save_task_result() {
     let (_c, backend) = setup().await;
     let mut snapshot = WorkflowSnapshot::new("wf-1".into(), "hash-1".into());
     snapshot.update_position(ExecutionPosition::AtTask {
-        task_id: "task-1".into(),
+        task_id: sayiir_core::TaskId::from("task-1"),
     });
     backend.save_snapshot(&snapshot).await.unwrap();
 
     backend
-        .save_task_result("wf-1", "task-1", Bytes::from(r#""done""#))
+        .save_task_result(
+            "wf-1",
+            &sayiir_core::TaskId::from("task-1"),
+            Bytes::from(r#""done""#),
+        )
         .await
         .unwrap();
 
     let loaded = backend.load_snapshot("wf-1").await.unwrap();
-    let result = loaded.get_task_result("task-1");
+    let result = loaded.get_task_result(&sayiir_core::TaskId::from("task-1"));
     assert!(result.is_some());
     assert_eq!(result.unwrap().output, Bytes::from(r#""done""#));
 }
@@ -270,7 +276,7 @@ async fn check_and_cancel_success() {
         .unwrap();
 
     let cancelled = backend
-        .check_and_cancel("wf-1", Some("task-1"))
+        .check_and_cancel("wf-1", Some(sayiir_core::TaskId::from("task-1")))
         .await
         .unwrap();
     assert!(cancelled);
@@ -361,14 +367,19 @@ async fn claim_task_success() {
     let (_c, backend) = setup().await;
 
     let claim = backend
-        .claim_task("wf-1", "task-1", "worker-1", Some(Duration::seconds(300)))
+        .claim_task(
+            "wf-1",
+            &sayiir_core::TaskId::from("task-1"),
+            "worker-1",
+            Some(Duration::seconds(300)),
+        )
         .await
         .unwrap();
 
     assert!(claim.is_some());
     let claim = claim.unwrap();
     assert_eq!(claim.instance_id, "wf-1");
-    assert_eq!(claim.task_id, "task-1");
+    assert_eq!(claim.task_id, sayiir_core::TaskId::from("task-1"));
     assert_eq!(claim.worker_id, "worker-1");
     assert!(claim.expires_at.is_some());
 }
@@ -378,14 +389,24 @@ async fn claim_task_already_claimed() {
     let (_c, backend) = setup().await;
 
     let claim1 = backend
-        .claim_task("wf-1", "task-1", "worker-1", Some(Duration::seconds(300)))
+        .claim_task(
+            "wf-1",
+            &sayiir_core::TaskId::from("task-1"),
+            "worker-1",
+            Some(Duration::seconds(300)),
+        )
         .await
         .unwrap();
     assert!(claim1.is_some());
 
     // Second claim by different worker should fail
     let claim2 = backend
-        .claim_task("wf-1", "task-1", "worker-2", Some(Duration::seconds(300)))
+        .claim_task(
+            "wf-1",
+            &sayiir_core::TaskId::from("task-1"),
+            "worker-2",
+            Some(Duration::seconds(300)),
+        )
         .await
         .unwrap();
     assert!(claim2.is_none());
@@ -397,7 +418,12 @@ async fn claim_task_expired_claim_replaced() {
 
     // Claim with 1-second TTL then wait for it to expire
     backend
-        .claim_task("wf-1", "task-1", "worker-1", Some(Duration::seconds(1)))
+        .claim_task(
+            "wf-1",
+            &sayiir_core::TaskId::from("task-1"),
+            "worker-1",
+            Some(Duration::seconds(1)),
+        )
         .await
         .unwrap();
 
@@ -405,7 +431,12 @@ async fn claim_task_expired_claim_replaced() {
 
     // Second claim should succeed because first is expired
     let claim2 = backend
-        .claim_task("wf-1", "task-1", "worker-2", Some(Duration::seconds(300)))
+        .claim_task(
+            "wf-1",
+            &sayiir_core::TaskId::from("task-1"),
+            "worker-2",
+            Some(Duration::seconds(300)),
+        )
         .await
         .unwrap();
     assert!(claim2.is_some());
@@ -417,7 +448,12 @@ async fn claim_task_no_ttl() {
     let (_c, backend) = setup().await;
 
     let claim = backend
-        .claim_task("wf-1", "task-1", "worker-1", None)
+        .claim_task(
+            "wf-1",
+            &sayiir_core::TaskId::from("task-1"),
+            "worker-1",
+            None,
+        )
         .await
         .unwrap();
 
@@ -432,18 +468,28 @@ async fn release_task_claim() {
     let (_c, backend) = setup().await;
 
     backend
-        .claim_task("wf-1", "task-1", "worker-1", Some(Duration::seconds(300)))
+        .claim_task(
+            "wf-1",
+            &sayiir_core::TaskId::from("task-1"),
+            "worker-1",
+            Some(Duration::seconds(300)),
+        )
         .await
         .unwrap();
 
     backend
-        .release_task_claim("wf-1", "task-1", "worker-1")
+        .release_task_claim("wf-1", &sayiir_core::TaskId::from("task-1"), "worker-1")
         .await
         .unwrap();
 
     // Can claim again after release
     let claim = backend
-        .claim_task("wf-1", "task-1", "worker-2", Some(Duration::seconds(300)))
+        .claim_task(
+            "wf-1",
+            &sayiir_core::TaskId::from("task-1"),
+            "worker-2",
+            Some(Duration::seconds(300)),
+        )
         .await
         .unwrap();
     assert!(claim.is_some());
@@ -454,12 +500,17 @@ async fn release_task_claim_wrong_worker() {
     let (_c, backend) = setup().await;
 
     backend
-        .claim_task("wf-1", "task-1", "worker-1", Some(Duration::seconds(300)))
+        .claim_task(
+            "wf-1",
+            &sayiir_core::TaskId::from("task-1"),
+            "worker-1",
+            Some(Duration::seconds(300)),
+        )
         .await
         .unwrap();
 
     let result = backend
-        .release_task_claim("wf-1", "task-1", "worker-2")
+        .release_task_claim("wf-1", &sayiir_core::TaskId::from("task-1"), "worker-2")
         .await;
     assert!(matches!(result, Err(BackendError::Backend(_))));
 }
@@ -469,20 +520,35 @@ async fn extend_task_claim() {
     let (_c, backend) = setup().await;
 
     let claim = backend
-        .claim_task("wf-1", "task-1", "worker-1", Some(Duration::seconds(10)))
+        .claim_task(
+            "wf-1",
+            &sayiir_core::TaskId::from("task-1"),
+            "worker-1",
+            Some(Duration::seconds(10)),
+        )
         .await
         .unwrap()
         .unwrap();
     let original_expiry = claim.expires_at.unwrap();
 
     backend
-        .extend_task_claim("wf-1", "task-1", "worker-1", Duration::seconds(300))
+        .extend_task_claim(
+            "wf-1",
+            &sayiir_core::TaskId::from("task-1"),
+            "worker-1",
+            Duration::seconds(300),
+        )
         .await
         .unwrap();
 
     // Re-claim to verify extension (claim should fail since it's still held)
     let reclaim = backend
-        .claim_task("wf-1", "task-1", "worker-2", Some(Duration::seconds(10)))
+        .claim_task(
+            "wf-1",
+            &sayiir_core::TaskId::from("task-1"),
+            "worker-2",
+            Some(Duration::seconds(10)),
+        )
         .await
         .unwrap();
     assert!(reclaim.is_none(), "claim should still be held after extend");
@@ -495,12 +561,22 @@ async fn extend_task_claim_wrong_worker() {
     let (_c, backend) = setup().await;
 
     backend
-        .claim_task("wf-1", "task-1", "worker-1", Some(Duration::seconds(300)))
+        .claim_task(
+            "wf-1",
+            &sayiir_core::TaskId::from("task-1"),
+            "worker-1",
+            Some(Duration::seconds(300)),
+        )
         .await
         .unwrap();
 
     let result = backend
-        .extend_task_claim("wf-1", "task-1", "worker-2", Duration::seconds(300))
+        .extend_task_claim(
+            "wf-1",
+            &sayiir_core::TaskId::from("task-1"),
+            "worker-2",
+            Duration::seconds(300),
+        )
         .await;
     assert!(matches!(result, Err(BackendError::Backend(_))));
 }
@@ -515,7 +591,7 @@ async fn find_available_tasks_basic() {
         Bytes::from(r#""input""#),
     );
     snapshot.update_position(ExecutionPosition::AtTask {
-        task_id: "task-1".into(),
+        task_id: sayiir_core::TaskId::from("task-1"),
     });
     backend.save_snapshot(&snapshot).await.unwrap();
 
@@ -525,7 +601,7 @@ async fn find_available_tasks_basic() {
         .unwrap();
     assert_eq!(tasks.len(), 1);
     assert_eq!(tasks[0].instance_id, "wf-1");
-    assert_eq!(tasks[0].task_id, "task-1");
+    assert_eq!(tasks[0].task_id, sayiir_core::TaskId::from("task-1"));
 }
 
 #[tokio::test]
@@ -539,7 +615,7 @@ async fn find_available_tasks_skips_cancelled() {
         Bytes::from(r#""input""#),
     );
     snapshot1.update_position(ExecutionPosition::AtTask {
-        task_id: "task-1".into(),
+        task_id: sayiir_core::TaskId::from("task-1"),
     });
     backend.save_snapshot(&snapshot1).await.unwrap();
     backend
@@ -554,7 +630,7 @@ async fn find_available_tasks_skips_cancelled() {
         Bytes::from(r#""input""#),
     );
     snapshot2.update_position(ExecutionPosition::AtTask {
-        task_id: "task-2".into(),
+        task_id: sayiir_core::TaskId::from("task-2"),
     });
     backend.save_snapshot(&snapshot2).await.unwrap();
 
@@ -591,7 +667,7 @@ async fn find_available_tasks_filters_by_worker_tags() {
     let mut snap1 =
         WorkflowSnapshot::with_initial_input("wf-gpu".into(), "h1".into(), Bytes::from(r#""1""#));
     snap1.update_position(ExecutionPosition::AtTask {
-        task_id: "t1".into(),
+        task_id: sayiir_core::TaskId::from("t1"),
     });
     snap1.task_tags = vec!["gpu".into()];
     backend.save_snapshot(&snap1).await.unwrap();
@@ -600,7 +676,7 @@ async fn find_available_tasks_filters_by_worker_tags() {
     let mut snap2 =
         WorkflowSnapshot::with_initial_input("wf-cpu".into(), "h1".into(), Bytes::from(r#""2""#));
     snap2.update_position(ExecutionPosition::AtTask {
-        task_id: "t2".into(),
+        task_id: sayiir_core::TaskId::from("t2"),
     });
     snap2.task_tags = vec!["cpu".into()];
     backend.save_snapshot(&snap2).await.unwrap();
@@ -624,7 +700,7 @@ async fn find_available_tasks_untagged_worker_accepts_all() {
         Bytes::from(r#""1""#),
     );
     snap1.update_position(ExecutionPosition::AtTask {
-        task_id: "t1".into(),
+        task_id: sayiir_core::TaskId::from("t1"),
     });
     snap1.task_tags = vec!["gpu".into()];
     backend.save_snapshot(&snap1).await.unwrap();
@@ -632,7 +708,7 @@ async fn find_available_tasks_untagged_worker_accepts_all() {
     let mut snap2 =
         WorkflowSnapshot::with_initial_input("wf-plain".into(), "h1".into(), Bytes::from(r#""2""#));
     snap2.update_position(ExecutionPosition::AtTask {
-        task_id: "t2".into(),
+        task_id: sayiir_core::TaskId::from("t2"),
     });
     backend.save_snapshot(&snap2).await.unwrap();
 
@@ -652,7 +728,7 @@ async fn find_available_tasks_untagged_tasks_accepted_by_tagged_worker() {
     let mut snap =
         WorkflowSnapshot::with_initial_input("wf-plain".into(), "h1".into(), Bytes::from(r#""1""#));
     snap.update_position(ExecutionPosition::AtTask {
-        task_id: "t1".into(),
+        task_id: sayiir_core::TaskId::from("t1"),
     });
     backend.save_snapshot(&snap).await.unwrap();
 
@@ -673,7 +749,7 @@ async fn find_available_tasks_multi_tag_subset() {
     let mut snap1 =
         WorkflowSnapshot::with_initial_input("wf-multi".into(), "h1".into(), Bytes::from(r#""1""#));
     snap1.update_position(ExecutionPosition::AtTask {
-        task_id: "t1".into(),
+        task_id: sayiir_core::TaskId::from("t1"),
     });
     snap1.task_tags = vec!["gpu".into(), "cuda".into()];
     backend.save_snapshot(&snap1).await.unwrap();
@@ -685,7 +761,7 @@ async fn find_available_tasks_multi_tag_subset() {
         Bytes::from(r#""2""#),
     );
     snap2.update_position(ExecutionPosition::AtTask {
-        task_id: "t2".into(),
+        task_id: sayiir_core::TaskId::from("t2"),
     });
     snap2.task_tags = vec!["gpu".into()];
     backend.save_snapshot(&snap2).await.unwrap();
@@ -721,7 +797,7 @@ async fn find_available_tasks_tags_persist_through_save_load() {
         Bytes::from(r#""1""#),
     );
     snap.update_position(ExecutionPosition::AtTask {
-        task_id: "t1".into(),
+        task_id: sayiir_core::TaskId::from("t1"),
     });
     snap.task_tags = vec!["gpu".into(), "cuda".into()];
     backend.save_snapshot(&snap).await.unwrap();
@@ -742,7 +818,7 @@ async fn find_available_tasks_disjoint_tags_no_match() {
     let mut snap =
         WorkflowSnapshot::with_initial_input("wf-cpu".into(), "h1".into(), Bytes::from(r#""1""#));
     snap.update_position(ExecutionPosition::AtTask {
-        task_id: "t1".into(),
+        task_id: sayiir_core::TaskId::from("t1"),
     });
     snap.task_tags = vec!["cpu".into()];
     backend.save_snapshot(&snap).await.unwrap();
@@ -761,10 +837,16 @@ async fn find_available_tasks_disjoint_tags_no_match() {
 async fn load_task_result_in_progress() {
     let (_c, backend) = setup().await;
     let mut snapshot = WorkflowSnapshot::new("wf-1".into(), "hash-1".into());
-    snapshot.mark_task_completed("task-1".into(), Bytes::from(r#""out1""#));
+    snapshot.mark_task_completed(
+        sayiir_core::TaskId::from("task-1"),
+        Bytes::from(r#""out1""#),
+    );
     backend.save_snapshot(&snapshot).await.unwrap();
 
-    let result = backend.load_task_result("wf-1", "task-1").await.unwrap();
+    let result = backend
+        .load_task_result("wf-1", &sayiir_core::TaskId::from("task-1"))
+        .await
+        .unwrap();
     assert_eq!(result, Some(Bytes::from(r#""out1""#)));
 }
 
@@ -775,7 +857,7 @@ async fn load_task_result_not_found() {
     backend.save_snapshot(&snapshot).await.unwrap();
 
     let result = backend
-        .load_task_result("wf-1", "no-such-task")
+        .load_task_result("wf-1", &sayiir_core::TaskId::from("no-such-task"))
         .await
         .unwrap();
     assert!(result.is_none());
@@ -784,7 +866,9 @@ async fn load_task_result_not_found() {
 #[tokio::test]
 async fn load_task_result_nonexistent_instance() {
     let (_c, backend) = setup().await;
-    let result = backend.load_task_result("no-such-wf", "task-1").await;
+    let result = backend
+        .load_task_result("no-such-wf", &sayiir_core::TaskId::from("task-1"))
+        .await;
     assert!(matches!(result, Err(BackendError::NotFound(_))));
 }
 
@@ -794,7 +878,10 @@ async fn load_task_result_after_completion() {
 
     // Create workflow with a completed task
     let mut snapshot = WorkflowSnapshot::new("wf-1".into(), "hash-1".into());
-    snapshot.mark_task_completed("task-1".into(), Bytes::from(r#""out1""#));
+    snapshot.mark_task_completed(
+        sayiir_core::TaskId::from("task-1"),
+        Bytes::from(r#""out1""#),
+    );
     backend.save_snapshot(&snapshot).await.unwrap();
 
     // Complete the workflow
@@ -802,7 +889,10 @@ async fn load_task_result_after_completion() {
     backend.save_snapshot(&snapshot).await.unwrap();
 
     // Task result should still be accessible from history
-    let result = backend.load_task_result("wf-1", "task-1").await.unwrap();
+    let result = backend
+        .load_task_result("wf-1", &sayiir_core::TaskId::from("task-1"))
+        .await
+        .unwrap();
     assert_eq!(result, Some(Bytes::from(r#""out1""#)));
 }
 
@@ -833,7 +923,7 @@ async fn works_on_minimum_pg_version() {
         .await
         .unwrap();
     let cancelled = backend
-        .check_and_cancel("min-pg-2", Some("task-1"))
+        .check_and_cancel("min-pg-2", Some(sayiir_core::TaskId::from("task-1")))
         .await
         .unwrap();
     assert!(cancelled);
@@ -842,7 +932,7 @@ async fn works_on_minimum_pg_version() {
     let claim = backend
         .claim_task(
             "min-pg-3",
-            "task-1",
+            &sayiir_core::TaskId::from("task-1"),
             "worker-1",
             Some(Duration::seconds(60)),
         )
@@ -893,7 +983,7 @@ async fn save_snapshot_emits_notify_only_when_poll_eligible() {
     //    definition_hash.
     let mut snapshot = backend.load_snapshot("wf-notify").await.unwrap();
     snapshot.update_position(ExecutionPosition::AtTask {
-        task_id: "step-1".into(),
+        task_id: sayiir_core::TaskId::from("step-1"),
     });
     backend.save_snapshot(&snapshot).await.unwrap();
     let notif = tokio::time::timeout(Duration::from_secs(1), listener.recv())
@@ -939,7 +1029,7 @@ async fn wait_for_wakeup_returns_on_notify() {
         sleep(Duration::from_millis(150)).await;
         let mut snapshot = WorkflowSnapshot::new("wf-wake".into(), "h".into());
         snapshot.update_position(ExecutionPosition::AtTask {
-            task_id: "step-1".into(),
+            task_id: sayiir_core::TaskId::from("step-1"),
         });
         backend2.save_snapshot(&snapshot).await.unwrap();
     });
@@ -1002,7 +1092,7 @@ async fn wait_for_wakeup_delivers_parsed_hint() {
         sleep(Duration::from_millis(100)).await;
         let mut snapshot = WorkflowSnapshot::new("wf-hinted".into(), "h-xyz".into());
         snapshot.update_position(ExecutionPosition::AtTask {
-            task_id: "task-a".into(),
+            task_id: sayiir_core::TaskId::from("task-a"),
         });
         backend2.save_snapshot(&snapshot).await.unwrap();
     });
@@ -1032,13 +1122,13 @@ async fn find_hinted_task_returns_available_task() {
         Bytes::from_static(b"\"input\""),
     );
     snapshot.update_position(ExecutionPosition::AtTask {
-        task_id: "first".into(),
+        task_id: sayiir_core::TaskId::from("first"),
     });
     backend.save_snapshot(&snapshot).await.unwrap();
 
     let hint = TaskWakeupHint {
         instance_id: "wf-hint-found".into(),
-        task_id: "first".into(),
+        task_id: sayiir_core::TaskId::from("first").to_hex(),
         definition_hash: "h".into(),
         tags: vec![],
     };
@@ -1048,7 +1138,7 @@ async fn find_hinted_task_returns_available_task() {
         .unwrap()
         .expect("hinted task should still be eligible");
     assert_eq!(task.instance_id, "wf-hint-found");
-    assert_eq!(task.task_id, "first");
+    assert_eq!(task.task_id, sayiir_core::TaskId::from("first"));
     assert_eq!(
         task.workflow_definition_hash,
         sayiir_core::DefinitionHash::from("h")
@@ -1065,14 +1155,14 @@ async fn find_hinted_task_returns_none_when_stale() {
     let (_c, backend) = setup().await;
     let mut snapshot = WorkflowSnapshot::new("wf-stale".into(), "h".into());
     snapshot.update_position(ExecutionPosition::AtTask {
-        task_id: "second".into(),
+        task_id: sayiir_core::TaskId::from("second"),
     });
     backend.save_snapshot(&snapshot).await.unwrap();
 
     // Hint targets a task the workflow is no longer at — should be skipped.
     let hint = TaskWakeupHint {
         instance_id: "wf-stale".into(),
-        task_id: "first".into(),
+        task_id: sayiir_core::TaskId::from("first").to_hex(),
         definition_hash: "h".into(),
         tags: vec![],
     };
@@ -1089,19 +1179,24 @@ async fn find_hinted_task_returns_none_when_claimed() {
     let (_c, backend) = setup().await;
     let mut snapshot = WorkflowSnapshot::new("wf-claimed".into(), "h".into());
     snapshot.update_position(ExecutionPosition::AtTask {
-        task_id: "first".into(),
+        task_id: sayiir_core::TaskId::from("first"),
     });
     backend.save_snapshot(&snapshot).await.unwrap();
 
     backend
-        .claim_task("wf-claimed", "first", "other-worker", None)
+        .claim_task(
+            "wf-claimed",
+            &sayiir_core::TaskId::from("first"),
+            "other-worker",
+            None,
+        )
         .await
         .unwrap()
         .expect("first claim should succeed");
 
     let hint = TaskWakeupHint {
         instance_id: "wf-claimed".into(),
-        task_id: "first".into(),
+        task_id: sayiir_core::TaskId::from("first").to_hex(),
         definition_hash: "h".into(),
         tags: vec![],
     };

--- a/sayiir-postgres/tests/integration.rs
+++ b/sayiir-postgres/tests/integration.rs
@@ -57,7 +57,10 @@ async fn save_and_load_snapshot() {
     let loaded = backend.load_snapshot("test-1").await.unwrap();
 
     assert_eq!(loaded.instance_id, "test-1");
-    assert_eq!(loaded.definition_hash, "hash-1");
+    assert_eq!(
+        loaded.definition_hash,
+        sayiir_core::DefinitionHash::from("hash-1")
+    );
     assert!(loaded.state.is_in_progress());
 }
 

--- a/sayiir-py/src/backend.rs
+++ b/sayiir-py/src/backend.rs
@@ -183,7 +183,7 @@ impl SnapshotStore for BackendKind {
     async fn save_task_result(
         &self,
         instance_id: &str,
-        task_id: &str,
+        task_id: &sayiir_core::TaskId,
         output: bytes::Bytes,
     ) -> Result<(), BackendError> {
         dispatch!(self, |b| b
@@ -250,7 +250,7 @@ impl TaskClaimStore for BackendKind {
     async fn claim_task(
         &self,
         instance_id: &str,
-        task_id: &str,
+        task_id: &sayiir_core::TaskId,
         worker_id: &str,
         ttl: Option<chrono::Duration>,
     ) -> Result<Option<TaskClaim>, BackendError> {
@@ -262,7 +262,7 @@ impl TaskClaimStore for BackendKind {
     async fn release_task_claim(
         &self,
         instance_id: &str,
-        task_id: &str,
+        task_id: &sayiir_core::TaskId,
         worker_id: &str,
     ) -> Result<(), BackendError> {
         dispatch!(self, |b| b
@@ -273,7 +273,7 @@ impl TaskClaimStore for BackendKind {
     async fn extend_task_claim(
         &self,
         instance_id: &str,
-        task_id: &str,
+        task_id: &sayiir_core::TaskId,
         worker_id: &str,
         additional_duration: chrono::Duration,
     ) -> Result<(), BackendError> {
@@ -299,7 +299,7 @@ impl TaskResultStore for BackendKind {
     async fn load_task_result(
         &self,
         instance_id: &str,
-        task_id: &str,
+        task_id: &sayiir_core::TaskId,
     ) -> Result<Option<bytes::Bytes>, BackendError> {
         dispatch!(self, |b| b.load_task_result(instance_id, task_id).await)
     }

--- a/sayiir-py/src/durable_engine.rs
+++ b/sayiir-py/src/durable_engine.rs
@@ -147,7 +147,7 @@ impl PyDurableEngine {
             py.detach(|| {
                 self.runtime.block_on(async {
                     let mut snapshot = match prepare_run(
-                        instance_id,
+                        &instance_id,
                         definition_hash,
                         input_bytes.clone(),
                         first_task,

--- a/sayiir-py/src/durable_engine.rs
+++ b/sayiir-py/src/durable_engine.rs
@@ -419,7 +419,7 @@ fn make_task_executor<'a>(
             workflow_id: Arc::from(workflow_id),
             instance_id: Arc::from(instance_id),
             task_id: Arc::from(task_id),
-            metadata: continuation.build_task_metadata(task_id),
+            metadata: continuation.build_task_metadata(&sayiir_core::TaskId::from(task_id)),
             workflow_metadata_json: workflow_metadata_json.clone(),
         };
         Box::pin(async move {

--- a/sayiir-py/src/durable_engine.rs
+++ b/sayiir-py/src/durable_engine.rs
@@ -100,7 +100,7 @@ impl PyDurableEngine {
         task_registry: Py<PyDict>,
     ) -> PyResult<PyWorkflowStatus> {
         let continuation = Arc::clone(&workflow.continuation);
-        let definition_hash = workflow.definition_hash.clone();
+        let definition_hash = workflow.definition_hash;
         let first_task = continuation.first_task_hint();
         let registry = Arc::new(task_registry);
 
@@ -208,7 +208,7 @@ impl PyDurableEngine {
         task_registry: Py<PyDict>,
     ) -> PyResult<PyWorkflowStatus> {
         let continuation = Arc::clone(&workflow.continuation);
-        let definition_hash = workflow.definition_hash.clone();
+        let definition_hash = workflow.definition_hash;
         let workflow_id = workflow.workflow_id.clone();
         let workflow_metadata_json: Option<Arc<str>> =
             workflow.metadata_json.as_deref().map(Arc::from);

--- a/sayiir-py/src/engine.rs
+++ b/sayiir-py/src/engine.rs
@@ -171,7 +171,7 @@ impl PyWorkflowEngine {
                     workflow_id: Arc::clone(&workflow_id),
                     instance_id: Arc::clone(&workflow_id), // sync path: no instance_id
                     task_id: Arc::from(task_id),
-                    metadata: continuation.build_task_metadata(task_id),
+                    metadata: continuation.build_task_metadata(&sayiir_core::TaskId::from(task_id)),
                     workflow_metadata_json: workflow_metadata_json.clone(),
                 };
                 with_thread_local_task_context(task_ctx, || {

--- a/sayiir-py/src/flow.rs
+++ b/sayiir-py/src/flow.rs
@@ -50,6 +50,7 @@ pub struct PyWorkflow {
     pub(crate) workflow_id: String,
     pub(crate) definition_hash: sayiir_core::DefinitionHash,
     pub(crate) continuation: Arc<WorkflowContinuation>,
+    pub(crate) task_index: Arc<sayiir_core::TaskIndex>,
     pub(crate) metadata_json: Option<String>,
 }
 
@@ -270,10 +271,12 @@ impl PyFlowBuilder {
             "workflow built"
         );
 
+        let task_index = Arc::new(sayiir_core::TaskIndex::build(&continuation));
         Ok(PyWorkflow {
             workflow_id: self.workflow_id.clone(),
             definition_hash,
             continuation: Arc::new(continuation),
+            task_index,
             metadata_json: self.metadata_json.clone(),
         })
     }

--- a/sayiir-py/src/flow.rs
+++ b/sayiir-py/src/flow.rs
@@ -48,7 +48,7 @@ impl PyNodeInfo {
 #[pyclass]
 pub struct PyWorkflow {
     pub(crate) workflow_id: String,
-    pub(crate) definition_hash: String,
+    pub(crate) definition_hash: sayiir_core::DefinitionHash,
     pub(crate) continuation: Arc<WorkflowContinuation>,
     pub(crate) metadata_json: Option<String>,
 }
@@ -61,8 +61,8 @@ impl PyWorkflow {
     }
 
     #[getter]
-    fn definition_hash(&self) -> &str {
-        &self.definition_hash
+    fn definition_hash(&self) -> String {
+        self.definition_hash.to_hex()
     }
 
     #[getter]

--- a/sayiir-py/src/worker.rs
+++ b/sayiir-py/src/worker.rs
@@ -87,6 +87,7 @@ impl PyWorker {
                 wf.definition_hash,
                 ExternalWorkflow {
                     continuation: Arc::clone(&wf.continuation),
+                    task_index: Arc::clone(&wf.task_index),
                     workflow_id: Arc::from(wf.workflow_id.as_str()),
                     metadata_json: wf.metadata_json.as_deref().map(Arc::from),
                 },

--- a/sayiir-py/src/worker.rs
+++ b/sayiir-py/src/worker.rs
@@ -68,24 +68,26 @@ impl PyWorker {
     ///
     /// Args:
     ///     workflows: List of `(Workflow, task_registry_dict)` tuples
+    #[allow(clippy::too_many_lines)]
     fn start(
         &self,
         py: Python<'_>,
         workflows: Vec<(PyRef<'_, PyWorkflow>, Py<PyDict>)>,
     ) -> PyResult<PyWorkerHandle> {
         let mut external_workflows: WorkflowIndex = WorkflowIndex::with_capacity(workflows.len());
-        let mut registries: Vec<(String, Arc<Py<PyDict>>)> = Vec::with_capacity(workflows.len());
+        let mut registries: Vec<(sayiir_core::DefinitionHash, Arc<Py<PyDict>>)> =
+            Vec::with_capacity(workflows.len());
 
         for (wf, reg) in &workflows {
             external_workflows.insert(
-                wf.definition_hash.clone(),
+                wf.definition_hash,
                 ExternalWorkflow {
                     continuation: Arc::clone(&wf.continuation),
                     workflow_id: Arc::from(wf.workflow_id.as_str()),
                     metadata_json: wf.metadata_json.as_deref().map(Arc::from),
                 },
             );
-            registries.push((wf.definition_hash.clone(), Arc::new(reg.clone_ref(py))));
+            registries.push((wf.definition_hash, Arc::new(reg.clone_ref(py))));
         }
 
         let registries = Arc::new(registries);

--- a/sayiir-py/src/workflow_client.rs
+++ b/sayiir-py/src/workflow_client.rs
@@ -125,7 +125,7 @@ impl PyWorkflowClient {
             py.detach(|| {
                 self.runtime.block_on(async {
                     match prepare_run(
-                        instance_id,
+                        &instance_id,
                         definition_hash,
                         input_bytes,
                         first_task,

--- a/sayiir-py/src/workflow_client.rs
+++ b/sayiir-py/src/workflow_client.rs
@@ -246,11 +246,15 @@ impl PyWorkflowClient {
         instance_id: String,
         task_id: String,
     ) -> PyResult<Option<Py<PyAny>>> {
-        let bytes = with_backend!(self, |backend| {
-            self.runtime
-                .block_on(backend.load_task_result(&instance_id, &task_id))
-                .map_err(backend_err_to_py)?
-        });
+        let bytes =
+            with_backend!(self, |backend| {
+                self.runtime
+                    .block_on(backend.load_task_result(
+                        &instance_id,
+                        &sayiir_core::TaskId::from(task_id.as_str()),
+                    ))
+                    .map_err(backend_err_to_py)?
+            });
         match bytes {
             Some(b) => Ok(Some(decode_to_pyobject(py, &b)?)),
             None => Ok(None),

--- a/sayiir-py/src/workflow_client.rs
+++ b/sayiir-py/src/workflow_client.rs
@@ -93,7 +93,7 @@ impl PyWorkflowClient {
         instance_id: String,
         input: &Bound<'_, PyAny>,
     ) -> PyResult<PyWorkflowStatus> {
-        let definition_hash = workflow.definition_hash.clone();
+        let definition_hash = workflow.definition_hash;
         let first_task = workflow.continuation.first_task_hint();
         let conflict_policy = self.conflict_policy;
 

--- a/sayiir-runtime/src/client.rs
+++ b/sayiir-runtime/src/client.rs
@@ -250,7 +250,10 @@ where
         instance_id: &str,
         task_id: &str,
     ) -> Result<Option<Bytes>, RuntimeError> {
-        Ok(self.backend.load_task_result(instance_id, task_id).await?)
+        Ok(self
+            .backend
+            .load_task_result(instance_id, &sayiir_core::TaskId::from(task_id))
+            .await?)
     }
 
     /// Type-safe variant of [`get_task_result`](Self::get_task_result) that

--- a/sayiir-runtime/src/client.rs
+++ b/sayiir-runtime/src/client.rs
@@ -110,7 +110,7 @@ where
         C: Codec + EnvelopeCodec + sealed::EncodeValue<Input> + 'static,
     {
         let instance_id = instance_id.into();
-        let definition_hash = workflow.definition_hash().to_string();
+        let definition_hash = *workflow.definition_hash();
         let conflict_policy = self.conflict_policy;
 
         // Phase 1: check for existing instance before encoding input.

--- a/sayiir-runtime/src/client.rs
+++ b/sayiir-runtime/src/client.rs
@@ -130,7 +130,7 @@ where
         let first_task = workflow.continuation().first_task_hint();
 
         match prepare_run(
-            instance_id,
+            &instance_id,
             definition_hash,
             input_bytes,
             first_task,

--- a/sayiir-runtime/src/error.rs
+++ b/sayiir-runtime/src/error.rs
@@ -1,5 +1,6 @@
 //! Typed error for the sayiir runtime layer.
 
+use sayiir_core::InvalidInstanceId;
 use sayiir_core::error::{BoxError, BuildError, BuildErrors, CodecError, WorkflowError};
 use sayiir_persistence::{BackendError, RunConflict};
 
@@ -36,6 +37,10 @@ pub enum RuntimeError {
     /// A workflow instance with this ID already exists (conflict policy = Fail).
     #[error("Workflow instance already exists: {0}")]
     InstanceAlreadyExists(String),
+
+    /// The supplied workflow `instance_id` failed the API-boundary length check.
+    #[error(transparent)]
+    InvalidInstanceId(#[from] InvalidInstanceId),
 }
 
 impl From<BoxError> for RuntimeError {
@@ -56,6 +61,7 @@ impl From<BuildError> for RuntimeError {
 impl From<RunConflict> for RuntimeError {
     fn from(error: RunConflict) -> Self {
         match error {
+            RunConflict::InvalidInstanceId(e) => Self::InvalidInstanceId(e),
             RunConflict::AlreadyExists(id) => Self::InstanceAlreadyExists(id),
             RunConflict::DefinitionMismatch { expected, found } => {
                 Self::Workflow(WorkflowError::DefinitionMismatch { expected, found })

--- a/sayiir-runtime/src/execution/control_flow.rs
+++ b/sayiir-runtime/src/execution/control_flow.rs
@@ -18,7 +18,7 @@ use crate::error::RuntimeError;
 pub(crate) enum ParkReason {
     /// A durable delay that hasn't expired yet.
     Delay {
-        delay_id: String,
+        delay_id: sayiir_core::TaskId,
         wake_at: DateTime<Utc>,
         /// Pre-computed hint for the next task (priority + tags for persistence-layer advancement).
         next_task: Option<TaskHint>,
@@ -27,7 +27,7 @@ pub(crate) enum ParkReason {
     },
     /// Waiting for an external signal that hasn't arrived yet.
     AwaitingSignal {
-        signal_id: String,
+        signal_id: sayiir_core::TaskId,
         signal_name: String,
         timeout: Option<DateTime<Utc>>,
         /// Pre-computed hint for the next task (priority + tags for persistence-layer advancement).
@@ -89,11 +89,11 @@ pub(crate) async fn save_park_checkpoint<B: SnapshotStore>(
             next_task,
             passthrough,
         } => {
-            let next_task_id = next_task.as_ref().map(|h| h.id.clone());
+            let next_task_id = next_task.as_ref().map(|h| h.id);
             snapshot.set_task_hint(next_task.as_ref().unwrap_or(&TaskHint::default()));
             let now = Utc::now();
             snapshot.update_position(ExecutionPosition::AtDelay {
-                delay_id: delay_id.clone(),
+                delay_id,
                 entered_at: now,
                 wake_at,
                 next_task_id,
@@ -110,10 +110,10 @@ pub(crate) async fn save_park_checkpoint<B: SnapshotStore>(
             timeout,
             next_task,
         } => {
-            let next_task_id = next_task.as_ref().map(|h| h.id.clone());
+            let next_task_id = next_task.as_ref().map(|h| h.id);
             snapshot.set_task_hint(next_task.as_ref().unwrap_or(&TaskHint::default()));
             snapshot.update_position(ExecutionPosition::AtSignal {
-                signal_id: signal_id.clone(),
+                signal_id,
                 signal_name: signal_name.clone(),
                 wake_at: timeout,
                 next_task_id,

--- a/sayiir-runtime/src/execution/executors.rs
+++ b/sayiir-runtime/src/execution/executors.rs
@@ -199,7 +199,7 @@ where
                     // prevents this today, but the guard keeps the code
                     // structurally sound — matching run_loop_async).
                     return Err(WorkflowError::MaxIterationsExceeded {
-                        loop_id: id.clone(),
+                        loop_id: sayiir_core::TaskId::from(id),
                         max_iterations: *max_iterations,
                     }
                     .into());
@@ -266,7 +266,7 @@ async fn run_task_with_retry(
             match tokio::time::timeout(*d, func.run(task_input)).await {
                 Ok(result) => result.map_err(RuntimeError::from),
                 Err(_) => Err(WorkflowError::TaskTimedOut {
-                    task_id: id.to_string(),
+                    task_id: sayiir_core::TaskId::from(id),
                     timeout: *d,
                 }
                 .into()),
@@ -555,14 +555,22 @@ where
                 Ok(ControlFlow::Continue(output))
             }
             WorkflowContinuation::Delay { id, duration, next } => {
-                check_guards(backend, &snapshot.instance_id, Some(id)).await?;
+                check_guards(
+                    backend,
+                    &snapshot.instance_id,
+                    Some(sayiir_core::TaskId::from(id)),
+                )
+                .await?;
 
-                if snapshot.get_task_result(id).is_some() {
+                if snapshot
+                    .get_task_result(&sayiir_core::TaskId::from(id))
+                    .is_some()
+                {
                     Ok(ControlFlow::Continue(current_input.clone()))
                 } else {
                     let wake_at = compute_wake_at(duration)?;
                     Ok(ControlFlow::Break(StepOutcome::Park(ParkReason::Delay {
-                        delay_id: id.clone(),
+                        delay_id: sayiir_core::TaskId::from(id),
                         wake_at,
                         next_task: next.as_deref().map(WorkflowContinuation::first_task_hint),
                         passthrough: current_input.clone(),
@@ -575,11 +583,19 @@ where
                 timeout,
                 next,
             } => {
-                check_guards(backend, &snapshot.instance_id, Some(id)).await?;
+                check_guards(
+                    backend,
+                    &snapshot.instance_id,
+                    Some(sayiir_core::TaskId::from(id)),
+                )
+                .await?;
 
-                if snapshot.get_task_result(id).is_some() {
+                if snapshot
+                    .get_task_result(&sayiir_core::TaskId::from(id))
+                    .is_some()
+                {
                     let payload = snapshot
-                        .get_task_result_bytes(id)
+                        .get_task_result_bytes(&sayiir_core::TaskId::from(id))
                         .unwrap_or(current_input.clone());
                     Ok(ControlFlow::Continue(payload))
                 } else {
@@ -589,23 +605,23 @@ where
                         .await
                     {
                         Ok(Some(payload)) => {
-                            snapshot.mark_task_completed(id.clone(), payload);
+                            snapshot.mark_task_completed(sayiir_core::TaskId::from(id), payload);
                             if let Some(next_cont) = next.as_deref() {
                                 let hint = next_cont.first_task_hint();
                                 snapshot.update_position(ExecutionPosition::AtTask {
-                                    task_id: hint.id.clone(),
+                                    task_id: hint.id,
                                 });
                                 snapshot.set_task_hint(&hint);
                             }
                             backend.save_snapshot(snapshot).await?;
                             let output = snapshot
-                                .get_task_result_bytes(id)
+                                .get_task_result_bytes(&sayiir_core::TaskId::from(id))
                                 .unwrap_or(current_input.clone());
                             Ok(ControlFlow::Continue(output))
                         }
                         Ok(None) => Ok(ControlFlow::Break(StepOutcome::Park(
                             ParkReason::AwaitingSignal {
-                                signal_id: id.clone(),
+                                signal_id: sayiir_core::TaskId::from(id),
                                 signal_name: signal_name.clone(),
                                 timeout: compute_signal_timeout(timeout.as_ref()),
                                 next_task: next
@@ -654,9 +670,14 @@ where
                 default,
                 ..
             } => {
-                check_guards(backend, &snapshot.instance_id, Some(id)).await?;
+                check_guards(
+                    backend,
+                    &snapshot.instance_id,
+                    Some(sayiir_core::TaskId::from(id)),
+                )
+                .await?;
 
-                if let Some(result) = snapshot.get_task_result(id) {
+                if let Some(result) = snapshot.get_task_result(&sayiir_core::TaskId::from(id)) {
                     Ok(ControlFlow::Continue(result.output.clone()))
                 } else {
                     let key_bytes =
@@ -684,7 +705,8 @@ where
                         .encode_branch_envelope(&key, &branch_output)
                         .map_err(RuntimeError::from)?;
 
-                    snapshot.mark_task_completed(id.clone(), envelope_bytes.clone());
+                    snapshot
+                        .mark_task_completed(sayiir_core::TaskId::from(id), envelope_bytes.clone());
                     backend.save_snapshot(snapshot).await?;
 
                     Ok(ControlFlow::Continue(envelope_bytes))
@@ -697,11 +719,16 @@ where
                 on_max,
                 ..
             } => {
-                check_guards(backend, &snapshot.instance_id, Some(id)).await?;
+                check_guards(
+                    backend,
+                    &snapshot.instance_id,
+                    Some(sayiir_core::TaskId::from(id)),
+                )
+                .await?;
 
                 // Short-circuit: if the loop already completed (cached from a
                 // previous run), skip re-execution entirely.
-                if let Some(result) = snapshot.get_task_result(id) {
+                if let Some(result) = snapshot.get_task_result(&sayiir_core::TaskId::from(id)) {
                     Ok(ControlFlow::Continue(result.output.clone()))
                 } else {
                     let cfg = LoopConfig {
@@ -709,7 +736,7 @@ where
                         body,
                         max_iterations: *max_iterations,
                         on_max: *on_max,
-                        start_iteration: snapshot.loop_iteration(id),
+                        start_iteration: snapshot.loop_iteration(&sayiir_core::TaskId::from(id)),
                     };
                     let mut loop_input = current_input.clone();
                     let mut final_output = None;
@@ -727,23 +754,31 @@ where
 
                         let body_ser = body.to_serializable();
                         for tid in &body_ser.task_ids() {
-                            snapshot.remove_task_result(tid);
+                            snapshot.remove_task_result(&sayiir_core::TaskId::from(*tid));
                         }
 
                         match resolve_loop_iteration(&output, iteration, &cfg)? {
                             ControlFlow::Break(LoopExit(inner)) => {
-                                snapshot.clear_loop_iteration(id);
-                                snapshot.mark_task_completed(id.clone(), inner.clone());
+                                snapshot.clear_loop_iteration(&sayiir_core::TaskId::from(id));
+                                snapshot.mark_task_completed(
+                                    sayiir_core::TaskId::from(id),
+                                    inner.clone(),
+                                );
                                 backend.save_snapshot(snapshot).await?;
                                 final_output = Some(inner);
                                 break;
                             }
                             ControlFlow::Continue(LoopNext(inner)) => {
-                                snapshot.set_loop_iteration(id, iteration + 1);
+                                snapshot.set_loop_iteration(
+                                    sayiir_core::TaskId::from(id),
+                                    iteration + 1,
+                                );
                                 snapshot.update_position(ExecutionPosition::InLoop {
-                                    loop_id: id.clone(),
+                                    loop_id: sayiir_core::TaskId::from(id),
                                     iteration: iteration + 1,
-                                    next_task_id: Some(body.first_task_id().to_string()),
+                                    next_task_id: Some(sayiir_core::TaskId::from(
+                                        body.first_task_id(),
+                                    )),
                                 });
                                 backend.save_snapshot(snapshot).await?;
                                 loop_input = inner;
@@ -754,16 +789,21 @@ where
                     match final_output {
                         Some(output) => Ok(ControlFlow::Continue(output)),
                         None => Err(RuntimeError::from(WorkflowError::MaxIterationsExceeded {
-                            loop_id: id.clone(),
+                            loop_id: sayiir_core::TaskId::from(id),
                             max_iterations: *max_iterations,
                         })),
                     }
                 }
             }
             WorkflowContinuation::ChildWorkflow { id, child, .. } => {
-                check_guards(backend, &snapshot.instance_id, Some(id)).await?;
+                check_guards(
+                    backend,
+                    &snapshot.instance_id,
+                    Some(sayiir_core::TaskId::from(id)),
+                )
+                .await?;
 
-                if let Some(result) = snapshot.get_task_result(id) {
+                if let Some(result) = snapshot.get_task_result(&sayiir_core::TaskId::from(id)) {
                     Ok(ControlFlow::Continue(result.output.clone()))
                 } else {
                     let output = Box::pin(execute_continuation_with_checkpointing(
@@ -776,7 +816,7 @@ where
                     ))
                     .await?;
 
-                    snapshot.mark_task_completed(id.clone(), output.clone());
+                    snapshot.mark_task_completed(sayiir_core::TaskId::from(id), output.clone());
                     backend.save_snapshot(snapshot).await?;
 
                     Ok(ControlFlow::Continue(output))

--- a/sayiir-runtime/src/execution/fork.rs
+++ b/sayiir-runtime/src/execution/fork.rs
@@ -37,7 +37,7 @@ pub(crate) fn build_completed_branches(
             (
                 id.clone(),
                 TaskResult {
-                    task_id: id.clone(),
+                    task_id: sayiir_core::TaskId::from(id),
                     output: output.clone(),
                 },
             )
@@ -52,9 +52,10 @@ pub(crate) fn collect_cached_branches(
 ) -> Option<Vec<(String, Bytes)>> {
     let mut results = Vec::with_capacity(branches.len());
     for branch in branches {
-        let branch_id = branch.id().to_string();
-        if let Some(result) = snapshot.get_task_result(&branch_id) {
-            results.push((branch_id, result.output.clone()));
+        let branch_name = branch.id().to_string();
+        let branch_hash = sayiir_core::TaskId::from(branch_name.as_str());
+        if let Some(result) = snapshot.get_task_result(&branch_hash) {
+            results.push((branch_name, result.output.clone()));
         } else {
             return None;
         }
@@ -80,8 +81,9 @@ pub(crate) async fn park_at_fork<B: SnapshotStore>(
     backend: &B,
 ) -> RuntimeError {
     for (branch_id, output) in branch_results {
+        let branch_tid = sayiir_core::TaskId::from(branch_id.as_str());
         if let Err(e) = backend
-            .save_task_result(&snapshot.instance_id, branch_id, output.clone())
+            .save_task_result(&snapshot.instance_id, &branch_tid, output.clone())
             .await
         {
             return RuntimeError::from(e);
@@ -93,8 +95,9 @@ pub(crate) async fn park_at_fork<B: SnapshotStore>(
         Err(e) => return RuntimeError::from(e),
     };
 
+    let fork_id_tid = sayiir_core::TaskId::from(fork_id);
     updated_snapshot.update_position(ExecutionPosition::AtFork {
-        fork_id: fork_id.to_string(),
+        fork_id: fork_id_tid,
         completed_branches: build_completed_branches(branch_results),
         wake_at,
     });
@@ -117,12 +120,12 @@ pub(crate) async fn save_join_position<B: SnapshotStore>(
     backend: &B,
 ) -> Result<(), RuntimeError> {
     for (branch_id, output) in branch_results {
-        snapshot.mark_task_completed(branch_id.clone(), output.clone());
+        snapshot.mark_task_completed(sayiir_core::TaskId::from(branch_id), output.clone());
     }
 
     if let Some(join_cont) = join {
         snapshot.update_position(ExecutionPosition::AtJoin {
-            join_id: join_cont.first_task_id().to_string(),
+            join_id: sayiir_core::TaskId::from(join_cont.first_task_id()),
             completed_branches: build_completed_branches(branch_results),
         });
     }
@@ -167,10 +170,11 @@ where
     let instance_id = snapshot.instance_id.clone();
 
     for branch in branches {
-        let branch_id = branch.id().to_string();
+        let branch_name = branch.id().to_string();
+        let branch_hash = sayiir_core::TaskId::from(branch_name.as_str());
 
-        if let Some(result) = snapshot.get_task_result(&branch_id) {
-            branch_results.push((branch_id, result.output.clone()));
+        if let Some(result) = snapshot.get_task_result(&branch_hash) {
+            branch_results.push((branch_name, result.output.clone()));
             continue;
         }
 
@@ -185,11 +189,11 @@ where
         .await
         {
             Ok(output) => {
-                snapshot.mark_task_completed(branch_id.clone(), output.clone());
+                snapshot.mark_task_completed(branch_hash, output.clone());
                 backend
-                    .save_task_result(&instance_id, &branch_id, output.clone())
+                    .save_task_result(&instance_id, &branch_hash, output.clone())
                     .await?;
-                branch_results.push((branch_id, output));
+                branch_results.push((branch_name, output));
             }
             Err(RuntimeError::Workflow(WorkflowError::Waiting { wake_at })) => {
                 max_wake_at = Some(match max_wake_at {
@@ -376,13 +380,13 @@ where
                 Ok(ControlFlow::Continue(output))
             }
             WorkflowContinuation::Delay { id, duration, .. } => {
-                if let Some(result) = snapshot.get_task_result(id) {
+                if let Some(result) = snapshot.get_task_result(&sayiir_core::TaskId::from(id)) {
                     tracing::debug!(delay_id = %id, "delay already completed in branch, skipping");
                     Ok(ControlFlow::Continue(result.output.clone()))
                 } else {
                     let wake_at = compute_wake_at(duration)?;
                     Ok(ControlFlow::Break(StepOutcome::Park(ParkReason::Delay {
-                        delay_id: id.clone(),
+                        delay_id: sayiir_core::TaskId::from(id),
                         wake_at,
                         next_task: None,
                         passthrough: current_input.clone(),
@@ -395,14 +399,14 @@ where
                 timeout,
                 ..
             } => {
-                if let Some(result) = snapshot.get_task_result(id) {
+                if let Some(result) = snapshot.get_task_result(&sayiir_core::TaskId::from(id)) {
                     tracing::debug!(signal_id = %id, %signal_name, "signal already consumed in branch, skipping");
                     Ok(ControlFlow::Continue(result.output.clone()))
                 } else {
                     let wake_at = super::control_flow::compute_signal_timeout(timeout.as_ref());
                     Ok(ControlFlow::Break(StepOutcome::Park(
                         ParkReason::AwaitingSignal {
-                            signal_id: id.clone(),
+                            signal_id: sayiir_core::TaskId::from(id),
                             signal_name: signal_name.clone(),
                             timeout: wake_at,
                             next_task: None,
@@ -434,7 +438,7 @@ where
                 default,
                 ..
             } => {
-                if let Some(result) = snapshot.get_task_result(id) {
+                if let Some(result) = snapshot.get_task_result(&sayiir_core::TaskId::from(id)) {
                     Ok(ControlFlow::Continue(result.output.clone()))
                 } else {
                     let key_bytes =
@@ -464,7 +468,11 @@ where
                         .map_err(RuntimeError::from)?;
 
                     backend
-                        .save_task_result(instance_id, id, envelope_bytes.clone())
+                        .save_task_result(
+                            instance_id,
+                            &sayiir_core::TaskId::from(id),
+                            envelope_bytes.clone(),
+                        )
                         .await?;
 
                     Ok(ControlFlow::Continue(envelope_bytes))
@@ -477,7 +485,7 @@ where
                 on_max,
                 ..
             } => {
-                if let Some(result) = snapshot.get_task_result(id) {
+                if let Some(result) = snapshot.get_task_result(&sayiir_core::TaskId::from(id)) {
                     Ok(ControlFlow::Continue(result.output.clone()))
                 } else {
                     let cfg = LoopConfig {
@@ -485,7 +493,7 @@ where
                         body,
                         max_iterations: *max_iterations,
                         on_max: *on_max,
-                        start_iteration: snapshot.loop_iteration(id),
+                        start_iteration: snapshot.loop_iteration(&sayiir_core::TaskId::from(id)),
                     };
                     let mut hooks = CheckpointingLoopHooks {
                         snapshot: &mut snapshot,
@@ -512,7 +520,7 @@ where
                 }
             }
             WorkflowContinuation::ChildWorkflow { id, child, .. } => {
-                if let Some(result) = snapshot.get_task_result(id) {
+                if let Some(result) = snapshot.get_task_result(&sayiir_core::TaskId::from(id)) {
                     Ok(ControlFlow::Continue(result.output.clone()))
                 } else {
                     let output = Box::pin(execute_branch_with_checkpointing(
@@ -525,7 +533,7 @@ where
                     ))
                     .await?;
 
-                    snapshot.mark_task_completed(id.clone(), output.clone());
+                    snapshot.mark_task_completed(sayiir_core::TaskId::from(id), output.clone());
                     backend.save_snapshot(&snapshot).await?;
 
                     Ok(ControlFlow::Continue(output))

--- a/sayiir-runtime/src/execution/helpers.rs
+++ b/sayiir-runtime/src/execution/helpers.rs
@@ -18,7 +18,7 @@ use sayiir_core::error::{CodecError, WorkflowError};
 pub(crate) async fn check_guards<B: SignalStore>(
     backend: &B,
     instance_id: &str,
-    cancel_scope: Option<&str>,
+    cancel_scope: Option<sayiir_core::TaskId>,
 ) -> Result<(), RuntimeError> {
     if backend.check_and_cancel(instance_id, cancel_scope).await? {
         return Err(WorkflowError::cancelled().into());
@@ -38,7 +38,7 @@ pub(crate) enum ParkedCheckResult {
     /// The wake time has not yet arrived.
     StillWaiting {
         wake_at: chrono::DateTime<chrono::Utc>,
-        node_id: String,
+        node_id: sayiir_core::TaskId,
     },
     /// The wake time has passed; execution can continue.
     Expired,
@@ -62,7 +62,7 @@ impl ParkedCheckResult {
 pub(crate) async fn check_parked_position<B: SignalStore>(
     backend: &B,
     instance_id: &str,
-    node_id: &str,
+    node_id: sayiir_core::TaskId,
     wake_at: chrono::DateTime<chrono::Utc>,
 ) -> Result<ParkedCheckResult, RuntimeError> {
     if backend.check_and_cancel(instance_id, Some(node_id)).await? {
@@ -85,10 +85,7 @@ pub(crate) async fn check_parked_position<B: SignalStore>(
         }));
     }
     if chrono::Utc::now() < wake_at {
-        return Ok(ParkedCheckResult::StillWaiting {
-            wake_at,
-            node_id: node_id.to_string(),
-        });
+        return Ok(ParkedCheckResult::StillWaiting { wake_at, node_id });
     }
     Ok(ParkedCheckResult::Expired)
 }
@@ -101,20 +98,20 @@ pub(crate) enum ResumeParkedPosition {
     /// Workflow was parked at a durable delay.
     Delay {
         wake_at: chrono::DateTime<chrono::Utc>,
-        delay_id: String,
-        next_task_id: Option<String>,
+        delay_id: sayiir_core::TaskId,
+        next_task_id: Option<sayiir_core::TaskId>,
     },
     /// Workflow was parked at a fork (one or more branches waiting).
     Fork {
         wake_at: chrono::DateTime<chrono::Utc>,
-        fork_id: String,
+        fork_id: sayiir_core::TaskId,
     },
     /// Workflow was parked waiting for an external signal.
     Signal {
-        signal_id: String,
+        signal_id: sayiir_core::TaskId,
         signal_name: String,
         wake_at: Option<chrono::DateTime<chrono::Utc>>,
-        next_task_id: Option<String>,
+        next_task_id: Option<sayiir_core::TaskId>,
     },
     /// Snapshot is not in a parked position.
     NotParked,
@@ -135,8 +132,8 @@ impl ResumeParkedPosition {
                 ..
             } => Self::Delay {
                 wake_at: *wake_at,
-                delay_id: delay_id.clone(),
-                next_task_id: next_task_id.clone(),
+                delay_id: *delay_id,
+                next_task_id: *next_task_id,
             },
             WorkflowSnapshotState::InProgress {
                 position:
@@ -146,7 +143,7 @@ impl ResumeParkedPosition {
                 ..
             } => Self::Fork {
                 wake_at: *wake_at,
-                fork_id: fork_id.clone(),
+                fork_id: *fork_id,
             },
             WorkflowSnapshotState::InProgress {
                 position:
@@ -158,10 +155,10 @@ impl ResumeParkedPosition {
                     },
                 ..
             } => Self::Signal {
-                signal_id: signal_id.clone(),
+                signal_id: *signal_id,
                 signal_name: signal_name.clone(),
                 wake_at: *wake_at,
-                next_task_id: next_task_id.clone(),
+                next_task_id: *next_task_id,
             },
             _ => Self::NotParked,
         }
@@ -186,8 +183,7 @@ impl ResumeParkedPosition {
                 delay_id,
                 next_task_id,
             } => {
-                let result =
-                    check_parked_position(backend, instance_id, &delay_id, wake_at).await?;
+                let result = check_parked_position(backend, instance_id, delay_id, wake_at).await?;
                 if let Some(status) = result.into_status() {
                     return Ok(Some(status));
                 }
@@ -207,7 +203,7 @@ impl ResumeParkedPosition {
                 Ok(None)
             }
             Self::Fork { wake_at, fork_id } => {
-                let result = check_parked_position(backend, instance_id, &fork_id, wake_at).await?;
+                let result = check_parked_position(backend, instance_id, fork_id, wake_at).await?;
                 if let Some(status) = result.into_status() {
                     return Ok(Some(status));
                 }
@@ -222,7 +218,7 @@ impl ResumeParkedPosition {
             } => {
                 // Check cancel/pause first
                 if backend
-                    .check_and_cancel(instance_id, Some(&signal_id))
+                    .check_and_cancel(instance_id, Some(signal_id))
                     .await?
                 {
                     let snap = backend.load_snapshot(instance_id).await?;
@@ -243,7 +239,7 @@ impl ResumeParkedPosition {
                 if let Some(payload) = backend.consume_event(instance_id, &signal_name).await? {
                     tracing::info!(instance_id, %signal_id, %signal_name, "signal received, advancing");
                     // Store under signal_id (node ID) so the executor's skip logic finds it
-                    snapshot.mark_task_completed(signal_id.clone(), payload);
+                    snapshot.mark_task_completed(signal_id, payload);
                     if let Some(next_id) = next_task_id {
                         snapshot.update_position(ExecutionPosition::AtTask { task_id: next_id });
                     } else {
@@ -304,7 +300,7 @@ pub(crate) fn resolve_branch<'a, E: sayiir_core::codec::EnvelopeCodec>(
         envelope_codec
             .decode_string(key_bytes)
             .map_err(|e| CodecError::DecodeFailed {
-                task_id: branch_id.to_string(),
+                task_id: sayiir_core::TaskId::from(branch_id),
                 expected_type: "String (branch key)",
                 source: e,
             })?;
@@ -358,14 +354,19 @@ where
     loop {
         match execute(snapshot).await {
             Ok(output) => {
-                snapshot.clear_retry_state(task_id);
+                snapshot.clear_retry_state(&sayiir_core::TaskId::from(task_id));
                 return Ok(output);
             }
             Err(e) => {
                 if let Some(rp) = retry_policy
-                    && !snapshot.retries_exhausted(task_id)
+                    && !snapshot.retries_exhausted(&sayiir_core::TaskId::from(task_id))
                 {
-                    let next_retry_at = snapshot.record_retry(task_id, rp, &e.to_string(), None);
+                    let next_retry_at = snapshot.record_retry(
+                        sayiir_core::TaskId::from(task_id),
+                        rp,
+                        &e.to_string(),
+                        None,
+                    );
                     snapshot.clear_task_deadline();
 
                     if let Some(backend) = save_backend {
@@ -374,7 +375,7 @@ where
 
                     tracing::info!(
                         task_id = %task_id,
-                        attempt = snapshot.get_retry_state(task_id).map_or(0, |rs| rs.attempts),
+                        attempt = snapshot.get_retry_state(&sayiir_core::TaskId::from(task_id)).map_or(0, |rs| rs.attempts),
                         max_retries = rp.max_retries,
                         %next_retry_at,
                         error = %e,
@@ -423,10 +424,12 @@ pub(crate) async fn set_deadline_if_needed<B: SnapshotStore>(
     snapshot: &mut WorkflowSnapshot,
     backend: &B,
 ) -> Result<(), RuntimeError> {
-    if snapshot.get_task_result(id).is_none()
+    if snapshot
+        .get_task_result(&sayiir_core::TaskId::from(id))
+        .is_none()
         && let Some(d) = timeout
     {
-        snapshot.set_task_deadline(id.to_string(), *d);
+        snapshot.set_task_deadline(sayiir_core::TaskId::from(id), *d);
         backend.save_snapshot(snapshot).await?;
     }
     Ok(())
@@ -461,7 +464,10 @@ where
     Fut: Future<Output = Result<Bytes, E>>,
     E: Into<RuntimeError>,
 {
-    if let Some(cached) = snapshot.get_task_result(id).map(|r| r.output.clone()) {
+    if let Some(cached) = snapshot
+        .get_task_result(&sayiir_core::TaskId::from(id))
+        .map(|r| r.output.clone())
+    {
         snapshot.clear_task_deadline();
         return Ok(cached);
     }
@@ -469,7 +475,7 @@ where
     // Crash recovery: deadline from a previous attempt already expired
     if let Some((tid, timeout)) = snapshot.expired_task_deadline() {
         let err = WorkflowError::TaskTimedOut {
-            task_id: tid.to_string(),
+            task_id: tid,
             timeout,
         };
         snapshot.clear_task_deadline();
@@ -492,7 +498,7 @@ where
                 _ = interval.tick() => {
                     if let Some((tid, timeout)) = snapshot.expired_task_deadline() {
                         let err = WorkflowError::TaskTimedOut {
-                            task_id: tid.to_string(),
+                            task_id: tid,
                             timeout,
                         };
                         snapshot.clear_task_deadline();
@@ -506,7 +512,7 @@ where
     };
 
     snapshot.clear_task_deadline();
-    snapshot.mark_task_completed(id.to_string(), output.clone());
+    snapshot.mark_task_completed(sayiir_core::TaskId::from(id), output.clone());
     Ok(output)
 }
 
@@ -533,18 +539,21 @@ where
     E: Into<RuntimeError>,
     B: SnapshotStore,
 {
-    if let Some(cached) = snapshot.get_task_result(id).map(|r| r.output.clone()) {
+    if let Some(cached) = snapshot
+        .get_task_result(&sayiir_core::TaskId::from(id))
+        .map(|r| r.output.clone())
+    {
         return Ok(cached);
     }
 
     if let Some(d) = timeout {
-        snapshot.set_task_deadline(id.to_string(), *d);
+        snapshot.set_task_deadline(sayiir_core::TaskId::from(id), *d);
     }
     let output = execute(input).await.map_err(Into::into)?;
 
     if let Some((tid, t)) = snapshot.expired_task_deadline() {
         let err = WorkflowError::TaskTimedOut {
-            task_id: tid.to_string(),
+            task_id: tid,
             timeout: t,
         };
         snapshot.clear_task_deadline();
@@ -553,7 +562,7 @@ where
     snapshot.clear_task_deadline();
 
     backend
-        .save_task_result(instance_id, id, output.clone())
+        .save_task_result(instance_id, &sayiir_core::TaskId::from(id), output.clone())
         .await?;
     Ok(output)
 }
@@ -590,7 +599,12 @@ where
     E: Into<RuntimeError>,
 {
     tracing::debug!("executing task step");
-    check_guards(backend, &snapshot.instance_id, Some(params.id)).await?;
+    check_guards(
+        backend,
+        &snapshot.instance_id,
+        Some(sayiir_core::TaskId::from(params.id)),
+    )
+    .await?;
     set_deadline_if_needed(params.id, params.timeout, snapshot, backend).await?;
 
     let output = retry_with_checkpoint(
@@ -605,9 +619,7 @@ where
 
     if let Some(next_cont) = params.next {
         let hint = next_cont.first_task_hint();
-        snapshot.update_position(ExecutionPosition::AtTask {
-            task_id: hint.id.clone(),
-        });
+        snapshot.update_position(ExecutionPosition::AtTask { task_id: hint.id });
         snapshot.set_task_hint(&hint);
     }
     #[cfg(feature = "otel")]

--- a/sayiir-runtime/src/execution/lifecycle.rs
+++ b/sayiir-runtime/src/execution/lifecycle.rs
@@ -39,6 +39,7 @@ pub async fn check_existing_instance<B>(
 where
     B: SnapshotStore,
 {
+    sayiir_core::validate_instance_id(instance_id)?;
     if matches!(conflict_policy, ConflictPolicy::TerminateExisting) {
         return Ok(None);
     }
@@ -95,6 +96,7 @@ pub async fn prepare_run<B>(
 where
     B: SnapshotStore + SignalStore,
 {
+    sayiir_core::validate_instance_id(instance_id)?;
     if matches!(conflict_policy, ConflictPolicy::TerminateExisting) {
         // Best-effort cleanup — if nothing exists the deletes are no-ops.
         match backend.load_snapshot(instance_id).await {
@@ -147,6 +149,7 @@ pub async fn prepare_resume<B>(
 where
     B: SignalStore,
 {
+    sayiir_core::validate_instance_id(instance_id)?;
     tracing::debug!("preparing workflow resume");
     let mut snapshot = backend.load_snapshot(instance_id).await?;
 

--- a/sayiir-runtime/src/execution/lifecycle.rs
+++ b/sayiir-runtime/src/execution/lifecycle.rs
@@ -32,7 +32,7 @@ use crate::error::RuntimeError;
 /// I/O errors.
 pub async fn check_existing_instance<B>(
     instance_id: &str,
-    definition_hash: &str,
+    definition_hash: &sayiir_core::DefinitionHash,
     backend: &B,
     conflict_policy: ConflictPolicy,
 ) -> Result<Option<(WorkflowStatus, Option<Bytes>)>, RuntimeError>
@@ -44,10 +44,10 @@ where
     }
     match backend.load_snapshot(instance_id).await {
         Ok(existing) => {
-            if existing.definition_hash != definition_hash {
+            if existing.definition_hash != *definition_hash {
                 return Err(WorkflowError::DefinitionMismatch {
-                    expected: definition_hash.to_string(),
-                    found: existing.definition_hash.clone(),
+                    expected: *definition_hash,
+                    found: existing.definition_hash,
                 }
                 .into());
             }
@@ -86,7 +86,7 @@ where
 )]
 pub async fn prepare_run<B>(
     instance_id: String,
-    definition_hash: String,
+    definition_hash: sayiir_core::DefinitionHash,
     input_bytes: Bytes,
     first_task: TaskHint,
     backend: &B,
@@ -143,7 +143,7 @@ where
 )]
 pub async fn prepare_resume<B>(
     instance_id: &str,
-    definition_hash: &str,
+    definition_hash: &sayiir_core::DefinitionHash,
     backend: &B,
 ) -> Result<ResumeOutcome, RuntimeError>
 where
@@ -153,10 +153,10 @@ where
     let mut snapshot = backend.load_snapshot(instance_id).await?;
 
     // Validate definition hash
-    if snapshot.definition_hash != definition_hash {
+    if snapshot.definition_hash != *definition_hash {
         return Err(WorkflowError::DefinitionMismatch {
-            expected: definition_hash.to_string(),
-            found: snapshot.definition_hash.clone(),
+            expected: *definition_hash,
+            found: snapshot.definition_hash,
         }
         .into());
     }

--- a/sayiir-runtime/src/execution/lifecycle.rs
+++ b/sayiir-runtime/src/execution/lifecycle.rs
@@ -85,7 +85,7 @@ where
     fields(%instance_id),
 )]
 pub async fn prepare_run<B>(
-    instance_id: String,
+    instance_id: &str,
     definition_hash: sayiir_core::DefinitionHash,
     input_bytes: Bytes,
     first_task: TaskHint,
@@ -97,16 +97,14 @@ where
 {
     if matches!(conflict_policy, ConflictPolicy::TerminateExisting) {
         // Best-effort cleanup — if nothing exists the deletes are no-ops.
-        match backend.load_snapshot(&instance_id).await {
+        match backend.load_snapshot(instance_id).await {
             Ok(_existing) => {
                 tracing::info!("terminating existing instance before restart");
-                backend.delete_snapshot(&instance_id).await?;
+                backend.delete_snapshot(instance_id).await?;
                 backend
-                    .clear_signal(&instance_id, SignalKind::Cancel)
+                    .clear_signal(instance_id, SignalKind::Cancel)
                     .await?;
-                backend
-                    .clear_signal(&instance_id, SignalKind::Pause)
-                    .await?;
+                backend.clear_signal(instance_id, SignalKind::Pause).await?;
             }
             Err(sayiir_persistence::BackendError::NotFound(_)) => {}
             Err(e) => return Err(e.into()),

--- a/sayiir-runtime/src/execution/lifecycle.rs
+++ b/sayiir-runtime/src/execution/lifecycle.rs
@@ -119,7 +119,7 @@ where
         snapshot.trace_parent = crate::trace_context::current_trace_parent();
     }
     snapshot.update_position(ExecutionPosition::AtTask {
-        task_id: first_task.id.clone(),
+        task_id: first_task.id,
     });
     snapshot.set_task_hint(&first_task);
     backend.save_snapshot(&snapshot).await?;
@@ -269,12 +269,12 @@ where
                 WorkflowSnapshotState::InProgress {
                     position: ExecutionPosition::AtDelay { delay_id, .. },
                     ..
-                } => delay_id.clone(),
+                } => *delay_id,
                 WorkflowSnapshotState::InProgress {
                     position: ExecutionPosition::AtFork { fork_id, .. },
                     ..
-                } => fork_id.clone(),
-                _ => String::new(),
+                } => *fork_id,
+                _ => sayiir_core::TaskId::default(),
             };
             tracing::info!(
                 instance_id = %snapshot.instance_id,

--- a/sayiir-runtime/src/execution/loop_runner.rs
+++ b/sayiir-runtime/src/execution/loop_runner.rs
@@ -75,7 +75,7 @@ pub(crate) fn resolve_loop_iteration(
     cfg: &LoopConfig<'_>,
 ) -> Result<ControlFlow<LoopExit, LoopNext>, RuntimeError> {
     let (decision, inner) = decode_loop_envelope(output).map_err(|e| CodecError::DecodeFailed {
-        task_id: cfg.id.to_string(),
+        task_id: sayiir_core::TaskId::from(cfg.id),
         expected_type: "LoopEnvelope",
         source: e,
     })?;
@@ -85,7 +85,7 @@ pub(crate) fn resolve_loop_iteration(
             if iteration + 1 >= cfg.max_iterations {
                 match cfg.on_max {
                     MaxIterationsPolicy::Fail => Err(WorkflowError::MaxIterationsExceeded {
-                        loop_id: cfg.id.to_string(),
+                        loop_id: sayiir_core::TaskId::from(cfg.id),
                         max_iterations: cfg.max_iterations,
                     }
                     .into()),
@@ -150,14 +150,15 @@ impl<B: SnapshotStore> LoopHooks for CheckpointingLoopHooks<'_, B> {
     fn clear_body_tasks(&mut self, body: &WorkflowContinuation) {
         let body_ser = body.to_serializable();
         for tid in &body_ser.task_ids() {
-            self.snapshot.remove_task_result(tid);
+            self.snapshot
+                .remove_task_result(&sayiir_core::TaskId::from(*tid));
         }
     }
 
     async fn on_loop_exit(&mut self, loop_id: &str, output: &Bytes) -> Result<(), RuntimeError> {
-        self.snapshot.clear_loop_iteration(loop_id);
-        self.snapshot
-            .mark_task_completed(loop_id.to_string(), output.clone());
+        let loop_id = sayiir_core::TaskId::from(loop_id);
+        self.snapshot.clear_loop_iteration(&loop_id);
+        self.snapshot.mark_task_completed(loop_id, output.clone());
         self.backend.save_snapshot(self.snapshot).await?;
         Ok(())
     }
@@ -168,12 +169,14 @@ impl<B: SnapshotStore> LoopHooks for CheckpointingLoopHooks<'_, B> {
         next_iteration: u32,
         body: &WorkflowContinuation,
     ) -> Result<(), RuntimeError> {
-        self.snapshot.set_loop_iteration(loop_id, next_iteration);
+        let loop_id_hash = sayiir_core::TaskId::from(loop_id);
+        self.snapshot
+            .set_loop_iteration(loop_id_hash, next_iteration);
         if self.track_position {
             self.snapshot.update_position(ExecutionPosition::InLoop {
-                loop_id: loop_id.to_string(),
+                loop_id: loop_id_hash,
                 iteration: next_iteration,
-                next_task_id: Some(body.first_task_id().to_string()),
+                next_task_id: Some(sayiir_core::TaskId::from(body.first_task_id())),
             });
         }
         // Always persist: the cleared body task results and updated iteration
@@ -228,7 +231,7 @@ where
     }
 
     Err(WorkflowError::MaxIterationsExceeded {
-        loop_id: cfg.id.to_string(),
+        loop_id: sayiir_core::TaskId::from(cfg.id),
         max_iterations: cfg.max_iterations,
     }
     .into())

--- a/sayiir-runtime/src/execution/tests.rs
+++ b/sayiir-runtime/src/execution/tests.rs
@@ -601,7 +601,7 @@ async fn test_prepare_run_creates_snapshot() {
         "inst-1",
         "hash-1".into(),
         Bytes::from("input"),
-        sayiir_core::snapshot::TaskHint::new("task-1", None, vec![]),
+        sayiir_core::snapshot::TaskHint::new("task-1", None, &[]),
         &backend,
         sayiir_core::workflow::ConflictPolicy::Fail,
     )

--- a/sayiir-runtime/src/execution/tests.rs
+++ b/sayiir-runtime/src/execution/tests.rs
@@ -513,8 +513,7 @@ async fn test_checkpointing_task_timeout() {
     };
 
     let input = encode_u32(1);
-    let mut snapshot =
-        WorkflowSnapshot::with_initial_input("inst-1".into(), "hash".into(), input.clone());
+    let mut snapshot = WorkflowSnapshot::with_initial_input("inst-1", "hash".into(), input.clone());
     snapshot.update_position(ExecutionPosition::AtTask {
         task_id: sayiir_core::TaskId::from("slow"),
     });
@@ -560,8 +559,7 @@ async fn test_checkpointing_skipped_tasks_bypass_timeout() {
     };
 
     let output = encode_u32(42);
-    let mut snapshot =
-        WorkflowSnapshot::with_initial_input("inst-1".into(), "hash".into(), encode_u32(1));
+    let mut snapshot = WorkflowSnapshot::with_initial_input("inst-1", "hash".into(), encode_u32(1));
     snapshot.update_position(ExecutionPosition::AtTask {
         task_id: sayiir_core::TaskId::from("cached"),
     });
@@ -600,7 +598,7 @@ async fn test_prepare_run_creates_snapshot() {
     // `check_existing_instance` (called via client.rs / distributed.rs).
     let backend = InMemoryBackend::new();
     let outcome = sayiir_persistence::prepare_run(
-        "inst-1".into(),
+        "inst-1",
         "hash-1".into(),
         Bytes::from("input"),
         sayiir_core::snapshot::TaskHint::new("task-1", None, vec![]),
@@ -617,7 +615,7 @@ async fn test_prepare_run_creates_snapshot() {
         }
     };
 
-    assert_eq!(snapshot.instance_id, "inst-1");
+    assert_eq!(&*snapshot.instance_id, "inst-1");
     assert_eq!(
         snapshot.definition_hash,
         sayiir_core::DefinitionHash::from("hash-1")
@@ -625,17 +623,14 @@ async fn test_prepare_run_creates_snapshot() {
     assert!(snapshot.state.is_in_progress());
 
     let loaded = backend.load_snapshot("inst-1").await.unwrap();
-    assert_eq!(loaded.instance_id, "inst-1");
+    assert_eq!(&*loaded.instance_id, "inst-1");
 }
 
 #[tokio::test]
 async fn test_prepare_resume_ready() {
     let backend = InMemoryBackend::new();
-    let snapshot = WorkflowSnapshot::with_initial_input(
-        "inst-1".into(),
-        "hash-1".into(),
-        Bytes::from("input"),
-    );
+    let snapshot =
+        WorkflowSnapshot::with_initial_input("inst-1", "hash-1".into(), Bytes::from("input"));
     backend.save_snapshot(&snapshot).await.unwrap();
 
     let outcome = prepare_resume("inst-1", &"hash-1".into(), &backend)
@@ -646,7 +641,7 @@ async fn test_prepare_resume_ready() {
             snapshot,
             input_bytes,
         } => {
-            assert_eq!(snapshot.instance_id, "inst-1");
+            assert_eq!(&*snapshot.instance_id, "inst-1");
             assert_eq!(input_bytes, Bytes::from("input"));
         }
         _ => panic!("Expected Ready outcome"),
@@ -656,11 +651,8 @@ async fn test_prepare_resume_ready() {
 #[tokio::test]
 async fn test_prepare_resume_with_completed_tasks() {
     let backend = InMemoryBackend::new();
-    let mut snapshot = WorkflowSnapshot::with_initial_input(
-        "inst-1".into(),
-        "hash-1".into(),
-        Bytes::from("initial"),
-    );
+    let mut snapshot =
+        WorkflowSnapshot::with_initial_input("inst-1", "hash-1".into(), Bytes::from("initial"));
     snapshot.mark_task_completed(
         sayiir_core::TaskId::from("task-1"),
         Bytes::from("task1_output"),
@@ -682,7 +674,7 @@ async fn test_prepare_resume_with_completed_tasks() {
 #[tokio::test]
 async fn test_prepare_resume_already_completed() {
     let backend = InMemoryBackend::new();
-    let mut snapshot = WorkflowSnapshot::new("inst-1".into(), "hash-1".into());
+    let mut snapshot = WorkflowSnapshot::new("inst-1", "hash-1".into());
     snapshot.mark_completed(Bytes::from("result"));
     backend.save_snapshot(&snapshot).await.unwrap();
 
@@ -698,7 +690,7 @@ async fn test_prepare_resume_already_completed() {
 #[tokio::test]
 async fn test_prepare_resume_already_failed() {
     let backend = InMemoryBackend::new();
-    let mut snapshot = WorkflowSnapshot::new("inst-1".into(), "hash-1".into());
+    let mut snapshot = WorkflowSnapshot::new("inst-1", "hash-1".into());
     snapshot.mark_failed("err".into());
     backend.save_snapshot(&snapshot).await.unwrap();
 
@@ -714,7 +706,7 @@ async fn test_prepare_resume_already_failed() {
 #[tokio::test]
 async fn test_prepare_resume_already_cancelled() {
     let backend = InMemoryBackend::new();
-    let mut snapshot = WorkflowSnapshot::new("inst-1".into(), "hash-1".into());
+    let mut snapshot = WorkflowSnapshot::new("inst-1", "hash-1".into());
     snapshot.mark_cancelled(Some("reason".into()), Some("admin".into()), None);
     backend.save_snapshot(&snapshot).await.unwrap();
 
@@ -732,7 +724,7 @@ async fn test_prepare_resume_already_cancelled() {
 #[tokio::test]
 async fn test_prepare_resume_hash_mismatch() {
     let backend = InMemoryBackend::new();
-    let snapshot = WorkflowSnapshot::new("inst-1".into(), "hash-1".into());
+    let snapshot = WorkflowSnapshot::new("inst-1", "hash-1".into());
     backend.save_snapshot(&snapshot).await.unwrap();
 
     let result = prepare_resume("inst-1", &"wrong-hash".into(), &backend).await;
@@ -743,7 +735,7 @@ async fn test_prepare_resume_hash_mismatch() {
 #[tokio::test]
 async fn test_finalize_execution_success() {
     let backend = InMemoryBackend::new();
-    let mut snapshot = WorkflowSnapshot::new("inst-1".into(), "hash-1".into());
+    let mut snapshot = WorkflowSnapshot::new("inst-1", "hash-1".into());
     backend.save_snapshot(&snapshot).await.unwrap();
 
     let (status, output) = finalize_execution(Ok(Bytes::from("output")), &mut snapshot, &backend)
@@ -763,7 +755,7 @@ async fn test_finalize_execution_success() {
 #[tokio::test]
 async fn test_finalize_execution_failure() {
     let backend = InMemoryBackend::new();
-    let mut snapshot = WorkflowSnapshot::new("inst-1".into(), "hash-1".into());
+    let mut snapshot = WorkflowSnapshot::new("inst-1", "hash-1".into());
     backend.save_snapshot(&snapshot).await.unwrap();
 
     let (status, output) = finalize_execution(
@@ -789,13 +781,13 @@ async fn test_finalize_execution_failure() {
 #[tokio::test]
 async fn test_finalize_execution_cancellation() {
     let backend = InMemoryBackend::new();
-    let mut snapshot = WorkflowSnapshot::new("inst-1".into(), "hash-1".into());
+    let mut snapshot = WorkflowSnapshot::new("inst-1", "hash-1".into());
     // Mark as cancelled in backend so finalize can reload details
     snapshot.mark_cancelled(Some("timeout".into()), Some("system".into()), None);
     backend.save_snapshot(&snapshot).await.unwrap();
 
     // Reset local snapshot to in-progress for finalize logic
-    let mut local_snapshot = WorkflowSnapshot::new("inst-1".into(), "hash-1".into());
+    let mut local_snapshot = WorkflowSnapshot::new("inst-1", "hash-1".into());
 
     let (status, output) = finalize_execution(
         Err(WorkflowError::cancelled().into()),
@@ -828,7 +820,7 @@ async fn test_checkpointing_single_task() {
     let input = encode_u32(5);
 
     let mut snapshot =
-        WorkflowSnapshot::with_initial_input("inst-1".into(), "hash-1".into(), input.clone());
+        WorkflowSnapshot::with_initial_input("inst-1", "hash-1".into(), input.clone());
     backend.save_snapshot(&snapshot).await.unwrap();
 
     let cont = stub_node("add_one", None);
@@ -869,7 +861,7 @@ async fn test_checkpointing_chain() {
     let input = encode_u32(10);
 
     let mut snapshot =
-        WorkflowSnapshot::with_initial_input("inst-1".into(), "hash-1".into(), input.clone());
+        WorkflowSnapshot::with_initial_input("inst-1", "hash-1".into(), input.clone());
     backend.save_snapshot(&snapshot).await.unwrap();
 
     let double = stub_node("double", None);
@@ -917,7 +909,7 @@ async fn test_checkpointing_skips_completed_tasks() {
     let input = encode_u32(10);
 
     let mut snapshot =
-        WorkflowSnapshot::with_initial_input("inst-1".into(), "hash-1".into(), input.clone());
+        WorkflowSnapshot::with_initial_input("inst-1", "hash-1".into(), input.clone());
     // Pre-mark task as completed (simulates resume)
     snapshot.mark_task_completed(sayiir_core::TaskId::from("add_one"), encode_u32(11));
     backend.save_snapshot(&snapshot).await.unwrap();
@@ -967,7 +959,7 @@ async fn test_checkpointing_fork_sequential() {
     let input = encode_u32(10);
 
     let mut snapshot =
-        WorkflowSnapshot::with_initial_input("inst-1".into(), "hash-1".into(), input.clone());
+        WorkflowSnapshot::with_initial_input("inst-1", "hash-1".into(), input.clone());
     backend.save_snapshot(&snapshot).await.unwrap();
 
     let branch_a = Arc::new(stub_node("branch_a", None));
@@ -1020,7 +1012,7 @@ async fn test_checkpointing_cancellation() {
     let input = encode_u32(5);
 
     let mut snapshot =
-        WorkflowSnapshot::with_initial_input("inst-1".into(), "hash-1".into(), input.clone());
+        WorkflowSnapshot::with_initial_input("inst-1", "hash-1".into(), input.clone());
     backend.save_snapshot(&snapshot).await.unwrap();
 
     // Request cancellation before execution
@@ -1065,22 +1057,16 @@ async fn test_checkpointing_cancellation() {
 
 #[test]
 fn test_get_resume_input_no_completed_tasks() {
-    let snapshot = WorkflowSnapshot::with_initial_input(
-        "inst-1".into(),
-        "hash-1".into(),
-        Bytes::from("initial"),
-    );
+    let snapshot =
+        WorkflowSnapshot::with_initial_input("inst-1", "hash-1".into(), Bytes::from("initial"));
     let input = get_resume_input(&snapshot).unwrap();
     assert_eq!(input, Bytes::from("initial"));
 }
 
 #[test]
 fn test_get_resume_input_with_completed_tasks() {
-    let mut snapshot = WorkflowSnapshot::with_initial_input(
-        "inst-1".into(),
-        "hash-1".into(),
-        Bytes::from("initial"),
-    );
+    let mut snapshot =
+        WorkflowSnapshot::with_initial_input("inst-1", "hash-1".into(), Bytes::from("initial"));
     snapshot.mark_task_completed(
         sayiir_core::TaskId::from("task-1"),
         Bytes::from("task1_out"),
@@ -1091,7 +1077,7 @@ fn test_get_resume_input_with_completed_tasks() {
 
 #[test]
 fn test_get_resume_input_not_in_progress() {
-    let mut snapshot = WorkflowSnapshot::new("inst-1".into(), "hash-1".into());
+    let mut snapshot = WorkflowSnapshot::new("inst-1", "hash-1".into());
     snapshot.mark_completed(Bytes::from("done"));
     let result = get_resume_input(&snapshot);
     assert!(result.is_err());
@@ -1099,7 +1085,7 @@ fn test_get_resume_input_not_in_progress() {
 
 #[test]
 fn test_get_resume_input_no_initial_input() {
-    let snapshot = WorkflowSnapshot::new("inst-1".into(), "hash-1".into());
+    let snapshot = WorkflowSnapshot::new("inst-1", "hash-1".into());
     let result = get_resume_input(&snapshot);
     assert!(result.is_err());
     assert!(
@@ -1200,7 +1186,7 @@ async fn test_checkpointing_delay_returns_waiting() {
     let input = encode_u32(42);
 
     let mut snapshot =
-        WorkflowSnapshot::with_initial_input("inst-1".into(), "hash-1".into(), input.clone());
+        WorkflowSnapshot::with_initial_input("inst-1", "hash-1".into(), input.clone());
     backend.save_snapshot(&snapshot).await.unwrap();
 
     let next_task = stub_node("process", None);
@@ -1260,7 +1246,7 @@ async fn test_checkpointing_delay_skip_on_resume() {
     let input = encode_u32(42);
 
     let mut snapshot =
-        WorkflowSnapshot::with_initial_input("inst-1".into(), "hash-1".into(), input.clone());
+        WorkflowSnapshot::with_initial_input("inst-1", "hash-1".into(), input.clone());
     // Pre-mark delay as completed (simulates resume after delay expired)
     snapshot.mark_task_completed(sayiir_core::TaskId::from("wait"), encode_u32(42));
     backend.save_snapshot(&snapshot).await.unwrap();
@@ -1304,7 +1290,7 @@ async fn test_checkpointing_delay_cancellation() {
     let input = encode_u32(10);
 
     let mut snapshot =
-        WorkflowSnapshot::with_initial_input("inst-1".into(), "hash-1".into(), input.clone());
+        WorkflowSnapshot::with_initial_input("inst-1", "hash-1".into(), input.clone());
     backend.save_snapshot(&snapshot).await.unwrap();
 
     // Request cancellation
@@ -1349,7 +1335,7 @@ async fn test_checkpointing_delay_cancellation() {
 #[tokio::test]
 async fn test_finalize_execution_waiting() {
     let backend = InMemoryBackend::new();
-    let mut snapshot = WorkflowSnapshot::new("inst-1".into(), "hash-1".into());
+    let mut snapshot = WorkflowSnapshot::new("inst-1", "hash-1".into());
 
     // Set up the snapshot as if it's parked at a delay
     let now = chrono::Utc::now();
@@ -1446,7 +1432,7 @@ async fn test_fork_with_delay_parks_at_fork() {
     let input = encode_u32(10);
 
     let mut snapshot =
-        WorkflowSnapshot::with_initial_input("inst-1".into(), "hash-1".into(), input.clone());
+        WorkflowSnapshot::with_initial_input("inst-1", "hash-1".into(), input.clone());
     backend.save_snapshot(&snapshot).await.unwrap();
 
     let fork = fork_with_delay_in_branch();
@@ -1514,7 +1500,7 @@ async fn test_fork_with_delay_resumes_after_expiry() {
     let input = encode_u32(10);
 
     let mut snapshot =
-        WorkflowSnapshot::with_initial_input("inst-1".into(), "hash-1".into(), input.clone());
+        WorkflowSnapshot::with_initial_input("inst-1", "hash-1".into(), input.clone());
     backend.save_snapshot(&snapshot).await.unwrap();
 
     // Use a very short delay so it expires immediately
@@ -1579,7 +1565,7 @@ async fn test_fork_with_delays_in_multiple_branches() {
     let input = encode_u32(5);
 
     let mut snapshot =
-        WorkflowSnapshot::with_initial_input("inst-1".into(), "hash-1".into(), input.clone());
+        WorkflowSnapshot::with_initial_input("inst-1", "hash-1".into(), input.clone());
     backend.save_snapshot(&snapshot).await.unwrap();
 
     // Both branches have delays
@@ -1663,7 +1649,7 @@ async fn test_fork_normal_branch_completes_delayed_branch_parks() {
     let input = encode_u32(10);
 
     let mut snapshot =
-        WorkflowSnapshot::with_initial_input("inst-1".into(), "hash-1".into(), input.clone());
+        WorkflowSnapshot::with_initial_input("inst-1", "hash-1".into(), input.clone());
     backend.save_snapshot(&snapshot).await.unwrap();
 
     // branch_a: normal task (completes immediately)
@@ -1982,8 +1968,7 @@ async fn test_checkpointing_retry_succeeds_after_failure() {
     let backend = InMemoryBackend::new();
     let input = encode_u32(10);
 
-    let mut snapshot =
-        WorkflowSnapshot::with_initial_input("inst-1".into(), "hash".into(), input.clone());
+    let mut snapshot = WorkflowSnapshot::with_initial_input("inst-1", "hash".into(), input.clone());
     snapshot.update_position(ExecutionPosition::AtTask {
         task_id: sayiir_core::TaskId::from("flaky"),
     });
@@ -2038,8 +2023,7 @@ async fn test_checkpointing_retry_exhaustion() {
     let backend = InMemoryBackend::new();
     let input = encode_u32(1);
 
-    let mut snapshot =
-        WorkflowSnapshot::with_initial_input("inst-1".into(), "hash".into(), input.clone());
+    let mut snapshot = WorkflowSnapshot::with_initial_input("inst-1", "hash".into(), input.clone());
     snapshot.update_position(ExecutionPosition::AtTask {
         task_id: sayiir_core::TaskId::from("always_fail"),
     });
@@ -2078,8 +2062,7 @@ async fn test_checkpointing_retry_state_persisted() {
     let backend = InMemoryBackend::new();
     let input = encode_u32(10);
 
-    let mut snapshot =
-        WorkflowSnapshot::with_initial_input("inst-1".into(), "hash".into(), input.clone());
+    let mut snapshot = WorkflowSnapshot::with_initial_input("inst-1", "hash".into(), input.clone());
     snapshot.update_position(ExecutionPosition::AtTask {
         task_id: sayiir_core::TaskId::from("flaky"),
     });
@@ -2138,8 +2121,7 @@ async fn test_checkpointing_retry_with_timeout() {
     let backend = InMemoryBackend::new();
     let input = encode_u32(10);
 
-    let mut snapshot =
-        WorkflowSnapshot::with_initial_input("inst-1".into(), "hash".into(), input.clone());
+    let mut snapshot = WorkflowSnapshot::with_initial_input("inst-1", "hash".into(), input.clone());
     snapshot.update_position(ExecutionPosition::AtTask {
         task_id: sayiir_core::TaskId::from("slow_then_fast"),
     });
@@ -2187,8 +2169,7 @@ async fn test_checkpointing_retry_in_chain() {
     let backend = InMemoryBackend::new();
     let input = encode_u32(5);
 
-    let mut snapshot =
-        WorkflowSnapshot::with_initial_input("inst-1".into(), "hash".into(), input.clone());
+    let mut snapshot = WorkflowSnapshot::with_initial_input("inst-1", "hash".into(), input.clone());
     backend.save_snapshot(&snapshot).await.unwrap();
 
     let double = stub_node("double", None);
@@ -2331,8 +2312,7 @@ async fn test_checkpointing_timeout_mid_chain() {
     let backend = InMemoryBackend::new();
     let input = encode_u32(5);
 
-    let mut snapshot =
-        WorkflowSnapshot::with_initial_input("inst-1".into(), "hash".into(), input.clone());
+    let mut snapshot = WorkflowSnapshot::with_initial_input("inst-1", "hash".into(), input.clone());
     backend.save_snapshot(&snapshot).await.unwrap();
 
     // fast_task → slow_task (times out)
@@ -2408,7 +2388,7 @@ async fn test_checkpointing_delay_terminal_parks() {
     let input = encode_u32(42);
 
     let mut snapshot =
-        WorkflowSnapshot::with_initial_input("inst-1".into(), "hash-1".into(), input.clone());
+        WorkflowSnapshot::with_initial_input("inst-1", "hash-1".into(), input.clone());
     backend.save_snapshot(&snapshot).await.unwrap();
 
     let delay = WorkflowContinuation::Delay {
@@ -2466,7 +2446,7 @@ async fn test_checkpointing_delay_after_task_chain() {
     let input = encode_u32(10);
 
     let mut snapshot =
-        WorkflowSnapshot::with_initial_input("inst-1".into(), "hash-1".into(), input.clone());
+        WorkflowSnapshot::with_initial_input("inst-1", "hash-1".into(), input.clone());
     backend.save_snapshot(&snapshot).await.unwrap();
 
     let process = stub_node("process", None);
@@ -2703,7 +2683,7 @@ mod proptests {
             cancelled_by in prop::option::of("[a-zA-Z0-9 ]{0,32}"),
             output_data in proptest::collection::vec(any::<u8>(), 0..32),
         ) {
-            let mut snapshot = WorkflowSnapshot::new("inst".into(), "hash".into());
+            let mut snapshot = WorkflowSnapshot::new("inst", "hash".into());
             match variant {
                 0 => snapshot.mark_completed(Bytes::from(output_data)),
                 1 => snapshot.mark_failed(error_msg),
@@ -2723,7 +2703,7 @@ mod proptests {
         ) {
             let initial = Bytes::from(input_data);
             let snapshot = WorkflowSnapshot::with_initial_input(
-                "inst".into(),
+                "inst",
                 "hash".into(),
                 initial.clone(),
             );
@@ -2922,7 +2902,7 @@ async fn test_checkpointing_loop_basic() {
     let input = encode_u32(3);
 
     let mut snapshot =
-        WorkflowSnapshot::with_initial_input("inst-1".into(), "hash-1".into(), input.clone());
+        WorkflowSnapshot::with_initial_input("inst-1", "hash-1".into(), input.clone());
     backend.save_snapshot(&snapshot).await.unwrap();
 
     let body = stub_node("countdown", None);
@@ -2968,7 +2948,7 @@ async fn test_checkpointing_loop_resumes_from_iteration() {
     let input = encode_u32(5);
 
     let mut snapshot =
-        WorkflowSnapshot::with_initial_input("inst-1".into(), "hash-1".into(), input.clone());
+        WorkflowSnapshot::with_initial_input("inst-1", "hash-1".into(), input.clone());
 
     // Simulate: 2 iterations already completed. Next input should be 3 (5→4→3).
     snapshot.set_loop_iteration(sayiir_core::TaskId::from("loop_0"), 2);
@@ -3373,7 +3353,7 @@ async fn test_checkpointing_loop_caches_result_on_exit() {
     let input = encode_u32(2);
 
     let mut snapshot =
-        WorkflowSnapshot::with_initial_input("inst-1".into(), "hash-1".into(), input.clone());
+        WorkflowSnapshot::with_initial_input("inst-1", "hash-1".into(), input.clone());
     backend.save_snapshot(&snapshot).await.unwrap();
 
     let body = stub_node("countdown", None);
@@ -3419,7 +3399,7 @@ async fn test_checkpointing_loop_short_circuits_when_cached() {
     let input = encode_u32(99);
 
     let mut snapshot =
-        WorkflowSnapshot::with_initial_input("inst-1".into(), "hash-1".into(), input.clone());
+        WorkflowSnapshot::with_initial_input("inst-1", "hash-1".into(), input.clone());
 
     // Pre-cache a result for the loop node.
     let cached_output = encode_u32(42);
@@ -3467,7 +3447,7 @@ async fn test_checkpointing_loop_exit_with_last() {
     let input = encode_u32(0);
 
     let mut snapshot =
-        WorkflowSnapshot::with_initial_input("inst-1".into(), "hash-1".into(), input.clone());
+        WorkflowSnapshot::with_initial_input("inst-1", "hash-1".into(), input.clone());
     backend.save_snapshot(&snapshot).await.unwrap();
 
     let body = stub_node("always_again", None);
@@ -3519,7 +3499,7 @@ async fn test_checkpointing_loop_in_chain() {
     let input = encode_u32(2);
 
     let mut snapshot =
-        WorkflowSnapshot::with_initial_input("inst-1".into(), "hash-1".into(), input.clone());
+        WorkflowSnapshot::with_initial_input("inst-1", "hash-1".into(), input.clone());
     backend.save_snapshot(&snapshot).await.unwrap();
 
     let double = stub_node("double", None);
@@ -3578,7 +3558,7 @@ async fn test_checkpointing_loop_inside_fork_branch() {
     let input = encode_u32(2);
 
     let mut snapshot =
-        WorkflowSnapshot::with_initial_input("inst-1".into(), "hash-1".into(), input.clone());
+        WorkflowSnapshot::with_initial_input("inst-1", "hash-1".into(), input.clone());
     backend.save_snapshot(&snapshot).await.unwrap();
 
     let body = stub_node("countdown", None);
@@ -3649,7 +3629,7 @@ async fn test_checkpointing_loop_iteration_counter_persisted() {
     let input = encode_u32(5);
 
     let mut snapshot =
-        WorkflowSnapshot::with_initial_input("inst-1".into(), "hash-1".into(), input.clone());
+        WorkflowSnapshot::with_initial_input("inst-1", "hash-1".into(), input.clone());
     backend.save_snapshot(&snapshot).await.unwrap();
 
     let body = stub_node("countdown", None);

--- a/sayiir-runtime/src/execution/tests.rs
+++ b/sayiir-runtime/src/execution/tests.rs
@@ -615,7 +615,10 @@ async fn test_prepare_run_creates_snapshot() {
     };
 
     assert_eq!(snapshot.instance_id, "inst-1");
-    assert_eq!(snapshot.definition_hash, "hash-1");
+    assert_eq!(
+        snapshot.definition_hash,
+        sayiir_core::DefinitionHash::from("hash-1")
+    );
     assert!(snapshot.state.is_in_progress());
 
     let loaded = backend.load_snapshot("inst-1").await.unwrap();
@@ -632,7 +635,9 @@ async fn test_prepare_resume_ready() {
     );
     backend.save_snapshot(&snapshot).await.unwrap();
 
-    let outcome = prepare_resume("inst-1", "hash-1", &backend).await.unwrap();
+    let outcome = prepare_resume("inst-1", &"hash-1".into(), &backend)
+        .await
+        .unwrap();
     match outcome {
         ResumeOutcome::Ready {
             snapshot,
@@ -656,7 +661,9 @@ async fn test_prepare_resume_with_completed_tasks() {
     snapshot.mark_task_completed("task-1".into(), Bytes::from("task1_output"));
     backend.save_snapshot(&snapshot).await.unwrap();
 
-    let outcome = prepare_resume("inst-1", "hash-1", &backend).await.unwrap();
+    let outcome = prepare_resume("inst-1", &"hash-1".into(), &backend)
+        .await
+        .unwrap();
     match outcome {
         ResumeOutcome::Ready { input_bytes, .. } => {
             // Should use last task output, not initial input
@@ -673,7 +680,9 @@ async fn test_prepare_resume_already_completed() {
     snapshot.mark_completed(Bytes::from("result"));
     backend.save_snapshot(&snapshot).await.unwrap();
 
-    let outcome = prepare_resume("inst-1", "hash-1", &backend).await.unwrap();
+    let outcome = prepare_resume("inst-1", &"hash-1".into(), &backend)
+        .await
+        .unwrap();
     match outcome {
         ResumeOutcome::AlreadyTerminal(WorkflowStatus::Completed) => {}
         _ => panic!("Expected AlreadyTerminal(Completed)"),
@@ -687,7 +696,9 @@ async fn test_prepare_resume_already_failed() {
     snapshot.mark_failed("err".into());
     backend.save_snapshot(&snapshot).await.unwrap();
 
-    let outcome = prepare_resume("inst-1", "hash-1", &backend).await.unwrap();
+    let outcome = prepare_resume("inst-1", &"hash-1".into(), &backend)
+        .await
+        .unwrap();
     match outcome {
         ResumeOutcome::AlreadyTerminal(WorkflowStatus::Failed(_)) => {}
         _ => panic!("Expected AlreadyTerminal(Failed)"),
@@ -701,7 +712,9 @@ async fn test_prepare_resume_already_cancelled() {
     snapshot.mark_cancelled(Some("reason".into()), Some("admin".into()), None);
     backend.save_snapshot(&snapshot).await.unwrap();
 
-    let outcome = prepare_resume("inst-1", "hash-1", &backend).await.unwrap();
+    let outcome = prepare_resume("inst-1", &"hash-1".into(), &backend)
+        .await
+        .unwrap();
     match outcome {
         ResumeOutcome::AlreadyTerminal(WorkflowStatus::Cancelled { reason, .. }) => {
             assert_eq!(reason, Some("reason".into()));
@@ -716,7 +729,7 @@ async fn test_prepare_resume_hash_mismatch() {
     let snapshot = WorkflowSnapshot::new("inst-1".into(), "hash-1".into());
     backend.save_snapshot(&snapshot).await.unwrap();
 
-    let result = prepare_resume("inst-1", "wrong-hash", &backend).await;
+    let result = prepare_resume("inst-1", &"wrong-hash".into(), &backend).await;
     assert!(result.is_err());
     assert!(result.unwrap_err().to_string().contains("mismatch"));
 }

--- a/sayiir-runtime/src/execution/tests.rs
+++ b/sayiir-runtime/src/execution/tests.rs
@@ -464,7 +464,10 @@ async fn test_async_task_exceeds_timeout() {
     let result = execute_continuation_async(&cont, input, &JsonCodec).await;
     let err = result.unwrap_err();
     assert!(err.to_string().contains("timed out"));
-    assert!(err.to_string().contains("slow"));
+    assert!(
+        err.to_string()
+            .contains(&sayiir_core::TaskId::from("slow").to_hex())
+    );
 }
 
 #[tokio::test]
@@ -513,7 +516,7 @@ async fn test_checkpointing_task_timeout() {
     let mut snapshot =
         WorkflowSnapshot::with_initial_input("inst-1".into(), "hash".into(), input.clone());
     snapshot.update_position(ExecutionPosition::AtTask {
-        task_id: "slow".into(),
+        task_id: sayiir_core::TaskId::from("slow"),
     });
     backend.save_snapshot(&snapshot).await.unwrap();
 
@@ -534,7 +537,10 @@ async fn test_checkpointing_task_timeout() {
 
     let err = result.unwrap_err();
     assert!(err.to_string().contains("timed out"));
-    assert!(err.to_string().contains("slow"));
+    assert!(
+        err.to_string()
+            .contains(&sayiir_core::TaskId::from("slow").to_hex())
+    );
 }
 
 #[tokio::test]
@@ -557,9 +563,9 @@ async fn test_checkpointing_skipped_tasks_bypass_timeout() {
     let mut snapshot =
         WorkflowSnapshot::with_initial_input("inst-1".into(), "hash".into(), encode_u32(1));
     snapshot.update_position(ExecutionPosition::AtTask {
-        task_id: "cached".into(),
+        task_id: sayiir_core::TaskId::from("cached"),
     });
-    snapshot.mark_task_completed("cached".to_string(), output.clone());
+    snapshot.mark_task_completed(sayiir_core::TaskId::from("cached"), output.clone());
     backend.save_snapshot(&snapshot).await.unwrap();
 
     let never_called = |_id: &str, _input: Bytes| async move {
@@ -655,7 +661,10 @@ async fn test_prepare_resume_with_completed_tasks() {
         "hash-1".into(),
         Bytes::from("initial"),
     );
-    snapshot.mark_task_completed("task-1".into(), Bytes::from("task1_output"));
+    snapshot.mark_task_completed(
+        sayiir_core::TaskId::from("task-1"),
+        Bytes::from("task1_output"),
+    );
     backend.save_snapshot(&snapshot).await.unwrap();
 
     let outcome = prepare_resume("inst-1", &"hash-1".into(), &backend)
@@ -847,7 +856,11 @@ async fn test_checkpointing_single_task() {
     .unwrap();
 
     assert_eq!(decode_u32(&result), 6);
-    assert!(snapshot.get_task_result("add_one").is_some());
+    assert!(
+        snapshot
+            .get_task_result(&sayiir_core::TaskId::from("add_one"))
+            .is_some()
+    );
 }
 
 #[tokio::test]
@@ -886,8 +899,16 @@ async fn test_checkpointing_chain() {
     .unwrap();
 
     assert_eq!(decode_u32(&result), 22); // (10+1)*2
-    assert!(snapshot.get_task_result("add_one").is_some());
-    assert!(snapshot.get_task_result("double").is_some());
+    assert!(
+        snapshot
+            .get_task_result(&sayiir_core::TaskId::from("add_one"))
+            .is_some()
+    );
+    assert!(
+        snapshot
+            .get_task_result(&sayiir_core::TaskId::from("double"))
+            .is_some()
+    );
 }
 
 #[tokio::test]
@@ -898,7 +919,7 @@ async fn test_checkpointing_skips_completed_tasks() {
     let mut snapshot =
         WorkflowSnapshot::with_initial_input("inst-1".into(), "hash-1".into(), input.clone());
     // Pre-mark task as completed (simulates resume)
-    snapshot.mark_task_completed("add_one".into(), encode_u32(11));
+    snapshot.mark_task_completed(sayiir_core::TaskId::from("add_one"), encode_u32(11));
     backend.save_snapshot(&snapshot).await.unwrap();
 
     let double = stub_node("double", None);
@@ -1060,7 +1081,10 @@ fn test_get_resume_input_with_completed_tasks() {
         "hash-1".into(),
         Bytes::from("initial"),
     );
-    snapshot.mark_task_completed("task-1".into(), Bytes::from("task1_out"));
+    snapshot.mark_task_completed(
+        sayiir_core::TaskId::from("task-1"),
+        Bytes::from("task1_out"),
+    );
     let input = get_resume_input(&snapshot).unwrap();
     assert_eq!(input, Bytes::from("task1_out"));
 }
@@ -1215,8 +1239,8 @@ async fn test_checkpointing_delay_returns_waiting() {
                 next_task_id,
                 ..
             } => {
-                assert_eq!(delay_id, "wait_1h");
-                assert_eq!(next_task_id.as_deref(), Some("process"));
+                assert_eq!(*delay_id, sayiir_core::TaskId::from("wait_1h"));
+                assert_eq!(next_task_id, &Some(sayiir_core::TaskId::from("process")));
             }
             other => panic!("Expected AtDelay, got {other:?}"),
         },
@@ -1224,7 +1248,9 @@ async fn test_checkpointing_delay_returns_waiting() {
     }
 
     // Pass-through value should be stored
-    let stored = snapshot.get_task_result("wait_1h").unwrap();
+    let stored = snapshot
+        .get_task_result(&sayiir_core::TaskId::from("wait_1h"))
+        .unwrap();
     assert_eq!(decode_u32(&stored.output), 42);
 }
 
@@ -1236,7 +1262,7 @@ async fn test_checkpointing_delay_skip_on_resume() {
     let mut snapshot =
         WorkflowSnapshot::with_initial_input("inst-1".into(), "hash-1".into(), input.clone());
     // Pre-mark delay as completed (simulates resume after delay expired)
-    snapshot.mark_task_completed("wait".into(), encode_u32(42));
+    snapshot.mark_task_completed(sayiir_core::TaskId::from("wait"), encode_u32(42));
     backend.save_snapshot(&snapshot).await.unwrap();
 
     let process = stub_node("process", None);
@@ -1329,7 +1355,7 @@ async fn test_finalize_execution_waiting() {
     let now = chrono::Utc::now();
     let wake_at = now + chrono::Duration::hours(1);
     snapshot.update_position(ExecutionPosition::AtDelay {
-        delay_id: "my_delay".into(),
+        delay_id: sayiir_core::TaskId::from("my_delay"),
         entered_at: now,
         wake_at,
         next_task_id: Some("next_step".into()),
@@ -1350,7 +1376,7 @@ async fn test_finalize_execution_waiting() {
             delay_id,
         } => {
             assert_eq!(wa, wake_at);
-            assert_eq!(delay_id, "my_delay");
+            assert_eq!(delay_id, sayiir_core::TaskId::from("my_delay"));
         }
         _ => panic!("Expected Waiting status, got {status:?}"),
     }
@@ -1451,7 +1477,7 @@ async fn test_fork_with_delay_parks_at_fork() {
                 completed_branches,
                 wake_at,
             } => {
-                assert_eq!(fork_id, "fork");
+                assert_eq!(*fork_id, sayiir_core::TaskId::from("fork"));
                 // branch_a completed, branch_b is waiting
                 assert_eq!(completed_branches.len(), 1);
                 assert!(completed_branches.contains_key("branch_a"));
@@ -1463,11 +1489,23 @@ async fn test_fork_with_delay_parks_at_fork() {
     }
 
     // branch_a result should be cached
-    assert!(snapshot.get_task_result("branch_a").is_some());
+    assert!(
+        snapshot
+            .get_task_result(&sayiir_core::TaskId::from("branch_a"))
+            .is_some()
+    );
     // before_delay task result should be cached (saved during branch execution)
-    assert!(snapshot.get_task_result("before_delay").is_some());
+    assert!(
+        snapshot
+            .get_task_result(&sayiir_core::TaskId::from("before_delay"))
+            .is_some()
+    );
     // delay pass-through should be cached
-    assert!(snapshot.get_task_result("branch_delay").is_some());
+    assert!(
+        snapshot
+            .get_task_result(&sayiir_core::TaskId::from("branch_delay"))
+            .is_some()
+    );
 }
 
 #[tokio::test]
@@ -1947,7 +1985,7 @@ async fn test_checkpointing_retry_succeeds_after_failure() {
     let mut snapshot =
         WorkflowSnapshot::with_initial_input("inst-1".into(), "hash".into(), input.clone());
     snapshot.update_position(ExecutionPosition::AtTask {
-        task_id: "flaky".into(),
+        task_id: sayiir_core::TaskId::from("flaky"),
     });
     backend.save_snapshot(&snapshot).await.unwrap();
 
@@ -1982,9 +2020,17 @@ async fn test_checkpointing_retry_succeeds_after_failure() {
     assert_eq!(decode_u32(&result), 11);
     assert_eq!(attempts.load(Ordering::SeqCst), 2);
     // Task result is cached after success
-    assert!(snapshot.get_task_result("flaky").is_some());
+    assert!(
+        snapshot
+            .get_task_result(&sayiir_core::TaskId::from("flaky"))
+            .is_some()
+    );
     // Retry state is cleared on success
-    assert!(snapshot.get_retry_state("flaky").is_none());
+    assert!(
+        snapshot
+            .get_retry_state(&sayiir_core::TaskId::from("flaky"))
+            .is_none()
+    );
 }
 
 #[tokio::test]
@@ -1995,7 +2041,7 @@ async fn test_checkpointing_retry_exhaustion() {
     let mut snapshot =
         WorkflowSnapshot::with_initial_input("inst-1".into(), "hash".into(), input.clone());
     snapshot.update_position(ExecutionPosition::AtTask {
-        task_id: "always_fail".into(),
+        task_id: sayiir_core::TaskId::from("always_fail"),
     });
     backend.save_snapshot(&snapshot).await.unwrap();
 
@@ -2035,7 +2081,7 @@ async fn test_checkpointing_retry_state_persisted() {
     let mut snapshot =
         WorkflowSnapshot::with_initial_input("inst-1".into(), "hash".into(), input.clone());
     snapshot.update_position(ExecutionPosition::AtTask {
-        task_id: "flaky".into(),
+        task_id: sayiir_core::TaskId::from("flaky"),
     });
     backend.save_snapshot(&snapshot).await.unwrap();
 
@@ -2072,11 +2118,19 @@ async fn test_checkpointing_retry_state_persisted() {
     assert_eq!(attempts.load(Ordering::SeqCst), 4);
 
     // Retry state should be cleared after success
-    assert!(snapshot.get_retry_state("flaky").is_none());
+    assert!(
+        snapshot
+            .get_retry_state(&sayiir_core::TaskId::from("flaky"))
+            .is_none()
+    );
 
     // Snapshot was saved to backend during retries — verify it has the task result
     let persisted = backend.load_snapshot("inst-1").await.unwrap();
-    assert!(persisted.get_task_result("flaky").is_some());
+    assert!(
+        persisted
+            .get_task_result(&sayiir_core::TaskId::from("flaky"))
+            .is_some()
+    );
 }
 
 #[tokio::test]
@@ -2087,7 +2141,7 @@ async fn test_checkpointing_retry_with_timeout() {
     let mut snapshot =
         WorkflowSnapshot::with_initial_input("inst-1".into(), "hash".into(), input.clone());
     snapshot.update_position(ExecutionPosition::AtTask {
-        task_id: "slow_then_fast".into(),
+        task_id: sayiir_core::TaskId::from("slow_then_fast"),
     });
     backend.save_snapshot(&snapshot).await.unwrap();
 
@@ -2178,8 +2232,16 @@ async fn test_checkpointing_retry_in_chain() {
     assert_eq!(decode_u32(&result), 12);
     assert_eq!(attempts.load(Ordering::SeqCst), 2);
     // Both tasks should be cached
-    assert!(snapshot.get_task_result("flaky").is_some());
-    assert!(snapshot.get_task_result("double").is_some());
+    assert!(
+        snapshot
+            .get_task_result(&sayiir_core::TaskId::from("flaky"))
+            .is_some()
+    );
+    assert!(
+        snapshot
+            .get_task_result(&sayiir_core::TaskId::from("double"))
+            .is_some()
+    );
 }
 
 // ========================================================================
@@ -2216,7 +2278,10 @@ async fn test_async_timeout_mid_chain_fails() {
     let result = execute_continuation_async(&fast_task, input, &JsonCodec).await;
     let err = result.unwrap_err();
     assert!(err.to_string().contains("timed out"));
-    assert!(err.to_string().contains("slow"));
+    assert!(
+        err.to_string()
+            .contains(&sayiir_core::TaskId::from("slow").to_hex())
+    );
 }
 
 #[tokio::test]
@@ -2320,9 +2385,16 @@ async fn test_checkpointing_timeout_mid_chain() {
 
     let err = result.unwrap_err();
     assert!(err.to_string().contains("timed out"));
-    assert!(err.to_string().contains("slow"));
+    assert!(
+        err.to_string()
+            .contains(&sayiir_core::TaskId::from("slow").to_hex())
+    );
     // First task should still be cached
-    assert!(snapshot.get_task_result("fast").is_some());
+    assert!(
+        snapshot
+            .get_task_result(&sayiir_core::TaskId::from("fast"))
+            .is_some()
+    );
 }
 
 // ========================================================================
@@ -2372,7 +2444,7 @@ async fn test_checkpointing_delay_terminal_parks() {
                 next_task_id,
                 ..
             } => {
-                assert_eq!(delay_id, "final_wait");
+                assert_eq!(*delay_id, sayiir_core::TaskId::from("final_wait"));
                 assert!(next_task_id.is_none());
             }
             other => panic!("Expected AtDelay, got {other:?}"),
@@ -2381,7 +2453,9 @@ async fn test_checkpointing_delay_terminal_parks() {
     }
 
     // Pass-through value should be stored
-    let stored = snapshot.get_task_result("final_wait").unwrap();
+    let stored = snapshot
+        .get_task_result(&sayiir_core::TaskId::from("final_wait"))
+        .unwrap();
     assert_eq!(decode_u32(&stored.output), 42);
 }
 
@@ -2429,7 +2503,11 @@ async fn test_checkpointing_delay_after_task_chain() {
         result.unwrap_err(),
         RuntimeError::Workflow(WorkflowError::Waiting { .. })
     ));
-    assert!(snapshot.get_task_result("prepare").is_some());
+    assert!(
+        snapshot
+            .get_task_result(&sayiir_core::TaskId::from("prepare"))
+            .is_some()
+    );
 
     // Wait for delay to expire
     tokio::time::sleep(std::time::Duration::from_millis(10)).await;
@@ -2878,7 +2956,10 @@ async fn test_checkpointing_loop_basic() {
 
     assert_eq!(decode_u32(&result), 0);
     // Loop iteration counter should be cleared after completion
-    assert_eq!(snapshot.loop_iteration("loop_0"), 0);
+    assert_eq!(
+        snapshot.loop_iteration(&sayiir_core::TaskId::from("loop_0")),
+        0
+    );
 }
 
 #[tokio::test]
@@ -2890,7 +2971,7 @@ async fn test_checkpointing_loop_resumes_from_iteration() {
         WorkflowSnapshot::with_initial_input("inst-1".into(), "hash-1".into(), input.clone());
 
     // Simulate: 2 iterations already completed. Next input should be 3 (5→4→3).
-    snapshot.set_loop_iteration("loop_0", 2);
+    snapshot.set_loop_iteration(sayiir_core::TaskId::from("loop_0"), 2);
     backend.save_snapshot(&snapshot).await.unwrap();
 
     let call_count = Arc::new(AtomicU32::new(0));
@@ -2936,7 +3017,10 @@ async fn test_checkpointing_loop_resumes_from_iteration() {
     // Should have run 4 body executions (3→2→1→0 → Done)
     assert_eq!(call_count.load(Ordering::SeqCst), 4);
     // Loop iteration counter should be cleared after completion
-    assert_eq!(snapshot.loop_iteration("loop_0"), 0);
+    assert_eq!(
+        snapshot.loop_iteration(&sayiir_core::TaskId::from("loop_0")),
+        0
+    );
 }
 
 // ========================================================================
@@ -3324,7 +3408,7 @@ async fn test_checkpointing_loop_caches_result_on_exit() {
     assert_eq!(decode_u32(&result), 0);
 
     // The loop node itself should have a cached result in the snapshot.
-    let cached = snapshot.get_task_result("loop_0");
+    let cached = snapshot.get_task_result(&sayiir_core::TaskId::from("loop_0"));
     assert!(cached.is_some(), "loop node should be cached after exit");
     assert_eq!(decode_u32(&cached.unwrap().output), 0);
 }
@@ -3339,7 +3423,7 @@ async fn test_checkpointing_loop_short_circuits_when_cached() {
 
     // Pre-cache a result for the loop node.
     let cached_output = encode_u32(42);
-    snapshot.mark_task_completed("loop_0".into(), cached_output.clone());
+    snapshot.mark_task_completed(sayiir_core::TaskId::from("loop_0"), cached_output.clone());
     backend.save_snapshot(&snapshot).await.unwrap();
 
     let body = stub_node("body", None);
@@ -3415,7 +3499,7 @@ async fn test_checkpointing_loop_exit_with_last() {
     assert_eq!(decode_u32(&result), 3);
 
     // Should be cached under the loop node.
-    let cached = snapshot.get_task_result("loop_0");
+    let cached = snapshot.get_task_result(&sayiir_core::TaskId::from("loop_0"));
     assert!(
         cached.is_some(),
         "loop node should be cached after exit_with_last"
@@ -3423,7 +3507,10 @@ async fn test_checkpointing_loop_exit_with_last() {
     assert_eq!(decode_u32(&cached.unwrap().output), 3);
 
     // Iteration counter should be cleared.
-    assert_eq!(snapshot.loop_iteration("loop_0"), 0);
+    assert_eq!(
+        snapshot.loop_iteration(&sayiir_core::TaskId::from("loop_0")),
+        0
+    );
 }
 
 #[tokio::test]
@@ -3478,7 +3565,11 @@ async fn test_checkpointing_loop_in_chain() {
     assert_eq!(decode_u32(&result), 20);
 
     // Loop node should be cached (even though there's a next step).
-    assert!(snapshot.get_task_result("loop_0").is_some());
+    assert!(
+        snapshot
+            .get_task_result(&sayiir_core::TaskId::from("loop_0"))
+            .is_some()
+    );
 }
 
 #[tokio::test]
@@ -3545,7 +3636,9 @@ async fn test_checkpointing_loop_inside_fork_branch() {
 
     // The loop node should be cached in the snapshot.
     assert!(
-        snapshot.get_task_result("loop_0").is_some(),
+        snapshot
+            .get_task_result(&sayiir_core::TaskId::from("loop_0"))
+            .is_some(),
         "loop inside fork branch should be cached"
     );
 }
@@ -3601,10 +3694,15 @@ async fn test_checkpointing_loop_iteration_counter_persisted() {
     // After completion, the backend's snapshot should also have the cached result.
     let persisted = backend.load_snapshot("inst-1").await.unwrap();
     assert!(
-        persisted.get_task_result("loop_0").is_some(),
+        persisted
+            .get_task_result(&sayiir_core::TaskId::from("loop_0"))
+            .is_some(),
         "loop result should be persisted to backend"
     );
-    assert_eq!(persisted.loop_iteration("loop_0"), 0);
+    assert_eq!(
+        persisted.loop_iteration(&sayiir_core::TaskId::from("loop_0")),
+        0
+    );
 }
 
 // ========================================================================

--- a/sayiir-runtime/src/runner/distributed.rs
+++ b/sayiir-runtime/src/runner/distributed.rs
@@ -298,7 +298,12 @@ where
                     retry_policy,
                     ..
                 } => {
-                    check_guards(backend.as_ref(), &snapshot.instance_id, Some(id)).await?;
+                    check_guards(
+                        backend.as_ref(),
+                        &snapshot.instance_id,
+                        Some(sayiir_core::TaskId::from(id)),
+                    )
+                    .await?;
                     set_deadline_if_needed(id, timeout.as_ref(), snapshot, backend.as_ref())
                         .await?;
 
@@ -316,13 +321,14 @@ where
                     .await?;
 
                     if let Some(next_cont) = current.get_next() {
-                        let next_id = next_cont.first_task_id().to_string();
+                        let next_name = next_cont.first_task_id().to_string();
+                        let next_hash = sayiir_core::TaskId::from(next_name.as_str());
                         snapshot.set_task_hint(&TaskHint::new(
-                            next_id.clone(),
-                            continuation.get_task_priority(&next_id),
-                            continuation.get_task_tags(&next_id),
+                            &next_name,
+                            continuation.get_task_priority(&next_hash),
+                            continuation.get_task_tags(&next_hash),
                         ));
-                        snapshot.update_position(ExecutionPosition::AtTask { task_id: next_id });
+                        snapshot.update_position(ExecutionPosition::AtTask { task_id: next_hash });
                     }
                     backend.save_snapshot(snapshot).await?;
                     check_guards(backend.as_ref(), &snapshot.instance_id, None).await?;
@@ -333,14 +339,22 @@ where
                     return Err(WorkflowError::TaskNotImplemented(id.clone()).into());
                 }
                 WorkflowContinuation::Delay { id, duration, next } => {
-                    check_guards(backend.as_ref(), &snapshot.instance_id, Some(id)).await?;
+                    check_guards(
+                        backend.as_ref(),
+                        &snapshot.instance_id,
+                        Some(sayiir_core::TaskId::from(id)),
+                    )
+                    .await?;
 
-                    if snapshot.get_task_result(id).is_some() {
+                    if snapshot
+                        .get_task_result(&sayiir_core::TaskId::from(id))
+                        .is_some()
+                    {
                         Ok(ControlFlow::Continue(current_input.clone()))
                     } else {
                         let wake_at = compute_wake_at(duration)?;
                         Ok(ControlFlow::Break(StepOutcome::Park(ParkReason::Delay {
-                            delay_id: id.clone(),
+                            delay_id: sayiir_core::TaskId::from(id),
                             wake_at,
                             next_task: next.as_deref().map(WorkflowContinuation::first_task_hint),
                             passthrough: current_input.clone(),
@@ -353,11 +367,19 @@ where
                     timeout,
                     next,
                 } => {
-                    check_guards(backend.as_ref(), &snapshot.instance_id, Some(id)).await?;
+                    check_guards(
+                        backend.as_ref(),
+                        &snapshot.instance_id,
+                        Some(sayiir_core::TaskId::from(id)),
+                    )
+                    .await?;
 
-                    if snapshot.get_task_result(id).is_some() {
+                    if snapshot
+                        .get_task_result(&sayiir_core::TaskId::from(id))
+                        .is_some()
+                    {
                         let payload = snapshot
-                            .get_task_result_bytes(id)
+                            .get_task_result_bytes(&sayiir_core::TaskId::from(id))
                             .unwrap_or(current_input.clone());
                         Ok(ControlFlow::Continue(payload))
                     } else {
@@ -366,27 +388,29 @@ where
                             .await
                         {
                             Ok(Some(payload)) => {
-                                snapshot.mark_task_completed(id.clone(), payload);
+                                snapshot
+                                    .mark_task_completed(sayiir_core::TaskId::from(id), payload);
                                 if let Some(next_cont) = next.as_deref() {
-                                    let next_id = next_cont.first_task_id().to_string();
+                                    let next_name = next_cont.first_task_id().to_string();
+                                    let next_hash = sayiir_core::TaskId::from(next_name.as_str());
                                     snapshot.set_task_hint(&TaskHint::new(
-                                        next_id.clone(),
-                                        continuation.get_task_priority(&next_id),
-                                        continuation.get_task_tags(&next_id),
+                                        &next_name,
+                                        continuation.get_task_priority(&next_hash),
+                                        continuation.get_task_tags(&next_hash),
                                     ));
                                     snapshot.update_position(ExecutionPosition::AtTask {
-                                        task_id: next_id,
+                                        task_id: next_hash,
                                     });
                                 }
                                 backend.save_snapshot(snapshot).await?;
                                 let output = snapshot
-                                    .get_task_result_bytes(id)
+                                    .get_task_result_bytes(&sayiir_core::TaskId::from(id))
                                     .unwrap_or(current_input.clone());
                                 Ok(ControlFlow::Continue(output))
                             }
                             Ok(None) => Ok(ControlFlow::Break(StepOutcome::Park(
                                 ParkReason::AwaitingSignal {
-                                    signal_id: id.clone(),
+                                    signal_id: sayiir_core::TaskId::from(id),
                                     signal_name: signal_name.clone(),
                                     timeout: compute_signal_timeout(timeout.as_ref()),
                                     next_task: next
@@ -441,9 +465,14 @@ where
                     default,
                     ..
                 } => {
-                    check_guards(backend.as_ref(), &snapshot.instance_id, Some(id)).await?;
+                    check_guards(
+                        backend.as_ref(),
+                        &snapshot.instance_id,
+                        Some(sayiir_core::TaskId::from(id)),
+                    )
+                    .await?;
 
-                    if let Some(result) = snapshot.get_task_result(id) {
+                    if let Some(result) = snapshot.get_task_result(&sayiir_core::TaskId::from(id)) {
                         Ok(ControlFlow::Continue(result.output.clone()))
                     } else {
                         let key_bytes = key_fn
@@ -476,7 +505,10 @@ where
                             .encode_branch_envelope(&key, &branch_output)
                             .map_err(RuntimeError::from)?;
 
-                        snapshot.mark_task_completed(id.clone(), envelope_bytes.clone());
+                        snapshot.mark_task_completed(
+                            sayiir_core::TaskId::from(id),
+                            envelope_bytes.clone(),
+                        );
                         backend.save_snapshot(snapshot).await?;
 
                         Ok(ControlFlow::Continue(envelope_bytes))
@@ -497,9 +529,14 @@ where
                     on_max,
                     ..
                 } => {
-                    check_guards(backend.as_ref(), &snapshot.instance_id, Some(id)).await?;
+                    check_guards(
+                        backend.as_ref(),
+                        &snapshot.instance_id,
+                        Some(sayiir_core::TaskId::from(id)),
+                    )
+                    .await?;
 
-                    if let Some(result) = snapshot.get_task_result(id) {
+                    if let Some(result) = snapshot.get_task_result(&sayiir_core::TaskId::from(id)) {
                         Ok(ControlFlow::Continue(result.output.clone()))
                     } else {
                         let cfg = LoopConfig {
@@ -507,7 +544,8 @@ where
                             body,
                             max_iterations: *max_iterations,
                             on_max: *on_max,
-                            start_iteration: snapshot.loop_iteration(id),
+                            start_iteration: snapshot
+                                .loop_iteration(&sayiir_core::TaskId::from(id)),
                         };
                         let mut loop_input = current_input.clone();
                         let mut final_output = None;
@@ -524,23 +562,31 @@ where
 
                             let body_ser = body.to_serializable();
                             for tid in &body_ser.task_ids() {
-                                snapshot.remove_task_result(tid);
+                                snapshot.remove_task_result(&sayiir_core::TaskId::from(*tid));
                             }
 
                             match resolve_loop_iteration(&output, iteration, &cfg)? {
                                 ControlFlow::Break(LoopExit(inner)) => {
-                                    snapshot.clear_loop_iteration(id);
-                                    snapshot.mark_task_completed(id.clone(), inner.clone());
+                                    snapshot.clear_loop_iteration(&sayiir_core::TaskId::from(id));
+                                    snapshot.mark_task_completed(
+                                        sayiir_core::TaskId::from(id),
+                                        inner.clone(),
+                                    );
                                     backend.save_snapshot(snapshot).await?;
                                     final_output = Some(inner);
                                     break;
                                 }
                                 ControlFlow::Continue(LoopNext(inner)) => {
-                                    snapshot.set_loop_iteration(id, iteration + 1);
+                                    snapshot.set_loop_iteration(
+                                        sayiir_core::TaskId::from(id),
+                                        iteration + 1,
+                                    );
                                     snapshot.update_position(ExecutionPosition::InLoop {
-                                        loop_id: id.clone(),
+                                        loop_id: sayiir_core::TaskId::from(id),
                                         iteration: iteration + 1,
-                                        next_task_id: Some(body.first_task_id().to_string()),
+                                        next_task_id: Some(sayiir_core::TaskId::from(
+                                            body.first_task_id(),
+                                        )),
                                     });
                                     backend.save_snapshot(snapshot).await?;
                                     loop_input = inner;
@@ -551,16 +597,21 @@ where
                         match final_output {
                             Some(output) => Ok(ControlFlow::Continue(output)),
                             None => Err(RuntimeError::from(WorkflowError::MaxIterationsExceeded {
-                                loop_id: id.clone(),
+                                loop_id: sayiir_core::TaskId::from(id),
                                 max_iterations: *max_iterations,
                             })),
                         }
                     }
                 }
                 WorkflowContinuation::ChildWorkflow { id, child, .. } => {
-                    check_guards(backend.as_ref(), &snapshot.instance_id, Some(id)).await?;
+                    check_guards(
+                        backend.as_ref(),
+                        &snapshot.instance_id,
+                        Some(sayiir_core::TaskId::from(id)),
+                    )
+                    .await?;
 
-                    if let Some(result) = snapshot.get_task_result(id) {
+                    if let Some(result) = snapshot.get_task_result(&sayiir_core::TaskId::from(id)) {
                         Ok(ControlFlow::Continue(result.output.clone()))
                     } else {
                         let output = Box::pin(Self::execute_with_checkpointing(
@@ -572,7 +623,7 @@ where
                         ))
                         .await?;
 
-                        snapshot.mark_task_completed(id.clone(), output.clone());
+                        snapshot.mark_task_completed(sayiir_core::TaskId::from(id), output.clone());
                         backend.save_snapshot(snapshot).await?;
 
                         Ok(ControlFlow::Continue(output))
@@ -614,10 +665,11 @@ where
         let instance_id = snapshot.instance_id.clone();
 
         for branch in branches {
-            let branch_id = branch.id().to_string();
+            let branch_name = branch.id().to_string();
+            let branch_hash = sayiir_core::TaskId::from(branch_name.as_str());
 
-            if let Some(result) = snapshot.get_task_result(&branch_id) {
-                branch_results.push((branch_id, result.output.clone()));
+            if let Some(result) = snapshot.get_task_result(&branch_hash) {
+                branch_results.push((branch_name, result.output.clone()));
             } else {
                 let branch = Arc::clone(branch);
                 let branch_input = input.clone();
@@ -634,7 +686,7 @@ where
                         ctx_for_work,
                     )
                     .await?;
-                    Ok((branch_id, result))
+                    Ok((branch_name, result))
                 });
             }
         }
@@ -762,19 +814,24 @@ where
                             .await
                             {
                                 Ok(output) => {
-                                    snapshot.clear_retry_state(id);
+                                    snapshot.clear_retry_state(&sayiir_core::TaskId::from(id));
                                     break output;
                                 }
                                 Err(e) => {
                                     if let Some(rp) = retry_policy
-                                        && !snapshot.retries_exhausted(id)
+                                        && !snapshot
+                                            .retries_exhausted(&sayiir_core::TaskId::from(id))
                                     {
-                                        let next_retry_at =
-                                            snapshot.record_retry(id, rp, &e.to_string(), None);
+                                        let next_retry_at = snapshot.record_retry(
+                                            sayiir_core::TaskId::from(id),
+                                            rp,
+                                            &e.to_string(),
+                                            None,
+                                        );
                                         snapshot.clear_task_deadline();
                                         tracing::info!(
                                             task_id = %id,
-                                            attempt = snapshot.get_retry_state(id).map_or(0, |rs| rs.attempts),
+                                            attempt = snapshot.get_retry_state(&sayiir_core::TaskId::from(id)).map_or(0, |rs| rs.attempts),
                                             max_retries = rp.max_retries,
                                             %next_retry_at,
                                             error = %e,
@@ -793,13 +850,15 @@ where
                         Ok(ControlFlow::Continue(output))
                     }
                     WorkflowContinuation::Delay { id, duration, .. } => {
-                        if let Some(result) = snapshot.get_task_result(id) {
+                        if let Some(result) =
+                            snapshot.get_task_result(&sayiir_core::TaskId::from(id))
+                        {
                             tracing::debug!(delay_id = %id, "delay already completed in branch, skipping");
                             Ok(ControlFlow::Continue(result.output.clone()))
                         } else {
                             let wake_at = compute_wake_at(duration)?;
                             Ok(ControlFlow::Break(StepOutcome::Park(ParkReason::Delay {
-                                delay_id: id.clone(),
+                                delay_id: sayiir_core::TaskId::from(id),
                                 wake_at,
                                 next_task: None,
                                 passthrough: current_input.clone(),
@@ -812,14 +871,16 @@ where
                         timeout,
                         ..
                     } => {
-                        if let Some(result) = snapshot.get_task_result(id) {
+                        if let Some(result) =
+                            snapshot.get_task_result(&sayiir_core::TaskId::from(id))
+                        {
                             tracing::debug!(signal_id = %id, %signal_name, "signal already consumed in branch, skipping");
                             Ok(ControlFlow::Continue(result.output.clone()))
                         } else {
                             let wake_at = compute_signal_timeout(timeout.as_ref());
                             Ok(ControlFlow::Break(StepOutcome::Park(
                                 ParkReason::AwaitingSignal {
-                                    signal_id: id.clone(),
+                                    signal_id: sayiir_core::TaskId::from(id),
                                     signal_name: signal_name.clone(),
                                     timeout: wake_at,
                                     next_task: None,
@@ -857,7 +918,9 @@ where
                         default,
                         ..
                     } => {
-                        if let Some(result) = snapshot.get_task_result(id) {
+                        if let Some(result) =
+                            snapshot.get_task_result(&sayiir_core::TaskId::from(id))
+                        {
                             Ok(ControlFlow::Continue(result.output.clone()))
                         } else {
                             let key_bytes = key_fn
@@ -891,7 +954,10 @@ where
                                 .encode_branch_envelope(&key, &branch_output)
                                 .map_err(RuntimeError::from)?;
 
-                            snapshot.mark_task_completed(id.clone(), envelope_bytes.clone());
+                            snapshot.mark_task_completed(
+                                sayiir_core::TaskId::from(id),
+                                envelope_bytes.clone(),
+                            );
                             backend.save_snapshot(&snapshot).await?;
 
                             Ok(ControlFlow::Continue(envelope_bytes))
@@ -912,7 +978,9 @@ where
                         on_max,
                         ..
                     } => {
-                        if let Some(result) = snapshot.get_task_result(id) {
+                        if let Some(result) =
+                            snapshot.get_task_result(&sayiir_core::TaskId::from(id))
+                        {
                             Ok(ControlFlow::Continue(result.output.clone()))
                         } else {
                             let cfg = LoopConfig {
@@ -920,7 +988,8 @@ where
                                 body,
                                 max_iterations: *max_iterations,
                                 on_max: *on_max,
-                                start_iteration: snapshot.loop_iteration(id),
+                                start_iteration: snapshot
+                                    .loop_iteration(&sayiir_core::TaskId::from(id)),
                             };
                             let mut hooks = CheckpointingLoopHooks {
                                 snapshot: &mut snapshot,
@@ -946,7 +1015,9 @@ where
                         }
                     }
                     WorkflowContinuation::ChildWorkflow { id, child, .. } => {
-                        if let Some(result) = snapshot.get_task_result(id) {
+                        if let Some(result) =
+                            snapshot.get_task_result(&sayiir_core::TaskId::from(id))
+                        {
                             Ok(ControlFlow::Continue(result.output.clone()))
                         } else {
                             let output = Box::pin(Self::execute_branch_with_checkpoint(
@@ -958,7 +1029,8 @@ where
                             ))
                             .await?;
 
-                            snapshot.mark_task_completed(id.clone(), output.clone());
+                            snapshot
+                                .mark_task_completed(sayiir_core::TaskId::from(id), output.clone());
                             backend.save_snapshot(&snapshot).await?;
 
                             Ok(ControlFlow::Continue(output))
@@ -1219,7 +1291,7 @@ mod tests {
             Bytes::from(serde_json::to_vec(&5u32).unwrap()),
         );
         snapshot.update_position(ExecutionPosition::AtTask {
-            task_id: "step1".into(),
+            task_id: sayiir_core::TaskId::from("step1"),
         });
         runner.backend().save_snapshot(&snapshot).await.unwrap();
 
@@ -1262,7 +1334,7 @@ mod tests {
             input_bytes,
         );
         snapshot.update_position(ExecutionPosition::AtTask {
-            task_id: "slow_task".into(),
+            task_id: sayiir_core::TaskId::from("slow_task"),
         });
         runner.backend().save_snapshot(&snapshot).await.unwrap();
 
@@ -1306,7 +1378,7 @@ mod tests {
             input_bytes,
         );
         snapshot.update_position(ExecutionPosition::AtTask {
-            task_id: "task1".into(),
+            task_id: sayiir_core::TaskId::from("task1"),
         });
         runner.backend().save_snapshot(&snapshot).await.unwrap();
 
@@ -1392,7 +1464,7 @@ mod tests {
         // Should return Waiting (delay is 1 hour in the future)
         match &status {
             WorkflowStatus::Waiting { delay_id, .. } => {
-                assert_eq!(delay_id, "wait_1h");
+                assert_eq!(*delay_id, sayiir_core::TaskId::from("wait_1h"));
             }
             _ => panic!("Expected Waiting status, got {status:?}"),
         }
@@ -1407,8 +1479,8 @@ mod tests {
                     next_task_id,
                     ..
                 } => {
-                    assert_eq!(delay_id, "wait_1h");
-                    assert_eq!(next_task_id.as_deref(), Some("step2"));
+                    assert_eq!(*delay_id, sayiir_core::TaskId::from("wait_1h"));
+                    assert_eq!(next_task_id, &Some(sayiir_core::TaskId::from("step2")));
                 }
                 other => panic!("Expected AtDelay, got {other:?}"),
             },
@@ -1416,9 +1488,17 @@ mod tests {
         }
 
         // step1 should have been completed
-        assert!(snapshot.get_task_result("step1").is_some());
+        assert!(
+            snapshot
+                .get_task_result(&sayiir_core::TaskId::from("step1"))
+                .is_some()
+        );
         // delay pass-through should be stored
-        assert!(snapshot.get_task_result("wait_1h").is_some());
+        assert!(
+            snapshot
+                .get_task_result(&sayiir_core::TaskId::from("wait_1h"))
+                .is_some()
+        );
     }
 
     #[tokio::test]
@@ -1441,7 +1521,7 @@ mod tests {
         let status = runner.resume(&workflow, "inst-1").await.unwrap();
         match &status {
             WorkflowStatus::Waiting { delay_id, .. } => {
-                assert_eq!(delay_id, "wait_1h");
+                assert_eq!(*delay_id, sayiir_core::TaskId::from("wait_1h"));
             }
             _ => panic!("Expected Waiting on resume, got {status:?}"),
         }
@@ -1606,9 +1686,10 @@ mod tests {
                     msg.contains("timed out"),
                     "Expected timeout error, got: {msg}"
                 );
+                let slow_hash = sayiir_core::TaskId::from("slow_task").to_hex();
                 assert!(
-                    msg.contains("slow_task"),
-                    "Expected task id in error, got: {msg}"
+                    msg.contains(&slow_hash),
+                    "Expected task id hash in error, got: {msg}"
                 );
             }
             other => panic!("Expected Failed status, got {other:?}"),

--- a/sayiir-runtime/src/runner/distributed.rs
+++ b/sayiir-runtime/src/runner/distributed.rs
@@ -184,10 +184,12 @@ where
         // Execute workflow with checkpointing
         let context = workflow.context().clone();
         let continuation = workflow.continuation();
+        let task_index = workflow.task_index();
         let backend = Arc::clone(&self.backend);
 
         let result = Self::execute_with_checkpointing(
             continuation,
+            task_index,
             input_bytes,
             &mut snapshot,
             Arc::clone(&backend),
@@ -254,6 +256,7 @@ where
         // Resume execution
         let context = workflow.context().clone();
         let continuation = workflow.continuation();
+        let task_index = workflow.task_index();
         let backend = Arc::clone(&self.backend);
 
         // Get the last completed task's output or initial input
@@ -261,6 +264,7 @@ where
 
         let result = Self::execute_with_checkpointing(
             continuation,
+            task_index,
             input_bytes,
             &mut snapshot,
             Arc::clone(&backend),
@@ -276,6 +280,7 @@ where
     #[allow(clippy::manual_async_fn, clippy::too_many_lines)]
     async fn execute_with_checkpointing<'a, C, M>(
         continuation: &'a WorkflowContinuation,
+        task_index: &'a sayiir_core::TaskIndex,
         input: Bytes,
         snapshot: &'a mut WorkflowSnapshot,
         backend: Arc<B>,
@@ -325,8 +330,8 @@ where
                         let next_hash = sayiir_core::TaskId::from(next_name.as_str());
                         snapshot.set_task_hint(&TaskHint::new(
                             &next_name,
-                            continuation.get_task_priority(&next_hash),
-                            continuation.get_task_tags(&next_hash),
+                            task_index.priority(&next_hash),
+                            task_index.tags(&next_hash),
                         ));
                         snapshot.update_position(ExecutionPosition::AtTask { task_id: next_hash });
                     }
@@ -354,7 +359,7 @@ where
                     } else {
                         let wake_at = compute_wake_at(duration)?;
                         Ok(ControlFlow::Break(StepOutcome::Park(ParkReason::Delay {
-                            delay_id: sayiir_core::TaskId::from(id),
+                            delay_id: sayiir_core::TaskId::from(id.as_str()),
                             wake_at,
                             next_task: next.as_deref().map(WorkflowContinuation::first_task_hint),
                             passthrough: current_input.clone(),
@@ -410,7 +415,7 @@ where
                             }
                             Ok(None) => Ok(ControlFlow::Break(StepOutcome::Park(
                                 ParkReason::AwaitingSignal {
-                                    signal_id: sayiir_core::TaskId::from(id),
+                                    signal_id: sayiir_core::TaskId::from(id.as_str()),
                                     signal_name: signal_name.clone(),
                                     timeout: compute_signal_timeout(timeout.as_ref()),
                                     next_task: next
@@ -553,6 +558,7 @@ where
                         for iteration in cfg.start_iteration..cfg.max_iterations {
                             let output = Box::pin(Self::execute_with_checkpointing(
                                 body,
+                                task_index,
                                 loop_input.clone(),
                                 snapshot,
                                 Arc::clone(&backend),
@@ -616,6 +622,7 @@ where
                     } else {
                         let output = Box::pin(Self::execute_with_checkpointing(
                             child,
+                            task_index,
                             current_input.clone(),
                             snapshot,
                             Arc::clone(&backend),

--- a/sayiir-runtime/src/runner/distributed.rs
+++ b/sayiir-runtime/src/runner/distributed.rs
@@ -400,8 +400,8 @@ where
                                     let next_hash = sayiir_core::TaskId::from(next_name.as_str());
                                     snapshot.set_task_hint(&TaskHint::new(
                                         &next_name,
-                                        continuation.get_task_priority(&next_hash),
-                                        continuation.get_task_tags(&next_hash),
+                                        task_index.priority(&next_hash),
+                                        task_index.tags(&next_hash),
                                     ));
                                     snapshot.update_position(ExecutionPosition::AtTask {
                                         task_id: next_hash,

--- a/sayiir-runtime/src/runner/distributed.rs
+++ b/sayiir-runtime/src/runner/distributed.rs
@@ -733,12 +733,13 @@ where
     {
         let mut set: tokio::task::JoinSet<Result<(String, Bytes), RuntimeError>> =
             tokio::task::JoinSet::new();
+        let shared_instance_id: Arc<str> = Arc::from(instance_id);
         for branch in branches {
             let id = branch.id().to_string();
             let branch = Arc::clone(branch);
             let branch_input = input.clone();
             let branch_backend = Arc::clone(backend);
-            let branch_instance_id: Arc<str> = Arc::from(instance_id);
+            let branch_instance_id = Arc::clone(&shared_instance_id);
             let ctx_for_work = context.clone();
 
             set.spawn(async move {

--- a/sayiir-runtime/src/runner/distributed.rs
+++ b/sayiir-runtime/src/runner/distributed.rs
@@ -166,7 +166,7 @@ where
         let first_task = workflow.continuation().first_task_hint();
 
         let mut snapshot = match prepare_run(
-            instance_id,
+            &instance_id,
             definition_hash,
             input_bytes.clone(),
             first_task,
@@ -738,7 +738,7 @@ where
             let branch = Arc::clone(branch);
             let branch_input = input.clone();
             let branch_backend = Arc::clone(backend);
-            let branch_instance_id = instance_id.to_string();
+            let branch_instance_id: Arc<str> = Arc::from(instance_id);
             let ctx_for_work = context.clone();
 
             set.spawn(async move {
@@ -774,7 +774,7 @@ where
         continuation: &WorkflowContinuation,
         input: Bytes,
         backend: Arc<B>,
-        instance_id: String,
+        instance_id: Arc<str>,
         context: WorkflowContext<C, M>,
     ) -> impl std::future::Future<Output = Result<Bytes, RuntimeError>> + Send + '_
     where
@@ -1286,7 +1286,7 @@ mod tests {
 
         // Manually create in-progress snapshot with workflow1's hash
         let mut snapshot = WorkflowSnapshot::with_initial_input(
-            "inst-2".into(),
+            "inst-2",
             *workflow1.definition_hash(),
             Bytes::from(serde_json::to_vec(&5u32).unwrap()),
         );
@@ -1329,7 +1329,7 @@ mod tests {
         // Set up a snapshot as if it's in progress
         let input_bytes = Arc::new(JsonCodec).encode(&1u32).unwrap();
         let mut snapshot = WorkflowSnapshot::with_initial_input(
-            "inst-cancel".into(),
+            "inst-cancel",
             *workflow.definition_hash(),
             input_bytes,
         );
@@ -1373,7 +1373,7 @@ mod tests {
         // Save initial snapshot and request cancellation before running
         let input_bytes = Arc::new(JsonCodec).encode(&1u32).unwrap();
         let mut snapshot = WorkflowSnapshot::with_initial_input(
-            "inst-precancel".into(),
+            "inst-precancel",
             *workflow.definition_hash(),
             input_bytes,
         );

--- a/sayiir-runtime/src/runner/distributed.rs
+++ b/sayiir-runtime/src/runner/distributed.rs
@@ -146,7 +146,7 @@ where
         use crate::{PrepareRunOutcome, check_existing_instance, prepare_run};
 
         let instance_id = instance_id.into();
-        let definition_hash = workflow.definition_hash().to_string();
+        let definition_hash = *workflow.definition_hash();
         let conflict_policy = self.conflict_policy;
 
         // Phase 1: check for existing instance before encoding input.
@@ -229,10 +229,10 @@ where
         let mut snapshot = self.backend.load_snapshot(instance_id).await?;
 
         // Validate definition hash
-        if snapshot.definition_hash != workflow.definition_hash() {
+        if snapshot.definition_hash != *workflow.definition_hash() {
             return Err(WorkflowError::DefinitionMismatch {
-                expected: workflow.definition_hash().to_string(),
-                found: snapshot.definition_hash.clone(),
+                expected: *workflow.definition_hash(),
+                found: snapshot.definition_hash,
             }
             .into());
         }
@@ -1215,7 +1215,7 @@ mod tests {
         // Manually create in-progress snapshot with workflow1's hash
         let mut snapshot = WorkflowSnapshot::with_initial_input(
             "inst-2".into(),
-            workflow1.definition_hash().to_string(),
+            *workflow1.definition_hash(),
             Bytes::from(serde_json::to_vec(&5u32).unwrap()),
         );
         snapshot.update_position(ExecutionPosition::AtTask {
@@ -1258,7 +1258,7 @@ mod tests {
         let input_bytes = Arc::new(JsonCodec).encode(&1u32).unwrap();
         let mut snapshot = WorkflowSnapshot::with_initial_input(
             "inst-cancel".into(),
-            workflow.definition_hash().to_string(),
+            *workflow.definition_hash(),
             input_bytes,
         );
         snapshot.update_position(ExecutionPosition::AtTask {
@@ -1302,7 +1302,7 @@ mod tests {
         let input_bytes = Arc::new(JsonCodec).encode(&1u32).unwrap();
         let mut snapshot = WorkflowSnapshot::with_initial_input(
             "inst-precancel".into(),
-            workflow.definition_hash().to_string(),
+            *workflow.definition_hash(),
             input_bytes,
         );
         snapshot.update_position(ExecutionPosition::AtTask {

--- a/sayiir-runtime/src/worker.rs
+++ b/sayiir-runtime/src/worker.rs
@@ -156,7 +156,7 @@ impl<B> WorkerHandle<B> {
 /// No `Drop` impl — callers must explicitly call `release()` or `release_quietly()`.
 struct ActiveTaskClaim<'a, B> {
     backend: &'a B,
-    instance_id: String,
+    instance_id: std::sync::Arc<str>,
     task_id: sayiir_core::TaskId,
     worker_id: String,
 }
@@ -729,7 +729,7 @@ where
 
         let task_ctx = TaskExecutionContext {
             workflow_id: Arc::clone(&ext_wf.workflow_id),
-            instance_id: Arc::from(available_task.instance_id.as_str()),
+            instance_id: Arc::clone(&available_task.instance_id),
             task_id: Arc::clone(&task_name),
             metadata: continuation.build_task_metadata(&task_id),
             workflow_metadata_json: ext_wf.metadata_json.clone(),
@@ -1122,7 +1122,7 @@ where
 
         let task_ctx = TaskExecutionContext {
             workflow_id: Arc::from(workflow.context().workflow_id()),
-            instance_id: Arc::from(available_task.instance_id.as_str()),
+            instance_id: Arc::clone(&available_task.instance_id),
             task_id: Arc::clone(&task_name),
             metadata: continuation.build_task_metadata(&task_id),
             workflow_metadata_json: workflow.context().metadata_json.clone(),
@@ -2234,7 +2234,7 @@ mod tests {
         let registry = TaskRegistry::new();
 
         // Create a workflow snapshot so store_signal can validate it
-        let snapshot = WorkflowSnapshot::new("wf-1".to_string(), "hash-1".into());
+        let snapshot = WorkflowSnapshot::new("wf-1", "hash-1".into());
         backend.save_snapshot(&snapshot).await.ok();
 
         let worker = PooledWorker::new("test-worker", backend, registry);

--- a/sayiir-runtime/src/worker.rs
+++ b/sayiir-runtime/src/worker.rs
@@ -594,11 +594,7 @@ where
     /// True if the worker has the hint's workflow registered and its
     /// tag set covers the hint's tags.
     fn can_handle_hint(&self, hint: &TaskWakeupHint, workflows: &impl WorkflowLookup) -> bool {
-        // `TaskWakeupHint.definition_hash` is the hex wire form; parse once for the
-        // O(1) HashMap probe. Malformed hex means we can't match — drop the hint.
-        let Ok(hash) = sayiir_core::DefinitionHash::from_hex(&hint.definition_hash) else {
-            return false;
-        };
+        let hash = sayiir_core::DefinitionHash::from_bytes(hint.definition_hash);
         if !workflows.contains_definition_hash(&hash) {
             return false;
         }

--- a/sayiir-runtime/src/worker.rs
+++ b/sayiir-runtime/src/worker.rs
@@ -695,6 +695,7 @@ where
         self.settle_execution_result_ext(
             execution_result,
             &ext_wf.continuation,
+            &ext_wf.task_index,
             available_task,
             &mut snapshot,
             claim,
@@ -718,16 +719,17 @@ where
         // walk and no per-node SHA-256 — this is a single hash-map probe.
         let indexed_meta = ext_wf.task_index.get(&task_id);
         let task_name: Arc<str> =
-            indexed_meta.map_or_else(|| Arc::from(task_id.to_hex()), |m| Arc::clone(&m.name));
+            indexed_meta.map_or_else(|| Arc::from(task_id.to_hex()), |m| Arc::clone(m.name()));
 
-        let deadline = if let Some(timeout) = indexed_meta.and_then(|m| m.timeout) {
-            snapshot.set_task_deadline(task_id, timeout);
-            let _ = self.backend.save_snapshot(snapshot).await;
-            snapshot.refresh_task_deadline();
-            snapshot.task_deadline.clone()
-        } else {
-            None
-        };
+        let deadline =
+            if let Some(timeout) = indexed_meta.and_then(sayiir_core::TaskNodeMetadata::timeout) {
+                snapshot.set_task_deadline(task_id, timeout);
+                let _ = self.backend.save_snapshot(snapshot).await;
+                snapshot.refresh_task_deadline();
+                snapshot.task_deadline.clone()
+            } else {
+                None
+            };
 
         let task_ctx = TaskExecutionContext {
             workflow_id: Arc::clone(&ext_wf.workflow_id),
@@ -767,6 +769,7 @@ where
         &self,
         outcome: ExecutionOutcome,
         continuation: &WorkflowContinuation,
+        task_index: &sayiir_core::TaskIndex,
         available_task: &AvailableTask,
         snapshot: &mut WorkflowSnapshot,
         claim: ActiveTaskClaim<'_, B>,
@@ -775,7 +778,7 @@ where
         match outcome {
             ExecutionOutcome::Timeout(err) => {
                 if let Ok(Some(status)) = self
-                    .try_schedule_retry(continuation, available_task, snapshot, &err.to_string())
+                    .try_schedule_retry(task_index, available_task, snapshot, &err.to_string())
                     .await
                 {
                     claim.release_quietly().await;
@@ -797,7 +800,7 @@ where
                 let panic_msg = extract_panic_message(&panic_payload);
 
                 if let Ok(Some(status)) = self
-                    .try_schedule_retry(continuation, available_task, snapshot, &panic_msg)
+                    .try_schedule_retry(task_index, available_task, snapshot, &panic_msg)
                     .await
                 {
                     claim.release_quietly().await;
@@ -815,7 +818,7 @@ where
             }
             ExecutionOutcome::TaskError(e) => {
                 if let Ok(Some(status)) = self
-                    .try_schedule_retry(continuation, available_task, snapshot, &e.to_string())
+                    .try_schedule_retry(task_index, available_task, snapshot, &e.to_string())
                     .await
                 {
                     claim.release_quietly().await;
@@ -1109,19 +1112,20 @@ where
         // task context exposed to user code (no tree walk, no rehashing).
         let indexed_meta = task_index.get(&task_id);
         let task_name: Arc<str> =
-            indexed_meta.map_or_else(|| Arc::from(task_id.to_hex()), |m| Arc::clone(&m.name));
+            indexed_meta.map_or_else(|| Arc::from(task_id.to_hex()), |m| Arc::clone(m.name()));
 
         // Set deadline if task has a timeout configured
-        let deadline = if let Some(timeout) = indexed_meta.and_then(|m| m.timeout) {
-            snapshot.set_task_deadline(task_id, timeout);
-            let _ = self.backend.save_snapshot(snapshot).await;
-            // Refresh deadline to now + timeout so it measures actual execution
-            // time, not time spent on the snapshot save above.
-            snapshot.refresh_task_deadline();
-            snapshot.task_deadline.clone()
-        } else {
-            None
-        };
+        let deadline =
+            if let Some(timeout) = indexed_meta.and_then(sayiir_core::TaskNodeMetadata::timeout) {
+                snapshot.set_task_deadline(task_id, timeout);
+                let _ = self.backend.save_snapshot(snapshot).await;
+                // Refresh deadline to now + timeout so it measures actual execution
+                // time, not time spent on the snapshot save above.
+                snapshot.refresh_task_deadline();
+                snapshot.task_deadline.clone()
+            } else {
+                None
+            };
 
         let task_ctx = TaskExecutionContext {
             workflow_id: Arc::from(workflow.context().workflow_id()),
@@ -1155,18 +1159,18 @@ where
 
     /// Try to schedule a retry for a failed task.
     ///
-    /// Looks up the retry policy on the continuation. If retries are available,
+    /// Looks up the retry policy in the task index. If retries are available,
     /// records the retry state on the snapshot, clears the deadline, saves the
     /// snapshot, releases the claim, and returns `Ok(Some(InProgress))`.
     /// Otherwise returns `Ok(None)` (caller falls through to existing error handling).
     async fn try_schedule_retry(
         &self,
-        continuation: &WorkflowContinuation,
+        task_index: &sayiir_core::TaskIndex,
         available_task: &AvailableTask,
         snapshot: &mut WorkflowSnapshot,
         error_msg: &str,
     ) -> Result<Option<WorkflowStatus>, crate::error::RuntimeError> {
-        let Some(policy) = continuation.get_task_retry_policy(&available_task.task_id) else {
+        let Some(policy) = task_index.retry_policy(&available_task.task_id) else {
             return Ok(None);
         };
 
@@ -1223,7 +1227,7 @@ where
             ExecutionOutcome::Timeout(err) => {
                 if let Ok(Some(status)) = self
                     .try_schedule_retry(
-                        workflow.continuation(),
+                        workflow.task_index(),
                         available_task,
                         snapshot,
                         &err.to_string(),
@@ -1249,12 +1253,7 @@ where
                 let panic_msg = extract_panic_message(&panic_payload);
 
                 if let Ok(Some(status)) = self
-                    .try_schedule_retry(
-                        workflow.continuation(),
-                        available_task,
-                        snapshot,
-                        &panic_msg,
-                    )
+                    .try_schedule_retry(workflow.task_index(), available_task, snapshot, &panic_msg)
                     .await
                 {
                     claim.release_quietly().await;
@@ -1273,7 +1272,7 @@ where
             ExecutionOutcome::TaskError(e) => {
                 if let Ok(Some(status)) = self
                     .try_schedule_retry(
-                        workflow.continuation(),
+                        workflow.task_index(),
                         available_task,
                         snapshot,
                         &e.to_string(),

--- a/sayiir-runtime/src/worker.rs
+++ b/sayiir-runtime/src/worker.rs
@@ -47,7 +47,7 @@ pub type WorkflowRegistry<C, Input, M> =
 pub struct ExternalWorkflow {
     /// The continuation tree describing the workflow structure.
     pub continuation: Arc<WorkflowContinuation>,
-    /// The workflow definition identifier (e.g. workflow name/ID).
+    /// Human-readable workflow name (for log/error display and FFI task executor).
     pub workflow_id: Arc<str>,
     /// Optional JSON-encoded workflow-level metadata.
     pub metadata_json: Option<Arc<str>>,
@@ -157,7 +157,7 @@ impl<B> WorkerHandle<B> {
 struct ActiveTaskClaim<'a, B> {
     backend: &'a B,
     instance_id: String,
-    task_id: String,
+    task_id: sayiir_core::TaskId,
     worker_id: String,
 }
 
@@ -709,11 +709,17 @@ where
         claim: &ActiveTaskClaim<'_, B>,
     ) -> ExecutionOutcome {
         let continuation = &ext_wf.continuation;
-        let task_id = available_task.task_id.clone();
+        let task_id = available_task.task_id;
         let input = available_task.input.clone();
+        // Resolve the human-readable task name from the continuation tree so we
+        // can hand it to the external task executor (which looks up Python/Node
+        // functions by name).
+        let task_name: Arc<str> = continuation
+            .find_task_name(&task_id)
+            .map_or_else(|| Arc::from(task_id.to_hex()), Arc::from);
 
         let deadline = if let Some(timeout) = continuation.get_task_timeout(&task_id) {
-            snapshot.set_task_deadline(task_id.clone(), timeout);
+            snapshot.set_task_deadline(task_id, timeout);
             let _ = self.backend.save_snapshot(snapshot).await;
             snapshot.refresh_task_deadline();
             snapshot.task_deadline.clone()
@@ -724,12 +730,12 @@ where
         let task_ctx = TaskExecutionContext {
             workflow_id: Arc::clone(&ext_wf.workflow_id),
             instance_id: Arc::from(available_task.instance_id.as_str()),
-            task_id: Arc::from(available_task.task_id.as_str()),
-            metadata: continuation.build_task_metadata(&available_task.task_id),
+            task_id: Arc::clone(&task_name),
+            metadata: continuation.build_task_metadata(&task_id),
             workflow_metadata_json: ext_wf.metadata_json.clone(),
         };
 
-        let execution_future = with_task_context(task_ctx, executor(&task_id, input));
+        let execution_future = with_task_context(task_ctx, executor(&task_name, input));
 
         let heartbeat_result = self
             .run_with_heartbeat(
@@ -1094,12 +1100,17 @@ where
             + 'static,
     {
         let continuation = workflow.continuation();
-        let task_id = available_task.task_id.clone();
+        let task_id = available_task.task_id;
         let input = available_task.input.clone();
+        // Resolve human-readable task name from the continuation tree for the
+        // task context exposed to user code.
+        let task_name: Arc<str> = continuation
+            .find_task_name(&task_id)
+            .map_or_else(|| Arc::from(task_id.to_hex()), Arc::from);
 
         // Set deadline if task has a timeout configured
         let deadline = if let Some(timeout) = continuation.get_task_timeout(&task_id) {
-            snapshot.set_task_deadline(task_id.clone(), timeout);
+            snapshot.set_task_deadline(task_id, timeout);
             let _ = self.backend.save_snapshot(snapshot).await;
             // Refresh deadline to now + timeout so it measures actual execution
             // time, not time spent on the snapshot save above.
@@ -1110,15 +1121,15 @@ where
         };
 
         let task_ctx = TaskExecutionContext {
-            workflow_id: Arc::clone(&workflow.context().workflow_id),
+            workflow_id: Arc::from(workflow.context().workflow_id()),
             instance_id: Arc::from(available_task.instance_id.as_str()),
-            task_id: Arc::from(task_id.as_str()),
+            task_id: Arc::clone(&task_name),
             metadata: continuation.build_task_metadata(&task_id),
             workflow_metadata_json: workflow.context().metadata_json.clone(),
         };
 
         let execution_future = with_task_context(task_ctx, async move {
-            Self::execute_task_by_id(continuation, &task_id, input).await
+            Self::execute_task_by_id(continuation, &task_name, input).await
         });
 
         let heartbeat_result = self
@@ -1161,7 +1172,7 @@ where
         }
 
         let next_retry_at = snapshot.record_retry(
-            &available_task.task_id,
+            available_task.task_id,
             policy,
             error_msg,
             Some(&self.worker_id),
@@ -1333,7 +1344,7 @@ where
                 task_id = %available_task.task_id,
                 "Task does not exist in workflow"
             );
-            return Err(WorkflowError::TaskNotFound(available_task.task_id.clone()).into());
+            return Err(WorkflowError::TaskNotFound(available_task.task_id.to_hex()).into());
         }
 
         if snapshot.get_task_result(&available_task.task_id).is_some() {
@@ -1375,7 +1386,7 @@ where
             Ok(Some(ActiveTaskClaim {
                 backend: &self.backend,
                 instance_id: available_task.instance_id.clone(),
-                task_id: available_task.task_id.clone(),
+                task_id: available_task.task_id,
                 worker_id: self.worker_id.clone(),
             }))
         } else {
@@ -1399,7 +1410,7 @@ where
     ) -> Result<Option<WorkflowStatus>, crate::error::RuntimeError> {
         if self
             .backend
-            .check_and_cancel(&available_task.instance_id, Some(&available_task.task_id))
+            .check_and_cancel(&available_task.instance_id, Some(available_task.task_id))
             .await?
         {
             tracing::info!(
@@ -1478,7 +1489,7 @@ where
                             "Task deadline expired during heartbeat, cancelling"
                         );
                         return Err(WorkflowError::TaskTimedOut {
-                            task_id: dl.task_id.clone(),
+                            task_id: dl.task_id,
                             timeout: std::time::Duration::from_millis(dl.timeout_ms),
                         }
                         .into());
@@ -1519,7 +1530,7 @@ where
         output: Bytes,
         claim: ActiveTaskClaim<'_, B>,
     ) -> Result<(), crate::error::RuntimeError> {
-        snapshot.mark_task_completed(available_task.task_id.clone(), output);
+        snapshot.mark_task_completed(available_task.task_id, output);
         tracing::debug!(
             instance_id = %available_task.instance_id,
             task_id = %available_task.task_id,
@@ -1599,12 +1610,15 @@ where
     ///
     /// Note: We can't clone `UntypedCoreTask`, so we need to execute it directly
     /// from the continuation structure. This method returns the task ID if found.
-    fn find_task_id_in_continuation(continuation: &WorkflowContinuation, task_id: &str) -> bool {
+    fn find_task_id_in_continuation(
+        continuation: &WorkflowContinuation,
+        task_id: &sayiir_core::TaskId,
+    ) -> bool {
         match continuation {
             WorkflowContinuation::Task { id, next, .. }
             | WorkflowContinuation::Delay { id, next, .. }
             | WorkflowContinuation::AwaitSignal { id, next, .. } => {
-                if id == task_id {
+                if sayiir_core::TaskId::from(id.as_str()) == *task_id {
                     return true;
                 }
                 next.as_ref()
@@ -1669,12 +1683,14 @@ where
     ) -> impl std::future::Future<Output = Result<Bytes, crate::error::RuntimeError>> + Send + 'a
     {
         async move {
+            let task_id_hash = sayiir_core::TaskId::from(task_id);
+            let task_id = &task_id_hash;
             let mut current = continuation;
 
             loop {
                 match current {
                     WorkflowContinuation::Task { id, func, next, .. } => {
-                        if id == task_id {
+                        if sayiir_core::TaskId::from(id.as_str()) == *task_id {
                             let func = func
                                 .as_ref()
                                 .ok_or_else(|| WorkflowError::TaskNotImplemented(id.clone()))?;
@@ -1774,19 +1790,17 @@ where
     /// Update execution position after a task completes.
     fn update_position_after_task(
         continuation: &WorkflowContinuation,
-        completed_task_id: &str,
+        completed_task_id: &sayiir_core::TaskId,
         snapshot: &mut WorkflowSnapshot,
     ) {
         match continuation {
             WorkflowContinuation::Task { id, next, .. }
             | WorkflowContinuation::Delay { id, next, .. }
             | WorkflowContinuation::AwaitSignal { id, next, .. } => {
-                if id == completed_task_id {
+                if sayiir_core::TaskId::from(id.as_str()) == *completed_task_id {
                     if let Some(next_cont) = next {
                         let hint = next_cont.first_task_hint();
-                        snapshot.update_position(ExecutionPosition::AtTask {
-                            task_id: hint.id.clone(),
-                        });
+                        snapshot.update_position(ExecutionPosition::AtTask { task_id: hint.id });
                         snapshot.set_task_hint(&hint);
                     }
                 } else if let Some(next_cont) = next {
@@ -1879,6 +1893,7 @@ where
         Self::resolve_loops_recursive(continuation, snapshot, backend).await
     }
 
+    #[allow(clippy::too_many_lines)]
     fn resolve_loops_recursive<'a>(
         continuation: &'a WorkflowContinuation,
         snapshot: &'a mut WorkflowSnapshot,
@@ -1896,32 +1911,39 @@ where
                     next,
                 } => {
                     // Only resolve if the loop isn't already marked complete.
-                    if snapshot.get_task_result(id).is_none() {
+                    if snapshot
+                        .get_task_result(&sayiir_core::TaskId::from(id))
+                        .is_none()
+                    {
                         let terminal_id = body.terminal_task_id();
-                        if let Some(result) = snapshot.get_task_result(terminal_id) {
+                        if let Some(result) =
+                            snapshot.get_task_result(&sayiir_core::TaskId::from(terminal_id))
+                        {
                             let output = result.output.clone();
                             match crate::execution::decode_loop_envelope(&output) {
                                 Ok((LoopDecision::Done, inner)) => {
-                                    snapshot.clear_loop_iteration(id);
-                                    snapshot.mark_task_completed(id.clone(), inner);
+                                    snapshot.clear_loop_iteration(&sayiir_core::TaskId::from(id));
+                                    snapshot
+                                        .mark_task_completed(sayiir_core::TaskId::from(id), inner);
                                     backend.save_snapshot(snapshot).await?;
                                 }
                                 Ok((LoopDecision::Again, again_value)) => {
-                                    let current_iter = snapshot.loop_iteration(id);
+                                    let current_iter =
+                                        snapshot.loop_iteration(&sayiir_core::TaskId::from(id));
                                     let next_iter = current_iter + 1;
                                     if next_iter >= *max_iterations {
                                         match on_max {
                                             sayiir_core::workflow::MaxIterationsPolicy::Fail => {
                                                 return Err(WorkflowError::MaxIterationsExceeded {
-                                                    loop_id: id.clone(),
+                                                    loop_id: sayiir_core::TaskId::from(id),
                                                     max_iterations: *max_iterations,
                                                 }
                                                 .into());
                                             }
                                             sayiir_core::workflow::MaxIterationsPolicy::ExitWithLast => {
-                                                snapshot.clear_loop_iteration(id);
+                                                snapshot.clear_loop_iteration(&sayiir_core::TaskId::from(id));
                                                 snapshot.mark_task_completed(
-                                                    id.clone(),
+                                                    sayiir_core::TaskId::from(id.as_str()),
                                                     again_value,
                                                 );
                                                 backend.save_snapshot(snapshot).await?;
@@ -1932,15 +1954,20 @@ where
                                         // available for re-execution on the next poll.
                                         let body_ser = body.to_serializable();
                                         for tid in &body_ser.task_ids() {
-                                            snapshot.remove_task_result(tid);
+                                            snapshot.remove_task_result(
+                                                &sayiir_core::TaskId::from(*tid),
+                                            );
                                         }
-                                        snapshot.set_loop_iteration(id, next_iter);
+                                        snapshot.set_loop_iteration(
+                                            sayiir_core::TaskId::from(id),
+                                            next_iter,
+                                        );
                                         backend.save_snapshot(snapshot).await?;
                                     }
                                 }
                                 Err(e) => {
                                     return Err(CodecError::DecodeFailed {
-                                        task_id: id.clone(),
+                                        task_id: sayiir_core::TaskId::from(id),
                                         expected_type: "LoopEnvelope",
                                         source: e,
                                     }
@@ -1990,7 +2017,10 @@ where
         // Check if all tasks in the continuation are completed
         match continuation {
             WorkflowContinuation::Task { id, next, .. } => {
-                if snapshot.get_task_result(id).is_none() {
+                if snapshot
+                    .get_task_result(&sayiir_core::TaskId::from(id))
+                    .is_none()
+                {
                     return false;
                 }
                 if let Some(next_cont) = next {
@@ -2001,7 +2031,10 @@ where
             }
             WorkflowContinuation::Delay { id, next, .. }
             | WorkflowContinuation::AwaitSignal { id, next, .. } => {
-                if snapshot.get_task_result(id).is_none() {
+                if snapshot
+                    .get_task_result(&sayiir_core::TaskId::from(id))
+                    .is_none()
+                {
                     return false;
                 }
                 next.as_ref()
@@ -2023,7 +2056,10 @@ where
             }
             WorkflowContinuation::Branch { id, next, .. } => {
                 // Branch is complete when the branch node itself has a cached result
-                if snapshot.get_task_result(id).is_none() {
+                if snapshot
+                    .get_task_result(&sayiir_core::TaskId::from(id))
+                    .is_none()
+                {
                     return false;
                 }
                 next.as_ref()
@@ -2031,7 +2067,10 @@ where
             }
             WorkflowContinuation::Loop { id, next, .. } => {
                 // Loop is complete when the loop node itself has a cached result
-                if snapshot.get_task_result(id).is_none() {
+                if snapshot
+                    .get_task_result(&sayiir_core::TaskId::from(id))
+                    .is_none()
+                {
                     return false;
                 }
                 next.as_ref()
@@ -2039,7 +2078,10 @@ where
             }
             WorkflowContinuation::ChildWorkflow { id, next, .. } => {
                 // ChildWorkflow is complete when the node itself has a cached result
-                if snapshot.get_task_result(id).is_none() {
+                if snapshot
+                    .get_task_result(&sayiir_core::TaskId::from(id))
+                    .is_none()
+                {
                     return false;
                 }
                 next.as_ref()

--- a/sayiir-runtime/src/worker.rs
+++ b/sayiir-runtime/src/worker.rs
@@ -47,6 +47,10 @@ pub type WorkflowRegistry<C, Input, M> =
 pub struct ExternalWorkflow {
     /// The continuation tree describing the workflow structure.
     pub continuation: Arc<WorkflowContinuation>,
+    /// Per-workflow `TaskId → metadata` index. Built once when the workflow
+    /// is registered; replaces the O(N) tree walk + per-node SHA-256 that
+    /// the worker would otherwise do for every task dispatch.
+    pub task_index: Arc<sayiir_core::TaskIndex>,
     /// Human-readable workflow name (for log/error display and FFI task executor).
     pub workflow_id: Arc<str>,
     /// Optional JSON-encoded workflow-level metadata.
@@ -655,14 +659,13 @@ where
             let _ = tracing::Span::current().set_parent(remote_ctx);
         }
 
-        let continuation = &ext_wf.continuation;
         let mut snapshot = self
             .backend
             .load_snapshot(&available_task.instance_id)
             .await?;
         let already_completed = Self::validate_task_preconditions(
             definition_hash,
-            continuation,
+            &ext_wf.task_index,
             available_task,
             &snapshot,
         )?;
@@ -708,17 +711,16 @@ where
         snapshot: &mut WorkflowSnapshot,
         claim: &ActiveTaskClaim<'_, B>,
     ) -> ExecutionOutcome {
-        let continuation = &ext_wf.continuation;
         let task_id = available_task.task_id;
         let input = available_task.input.clone();
-        // Resolve the human-readable task name from the continuation tree so we
-        // can hand it to the external task executor (which looks up Python/Node
-        // functions by name).
-        let task_name: Arc<str> = continuation
-            .find_task_name(&task_id)
-            .map_or_else(|| Arc::from(task_id.to_hex()), Arc::from);
+        // Resolve the human-readable task name from the prebuilt index so the
+        // FFI executor can look up the Python/Node function by name. No tree
+        // walk and no per-node SHA-256 — this is a single hash-map probe.
+        let indexed_meta = ext_wf.task_index.get(&task_id);
+        let task_name: Arc<str> =
+            indexed_meta.map_or_else(|| Arc::from(task_id.to_hex()), |m| Arc::clone(&m.name));
 
-        let deadline = if let Some(timeout) = continuation.get_task_timeout(&task_id) {
+        let deadline = if let Some(timeout) = indexed_meta.and_then(|m| m.timeout) {
             snapshot.set_task_deadline(task_id, timeout);
             let _ = self.backend.save_snapshot(snapshot).await;
             snapshot.refresh_task_deadline();
@@ -731,7 +733,7 @@ where
             workflow_id: Arc::clone(&ext_wf.workflow_id),
             instance_id: Arc::clone(&available_task.instance_id),
             task_id: Arc::clone(&task_name),
-            metadata: continuation.build_task_metadata(&task_id),
+            metadata: ext_wf.task_index.build_task_metadata(&task_id),
             workflow_metadata_json: ext_wf.metadata_json.clone(),
         };
 
@@ -1039,7 +1041,7 @@ where
             .await?;
         let already_completed = Self::validate_task_preconditions(
             workflow.definition_hash(),
-            workflow.continuation(),
+            workflow.task_index(),
             &available_task,
             &snapshot,
         )?;
@@ -1100,16 +1102,17 @@ where
             + 'static,
     {
         let continuation = workflow.continuation();
+        let task_index = workflow.task_index();
         let task_id = available_task.task_id;
         let input = available_task.input.clone();
-        // Resolve human-readable task name from the continuation tree for the
-        // task context exposed to user code.
-        let task_name: Arc<str> = continuation
-            .find_task_name(&task_id)
-            .map_or_else(|| Arc::from(task_id.to_hex()), Arc::from);
+        // Resolve human-readable task name from the prebuilt index for the
+        // task context exposed to user code (no tree walk, no rehashing).
+        let indexed_meta = task_index.get(&task_id);
+        let task_name: Arc<str> =
+            indexed_meta.map_or_else(|| Arc::from(task_id.to_hex()), |m| Arc::clone(&m.name));
 
         // Set deadline if task has a timeout configured
-        let deadline = if let Some(timeout) = continuation.get_task_timeout(&task_id) {
+        let deadline = if let Some(timeout) = indexed_meta.and_then(|m| m.timeout) {
             snapshot.set_task_deadline(task_id, timeout);
             let _ = self.backend.save_snapshot(snapshot).await;
             // Refresh deadline to now + timeout so it measures actual execution
@@ -1124,7 +1127,7 @@ where
             workflow_id: Arc::from(workflow.context().workflow_id()),
             instance_id: Arc::clone(&available_task.instance_id),
             task_id: Arc::clone(&task_name),
-            metadata: continuation.build_task_metadata(&task_id),
+            metadata: task_index.build_task_metadata(&task_id),
             workflow_metadata_json: workflow.context().metadata_json.clone(),
         };
 
@@ -1326,7 +1329,7 @@ where
     /// Returns `Ok(true)` if the task should be skipped (already completed).
     fn validate_task_preconditions(
         definition_hash: &sayiir_core::DefinitionHash,
-        continuation: &WorkflowContinuation,
+        task_index: &sayiir_core::TaskIndex,
         available_task: &AvailableTask,
         snapshot: &WorkflowSnapshot,
     ) -> Result<bool, crate::error::RuntimeError> {
@@ -1338,7 +1341,7 @@ where
             .into());
         }
 
-        if !Self::find_task_id_in_continuation(continuation, &available_task.task_id) {
+        if !task_index.contains(&available_task.task_id) {
             tracing::error!(
                 instance_id = %available_task.instance_id,
                 task_id = %available_task.task_id,
@@ -1608,8 +1611,11 @@ where
 
     /// Find a task function in the workflow continuation and return a reference.
     ///
-    /// Note: We can't clone `UntypedCoreTask`, so we need to execute it directly
-    /// from the continuation structure. This method returns the task ID if found.
+    /// Tree-walk predicate: does `task_id` appear anywhere inside `continuation`?
+    ///
+    /// Only used by [`execute_task_by_id`] to pick which subtree to descend into
+    /// at a `Fork`/`Branch`/`Loop`/`ChildWorkflow` boundary. Validation on the
+    /// dispatch hot path uses [`sayiir_core::TaskIndex::contains`] instead.
     fn find_task_id_in_continuation(
         continuation: &WorkflowContinuation,
         task_id: &sayiir_core::TaskId,
@@ -1625,13 +1631,11 @@ where
                     .is_some_and(|n| Self::find_task_id_in_continuation(n, task_id))
             }
             WorkflowContinuation::Fork { branches, join, .. } => {
-                // Check branches
                 for branch in branches {
                     if Self::find_task_id_in_continuation(branch, task_id) {
                         return true;
                     }
                 }
-                // Check join
                 if let Some(join_cont) = join {
                     Self::find_task_id_in_continuation(join_cont, task_id)
                 } else {

--- a/sayiir-runtime/src/worker.rs
+++ b/sayiir-runtime/src/worker.rs
@@ -1385,7 +1385,7 @@ where
             );
             Ok(Some(ActiveTaskClaim {
                 backend: &self.backend,
-                instance_id: available_task.instance_id.clone(),
+                instance_id: Arc::clone(&available_task.instance_id),
                 task_id: available_task.task_id,
                 worker_id: self.worker_id.clone(),
             }))

--- a/sayiir-runtime/src/worker.rs
+++ b/sayiir-runtime/src/worker.rs
@@ -36,7 +36,8 @@ use tokio::sync::mpsc;
 use tokio::time;
 
 /// A list of workflow definitions keyed by their definition hash.
-pub type WorkflowRegistry<C, Input, M> = Vec<(String, Arc<Workflow<C, Input, M>>)>;
+pub type WorkflowRegistry<C, Input, M> =
+    Vec<(sayiir_core::DefinitionHash, Arc<Workflow<C, Input, M>>)>;
 
 /// Workflow definition for binding-friendly worker API.
 ///
@@ -53,7 +54,7 @@ pub struct ExternalWorkflow {
 }
 
 /// Workflow index keyed by definition hash for O(1) lookup during task dispatch.
-pub type WorkflowIndex = HashMap<String, ExternalWorkflow>;
+pub type WorkflowIndex = HashMap<sayiir_core::DefinitionHash, ExternalWorkflow>;
 
 /// External task executor function signature.
 ///
@@ -209,7 +210,7 @@ fn extract_panic_message(payload: &Box<dyn std::any::Any + Send>) -> String {
 /// let workflow = WorkflowBuilder::new(ctx)
 ///     .then("step1", |i: u32| async move { Ok(i + 1) })
 ///     .build()?;
-/// let workflows = vec![(workflow.definition_hash().to_string(), Arc::new(workflow))];
+/// let workflows = vec![(*workflow.definition_hash(), Arc::new(workflow))];
 ///
 /// // Spawn the worker and get a handle for lifecycle control
 /// let handle = worker.spawn(Duration::from_secs(1), workflows);
@@ -547,7 +548,7 @@ where
     async fn execute_external_task(
         &self,
         ext_wf: &ExternalWorkflow,
-        definition_hash: &str,
+        definition_hash: &sayiir_core::DefinitionHash,
         executor: &ExternalTaskExecutor,
         available_task: &AvailableTask,
     ) -> Result<WorkflowStatus, crate::error::RuntimeError> {
@@ -803,6 +804,7 @@ where
                 if let Some((_, workflow)) = workflows
                     .iter()
                     .find(|(hash, _)| *hash == task.workflow_definition_hash)
+                // hash and task.workflow_definition_hash are both DefinitionHash
                 {
                     match self.execute_task(workflow.as_ref(), task).await {
                         Err(ref e) if e.is_timeout() => {
@@ -1195,15 +1197,15 @@ where
     /// and that the task is not already completed in the snapshot.
     /// Returns `Ok(true)` if the task should be skipped (already completed).
     fn validate_task_preconditions(
-        definition_hash: &str,
+        definition_hash: &sayiir_core::DefinitionHash,
         continuation: &WorkflowContinuation,
         available_task: &AvailableTask,
         snapshot: &WorkflowSnapshot,
     ) -> Result<bool, crate::error::RuntimeError> {
-        if available_task.workflow_definition_hash != definition_hash {
+        if available_task.workflow_definition_hash != *definition_hash {
             return Err(WorkflowError::DefinitionMismatch {
-                expected: definition_hash.to_string(),
-                found: available_task.workflow_definition_hash.clone(),
+                expected: *definition_hash,
+                found: available_task.workflow_definition_hash,
             }
             .into());
         }
@@ -2073,7 +2075,7 @@ mod tests {
         let registry = TaskRegistry::new();
 
         // Create a workflow snapshot so store_signal can validate it
-        let snapshot = WorkflowSnapshot::new("wf-1".to_string(), "hash-1".to_string());
+        let snapshot = WorkflowSnapshot::new("wf-1".to_string(), "hash-1".into());
         backend.save_snapshot(&snapshot).await.ok();
 
         let worker = PooledWorker::new("test-worker", backend, registry);

--- a/tests/integration/tests/checkpointing_runner.rs
+++ b/tests/integration/tests/checkpointing_runner.rs
@@ -138,7 +138,7 @@ async fn cancel_and_resume() {
     // Set up snapshot in-progress and request cancellation
     let input_bytes = Arc::new(JsonCodec).encode(&1u32).unwrap();
     let mut snapshot = sayiir_core::snapshot::WorkflowSnapshot::with_initial_input(
-        "inst-cancel".into(),
+        "inst-cancel",
         *workflow.definition_hash(),
         input_bytes,
     );
@@ -186,7 +186,7 @@ async fn pause_unpause_resume() {
     // Create an in-progress snapshot
     let input_bytes = Arc::new(JsonCodec).encode(&5u32).unwrap();
     let mut snapshot = sayiir_core::snapshot::WorkflowSnapshot::with_initial_input(
-        "inst-pause".into(),
+        "inst-pause",
         *workflow.definition_hash(),
         input_bytes,
     );
@@ -542,7 +542,7 @@ async fn definition_hash_mismatch_on_resume() {
     // Create an in-progress snapshot with v1's hash
     let input_bytes = Arc::new(JsonCodec).encode(&5u32).unwrap();
     let mut snapshot = sayiir_core::snapshot::WorkflowSnapshot::with_initial_input(
-        "inst-mismatch".into(),
+        "inst-mismatch",
         *workflow_v1.definition_hash(),
         input_bytes,
     );
@@ -591,7 +591,7 @@ async fn task_version_change_causes_hash_mismatch() {
     // Create an in-progress snapshot with v1's hash
     let input_bytes = Arc::new(JsonCodec).encode(&5u32).unwrap();
     let mut snapshot = sayiir_core::snapshot::WorkflowSnapshot::with_initial_input(
-        "inst-version".into(),
+        "inst-version",
         *workflow_v1.definition_hash(),
         input_bytes,
     );
@@ -663,7 +663,7 @@ async fn task_version_none_vs_some_causes_hash_mismatch() {
     // Create snapshot with v1
     let input_bytes = Arc::new(JsonCodec).encode(&5u32).unwrap();
     let mut snapshot = sayiir_core::snapshot::WorkflowSnapshot::with_initial_input(
-        "inst-version-none".into(),
+        "inst-version-none",
         *workflow_v1.definition_hash(),
         input_bytes,
     );

--- a/tests/integration/tests/checkpointing_runner.rs
+++ b/tests/integration/tests/checkpointing_runner.rs
@@ -97,7 +97,11 @@ async fn resume_after_simulated_crash() {
     // Verify step1 result was checkpointed (snapshot is still InProgress)
     let snapshot = runner1.backend().load_snapshot("inst-1").await.unwrap();
     assert!(snapshot.state.is_in_progress());
-    assert!(snapshot.get_task_result("step1").is_some());
+    assert!(
+        snapshot
+            .get_task_result(&sayiir_core::TaskId::from("step1"))
+            .is_some()
+    );
 
     // "Crash" — drop runner1, build new backend to same DB
     drop(runner1);
@@ -139,7 +143,7 @@ async fn cancel_and_resume() {
         input_bytes,
     );
     snapshot.update_position(sayiir_core::snapshot::ExecutionPosition::AtTask {
-        task_id: "step1".into(),
+        task_id: sayiir_core::TaskId::from("step1"),
     });
     runner.backend().save_snapshot(&snapshot).await.unwrap();
 
@@ -187,7 +191,7 @@ async fn pause_unpause_resume() {
         input_bytes,
     );
     snapshot.update_position(sayiir_core::snapshot::ExecutionPosition::AtTask {
-        task_id: "step1".into(),
+        task_id: sayiir_core::TaskId::from("step1"),
     });
     runner.backend().save_snapshot(&snapshot).await.unwrap();
 
@@ -235,14 +239,18 @@ async fn delay_returns_waiting_then_completes() {
     let status = runner.run(&workflow, "inst-1", 10u32).await.unwrap();
     match &status {
         WorkflowStatus::Waiting { delay_id, .. } => {
-            assert_eq!(delay_id, "short_wait");
+            assert_eq!(*delay_id, sayiir_core::TaskId::from("short_wait"));
         }
         other => panic!("Expected Waiting, got {other:?}"),
     }
 
     // step1 should be completed
     let snapshot = runner.backend().load_snapshot("inst-1").await.unwrap();
-    assert!(snapshot.get_task_result("step1").is_some());
+    assert!(
+        snapshot
+            .get_task_result(&sayiir_core::TaskId::from("step1"))
+            .is_some()
+    );
 
     // Wait for delay to expire
     tokio::time::sleep(std::time::Duration::from_millis(10)).await;
@@ -449,7 +457,11 @@ async fn signal_parks_then_resumes_with_payload() {
 
     // Verify step1 completed
     let snapshot = runner.backend().load_snapshot("inst-sig-1").await.unwrap();
-    assert!(snapshot.get_task_result("step1").is_some());
+    assert!(
+        snapshot
+            .get_task_result(&sayiir_core::TaskId::from("step1"))
+            .is_some()
+    );
 
     // Send the signal with a payload
     let payload = Arc::new(JsonCodec).encode(&42u32).unwrap();
@@ -535,7 +547,7 @@ async fn definition_hash_mismatch_on_resume() {
         input_bytes,
     );
     snapshot.update_position(sayiir_core::snapshot::ExecutionPosition::AtTask {
-        task_id: "step1".into(),
+        task_id: sayiir_core::TaskId::from("step1"),
     });
     runner.backend().save_snapshot(&snapshot).await.unwrap();
 
@@ -584,7 +596,7 @@ async fn task_version_change_causes_hash_mismatch() {
         input_bytes,
     );
     snapshot.update_position(sayiir_core::snapshot::ExecutionPosition::AtTask {
-        task_id: "process".into(),
+        task_id: sayiir_core::TaskId::from("process"),
     });
     runner.backend().save_snapshot(&snapshot).await.unwrap();
 
@@ -656,7 +668,7 @@ async fn task_version_none_vs_some_causes_hash_mismatch() {
         input_bytes,
     );
     snapshot.update_position(sayiir_core::snapshot::ExecutionPosition::AtTask {
-        task_id: "process".into(),
+        task_id: sayiir_core::TaskId::from("process"),
     });
     runner.backend().save_snapshot(&snapshot).await.unwrap();
 

--- a/tests/integration/tests/checkpointing_runner.rs
+++ b/tests/integration/tests/checkpointing_runner.rs
@@ -135,7 +135,7 @@ async fn cancel_and_resume() {
     let input_bytes = Arc::new(JsonCodec).encode(&1u32).unwrap();
     let mut snapshot = sayiir_core::snapshot::WorkflowSnapshot::with_initial_input(
         "inst-cancel".into(),
-        workflow.definition_hash().to_string(),
+        *workflow.definition_hash(),
         input_bytes,
     );
     snapshot.update_position(sayiir_core::snapshot::ExecutionPosition::AtTask {
@@ -183,7 +183,7 @@ async fn pause_unpause_resume() {
     let input_bytes = Arc::new(JsonCodec).encode(&5u32).unwrap();
     let mut snapshot = sayiir_core::snapshot::WorkflowSnapshot::with_initial_input(
         "inst-pause".into(),
-        workflow.definition_hash().to_string(),
+        *workflow.definition_hash(),
         input_bytes,
     );
     snapshot.update_position(sayiir_core::snapshot::ExecutionPosition::AtTask {
@@ -531,7 +531,7 @@ async fn definition_hash_mismatch_on_resume() {
     let input_bytes = Arc::new(JsonCodec).encode(&5u32).unwrap();
     let mut snapshot = sayiir_core::snapshot::WorkflowSnapshot::with_initial_input(
         "inst-mismatch".into(),
-        workflow_v1.definition_hash().to_string(),
+        *workflow_v1.definition_hash(),
         input_bytes,
     );
     snapshot.update_position(sayiir_core::snapshot::ExecutionPosition::AtTask {
@@ -580,7 +580,7 @@ async fn task_version_change_causes_hash_mismatch() {
     let input_bytes = Arc::new(JsonCodec).encode(&5u32).unwrap();
     let mut snapshot = sayiir_core::snapshot::WorkflowSnapshot::with_initial_input(
         "inst-version".into(),
-        workflow_v1.definition_hash().to_string(),
+        *workflow_v1.definition_hash(),
         input_bytes,
     );
     snapshot.update_position(sayiir_core::snapshot::ExecutionPosition::AtTask {
@@ -652,7 +652,7 @@ async fn task_version_none_vs_some_causes_hash_mismatch() {
     let input_bytes = Arc::new(JsonCodec).encode(&5u32).unwrap();
     let mut snapshot = sayiir_core::snapshot::WorkflowSnapshot::with_initial_input(
         "inst-version-none".into(),
-        workflow_v1.definition_hash().to_string(),
+        *workflow_v1.definition_hash(),
         input_bytes,
     );
     snapshot.update_position(sayiir_core::snapshot::ExecutionPosition::AtTask {
@@ -985,7 +985,7 @@ async fn two_workers_collaborate_on_workflows() {
         .unwrap();
 
     let wf = Arc::new(workflow);
-    let def_hash = wf.definition_hash().to_string();
+    let def_hash = *wf.definition_hash();
 
     // Submit 6 workflow instances via the client.
     let client = WorkflowClient::new(backend_client);
@@ -1001,8 +1001,8 @@ async fn two_workers_collaborate_on_workflows() {
     let registry1 = sayiir_core::registry::TaskRegistry::new();
     let registry2 = sayiir_core::registry::TaskRegistry::new();
 
-    let workflows1 = vec![(def_hash.clone(), Arc::clone(&wf))];
-    let workflows2 = vec![(def_hash.clone(), Arc::clone(&wf))];
+    let workflows1 = vec![(def_hash, Arc::clone(&wf))];
+    let workflows2 = vec![(def_hash, Arc::clone(&wf))];
 
     let worker1 = PooledWorker::new("worker-1", backend_w1, registry1)
         .with_claim_ttl(Some(Duration::from_secs(30)));


### PR DESCRIPTION
# Overview

Fixed-size hashes for internal IDs (SHA-256, 32 bytes): Introduced new Hash32([u8; 32]) three semantic newtypes: TaskId, WorkflowId,DefinitionHash and migrated all runtime data structures from heap-allocated String IDs to Copy 32-byte hashes.

migrated instance_id: String into Arc<str>

## Wins
- less heap allocations
- Results in storage savings for snapshots
- minor improvement is faster hashmaps lookups.
- WorkflowIndex lookup in worker's NOTIFY hot loop: DefinitionHash compare vs string compare against potentially long workflow names

The migration from String-typed identifiers to fixed-size hash newtypes  lifts a class of correctness invariants from convention into the type system: Identifier kinds can no longer be confused at call sites, hash canonicality is guaranteed by construction, and refactors become mechanically safe (wrong usages are compile errors, not silent runtime bugs). 

The newtypes are Copy and self-documenting, eliminating .clone() ceremony and replacing doc-comment intent with API-level guarantees, while centralizing hashing and serialization decisions in one place. making future wire-format changes a single-file edit. Net effect: load-bearing correctness checks moved from runtime audits to compile time, at zero runtime cost.