### PR TITLE
🐛 Fix PooledWorker advancing past Task into Delay/Signal

### DIFF
--- a/sayiir-runtime/src/worker.rs
+++ b/sayiir-runtime/src/worker.rs
@@ -1535,7 +1535,7 @@ where
             "Task completed"
         );
 
-        Self::update_position_after_task(continuation, &available_task.task_id, snapshot);
+        Self::update_position_after_task(continuation, &available_task.task_id, snapshot)?;
         #[cfg(feature = "otel")]
         {
             snapshot.trace_parent = crate::trace_context::current_trace_parent();
@@ -1795,18 +1795,22 @@ where
     /// directly — using `first_task_hint(...).id` would name the Delay or
     /// Signal node itself, but `execute_task_by_id` skips past those when
     /// dispatching, so the worker would loop on a phantom task ID.
-    fn set_position_at(cont: &WorkflowContinuation, snapshot: &mut WorkflowSnapshot) {
+    fn set_position_at(
+        cont: &WorkflowContinuation,
+        snapshot: &mut WorkflowSnapshot,
+    ) -> Result<(), crate::error::RuntimeError> {
+        use crate::execution::control_flow::{compute_signal_timeout, compute_wake_at};
         match cont {
             WorkflowContinuation::Delay { id, duration, next } => {
-                let now = chrono::Utc::now();
-                let wake_at = chrono::Duration::from_std(*duration).map_or(now, |d| now + d);
+                let wake_at = compute_wake_at(duration)?;
+                let entered_at = chrono::Utc::now();
                 let next_task_id = next
                     .as_deref()
                     .map(|n| sayiir_core::TaskId::from(n.first_task_id()));
                 let delay_id = sayiir_core::TaskId::from(id.as_str());
                 snapshot.update_position(ExecutionPosition::AtDelay {
                     delay_id,
-                    entered_at: now,
+                    entered_at,
                     wake_at,
                     next_task_id,
                 });
@@ -1824,10 +1828,7 @@ where
                 timeout,
                 next,
             } => {
-                let wake_at = timeout
-                    .as_ref()
-                    .and_then(|t| chrono::Duration::from_std(*t).ok())
-                    .map(|d| chrono::Utc::now() + d);
+                let wake_at = compute_signal_timeout(timeout.as_ref());
                 let next_task_id = next
                     .as_deref()
                     .map(|n| sayiir_core::TaskId::from(n.first_task_id()));
@@ -1844,6 +1845,7 @@ where
                 snapshot.set_task_hint(&hint);
             }
         }
+        Ok(())
     }
 
     /// Update execution position after a task completes.
@@ -1851,27 +1853,27 @@ where
         continuation: &WorkflowContinuation,
         completed_task_id: &sayiir_core::TaskId,
         snapshot: &mut WorkflowSnapshot,
-    ) {
+    ) -> Result<(), crate::error::RuntimeError> {
         match continuation {
             WorkflowContinuation::Task { id, next, .. }
             | WorkflowContinuation::Delay { id, next, .. }
             | WorkflowContinuation::AwaitSignal { id, next, .. } => {
                 if sayiir_core::TaskId::from(id.as_str()) == *completed_task_id {
                     if let Some(next_cont) = next.as_deref() {
-                        Self::set_position_at(next_cont, snapshot);
+                        Self::set_position_at(next_cont, snapshot)?;
                     }
                 } else if let Some(next_cont) = next {
-                    Self::update_position_after_task(next_cont, completed_task_id, snapshot);
+                    Self::update_position_after_task(next_cont, completed_task_id, snapshot)?;
                 }
             }
             WorkflowContinuation::Fork { branches, join, .. } => {
                 // Check if any branch task completed
                 for branch in branches {
-                    Self::update_position_after_task(branch, completed_task_id, snapshot);
+                    Self::update_position_after_task(branch, completed_task_id, snapshot)?;
                 }
                 // Check join
                 if let Some(join_cont) = join {
-                    Self::update_position_after_task(join_cont, completed_task_id, snapshot);
+                    Self::update_position_after_task(join_cont, completed_task_id, snapshot)?;
                 }
             }
             WorkflowContinuation::Branch {
@@ -1881,28 +1883,29 @@ where
                 ..
             } => {
                 for branch_cont in branches.values() {
-                    Self::update_position_after_task(branch_cont, completed_task_id, snapshot);
+                    Self::update_position_after_task(branch_cont, completed_task_id, snapshot)?;
                 }
                 if let Some(def) = default {
-                    Self::update_position_after_task(def, completed_task_id, snapshot);
+                    Self::update_position_after_task(def, completed_task_id, snapshot)?;
                 }
                 if let Some(next_cont) = next {
-                    Self::update_position_after_task(next_cont, completed_task_id, snapshot);
+                    Self::update_position_after_task(next_cont, completed_task_id, snapshot)?;
                 }
             }
             WorkflowContinuation::Loop { body, next, .. } => {
-                Self::update_position_after_task(body, completed_task_id, snapshot);
+                Self::update_position_after_task(body, completed_task_id, snapshot)?;
                 if let Some(next_cont) = next {
-                    Self::update_position_after_task(next_cont, completed_task_id, snapshot);
+                    Self::update_position_after_task(next_cont, completed_task_id, snapshot)?;
                 }
             }
             WorkflowContinuation::ChildWorkflow { child, next, .. } => {
-                Self::update_position_after_task(child, completed_task_id, snapshot);
+                Self::update_position_after_task(child, completed_task_id, snapshot)?;
                 if let Some(next_cont) = next {
-                    Self::update_position_after_task(next_cont, completed_task_id, snapshot);
+                    Self::update_position_after_task(next_cont, completed_task_id, snapshot)?;
                 }
             }
         }
+        Ok(())
     }
 
     /// Create a builder with sensible defaults.

--- a/sayiir-runtime/src/worker.rs
+++ b/sayiir-runtime/src/worker.rs
@@ -22,7 +22,7 @@ use sayiir_core::context::{TaskExecutionContext, with_task_context};
 use sayiir_core::error::{BoxError, CodecError, WorkflowError};
 use sayiir_core::registry::TaskRegistry;
 use sayiir_core::snapshot::{
-    ExecutionPosition, SignalKind, SignalRequest, TaskDeadline, WorkflowSnapshot,
+    ExecutionPosition, SignalKind, SignalRequest, TaskDeadline, TaskHint, WorkflowSnapshot,
 };
 use sayiir_core::task_claim::AvailableTask;
 use sayiir_core::workflow::{Workflow, WorkflowContinuation, WorkflowStatus};
@@ -1804,9 +1804,12 @@ where
             WorkflowContinuation::Delay { id, duration, next } => {
                 let wake_at = compute_wake_at(duration)?;
                 let entered_at = chrono::Utc::now();
-                let next_task_id = next
-                    .as_deref()
-                    .map(|n| sayiir_core::TaskId::from(n.first_task_id()));
+                let next_hint = next.as_deref().map(WorkflowContinuation::first_task_hint);
+                let next_task_id = next_hint.as_ref().map(|h| h.id);
+                // Update task_priority/task_tags so backends advancing
+                // AtDelay -> AtTask inherit the next task's routing hints
+                // (mirrors save_park_checkpoint).
+                snapshot.set_task_hint(next_hint.as_ref().unwrap_or(&TaskHint::default()));
                 let delay_id = sayiir_core::TaskId::from(id.as_str());
                 snapshot.update_position(ExecutionPosition::AtDelay {
                     delay_id,
@@ -1829,9 +1832,12 @@ where
                 next,
             } => {
                 let wake_at = compute_signal_timeout(timeout.as_ref());
-                let next_task_id = next
-                    .as_deref()
-                    .map(|n| sayiir_core::TaskId::from(n.first_task_id()));
+                let next_hint = next.as_deref().map(WorkflowContinuation::first_task_hint);
+                let next_task_id = next_hint.as_ref().map(|h| h.id);
+                // Update task_priority/task_tags so backends advancing
+                // AtSignal -> AtTask inherit the next task's routing hints
+                // (mirrors save_park_checkpoint).
+                snapshot.set_task_hint(next_hint.as_ref().unwrap_or(&TaskHint::default()));
                 snapshot.update_position(ExecutionPosition::AtSignal {
                     signal_id: sayiir_core::TaskId::from(id.as_str()),
                     signal_name: signal_name.clone(),

--- a/sayiir-runtime/src/worker.rs
+++ b/sayiir-runtime/src/worker.rs
@@ -1786,6 +1786,72 @@ where
         }
     }
 
+    /// Set the snapshot's execution position to reflect "execution is now at
+    /// the head of `cont`".
+    ///
+    /// For Task heads (and Branch / Fork / Loop / `ChildWorkflow` which all
+    /// start with a Task-shaped node), set `AtTask(first_task_hint)`. For
+    /// `Delay` / `AwaitSignal` heads, enter the corresponding park state
+    /// directly — using `first_task_hint(...).id` would name the Delay or
+    /// Signal node itself, but `execute_task_by_id` skips past those when
+    /// dispatching, so the worker would loop on a phantom task ID.
+    fn set_position_at(cont: &WorkflowContinuation, snapshot: &mut WorkflowSnapshot) {
+        match cont {
+            WorkflowContinuation::Delay {
+                id,
+                duration,
+                next,
+            } => {
+                let now = chrono::Utc::now();
+                let wake_at = chrono::Duration::from_std(*duration)
+                    .map(|d| now + d)
+                    .unwrap_or(now);
+                let next_task_id = next
+                    .as_deref()
+                    .map(|n| sayiir_core::TaskId::from(n.first_task_id()));
+                let delay_id = sayiir_core::TaskId::from(id.as_str());
+                snapshot.update_position(ExecutionPosition::AtDelay {
+                    delay_id,
+                    entered_at: now,
+                    wake_at,
+                    next_task_id,
+                });
+                // Mirror the executor's behaviour when it parks at a delay:
+                // mark the delay node as completed with the passthrough input
+                // (which is the *last* completed task's output, sitting at the
+                // top of `completed_tasks`) so downstream nodes see the same
+                // continuous output chain.
+                let passthrough = snapshot.get_last_task_output().unwrap_or_default();
+                snapshot.mark_task_completed(delay_id, passthrough);
+            }
+            WorkflowContinuation::AwaitSignal {
+                id,
+                signal_name,
+                timeout,
+                next,
+            } => {
+                let wake_at = timeout
+                    .as_ref()
+                    .and_then(|t| chrono::Duration::from_std(*t).ok())
+                    .map(|d| chrono::Utc::now() + d);
+                let next_task_id = next
+                    .as_deref()
+                    .map(|n| sayiir_core::TaskId::from(n.first_task_id()));
+                snapshot.update_position(ExecutionPosition::AtSignal {
+                    signal_id: sayiir_core::TaskId::from(id.as_str()),
+                    signal_name: signal_name.clone(),
+                    wake_at,
+                    next_task_id,
+                });
+            }
+            _ => {
+                let hint = cont.first_task_hint();
+                snapshot.update_position(ExecutionPosition::AtTask { task_id: hint.id });
+                snapshot.set_task_hint(&hint);
+            }
+        }
+    }
+
     /// Update execution position after a task completes.
     fn update_position_after_task(
         continuation: &WorkflowContinuation,
@@ -1797,10 +1863,8 @@ where
             | WorkflowContinuation::Delay { id, next, .. }
             | WorkflowContinuation::AwaitSignal { id, next, .. } => {
                 if sayiir_core::TaskId::from(id.as_str()) == *completed_task_id {
-                    if let Some(next_cont) = next {
-                        let hint = next_cont.first_task_hint();
-                        snapshot.update_position(ExecutionPosition::AtTask { task_id: hint.id });
-                        snapshot.set_task_hint(&hint);
+                    if let Some(next_cont) = next.as_deref() {
+                        Self::set_position_at(next_cont, snapshot);
                     }
                 } else if let Some(next_cont) = next {
                     Self::update_position_after_task(next_cont, completed_task_id, snapshot);

--- a/sayiir-runtime/src/worker.rs
+++ b/sayiir-runtime/src/worker.rs
@@ -1797,11 +1797,7 @@ where
     /// dispatching, so the worker would loop on a phantom task ID.
     fn set_position_at(cont: &WorkflowContinuation, snapshot: &mut WorkflowSnapshot) {
         match cont {
-            WorkflowContinuation::Delay {
-                id,
-                duration,
-                next,
-            } => {
+            WorkflowContinuation::Delay { id, duration, next } => {
                 let now = chrono::Utc::now();
                 let wake_at = chrono::Duration::from_std(*duration)
                     .map(|d| now + d)

--- a/sayiir-runtime/src/worker.rs
+++ b/sayiir-runtime/src/worker.rs
@@ -1799,9 +1799,7 @@ where
         match cont {
             WorkflowContinuation::Delay { id, duration, next } => {
                 let now = chrono::Utc::now();
-                let wake_at = chrono::Duration::from_std(*duration)
-                    .map(|d| now + d)
-                    .unwrap_or(now);
+                let wake_at = chrono::Duration::from_std(*duration).map_or(now, |d| now + d);
                 let next_task_id = next
                     .as_deref()
                     .map(|n| sayiir_core::TaskId::from(n.first_task_id()));

--- a/tests/integration/tests/checkpointing_runner.rs
+++ b/tests/integration/tests/checkpointing_runner.rs
@@ -1109,19 +1109,13 @@ async fn pooled_worker_handles_delay_in_chain() {
     let def_hash = *wf.definition_hash();
 
     let client = WorkflowClient::new(backend_client);
-    let (status, _) = client
-        .submit(wf.as_ref(), "delay-1", 5u32)
-        .await
-        .unwrap();
+    let (status, _) = client.submit(wf.as_ref(), "delay-1", 5u32).await.unwrap();
     assert!(matches!(status, WorkflowStatus::InProgress));
 
     let registry = sayiir_core::registry::TaskRegistry::new();
     let worker = PooledWorker::new("delay-w-0", backend_w, registry)
         .with_claim_ttl(Some(Duration::from_secs(30)));
-    let handle = worker.spawn(
-        Duration::from_millis(50),
-        vec![(def_hash, Arc::clone(&wf))],
-    );
+    let handle = worker.spawn(Duration::from_millis(50), vec![(def_hash, Arc::clone(&wf))]);
 
     let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
     loop {

--- a/tests/integration/tests/checkpointing_runner.rs
+++ b/tests/integration/tests/checkpointing_runner.rs
@@ -1083,3 +1083,68 @@ async fn two_workers_collaborate_on_workflows() {
         .unwrap()
         .unwrap();
 }
+
+// ─── delay in PooledWorker: regression for delay-advance bug ─────────────────
+
+/// PooledWorker must correctly advance a workflow that ends a task with a
+/// `delay(...)` next: previously it persisted `AtTask(delay_hash)` because
+/// `first_task_hint` of a `Delay` node returns the delay's own id, which
+/// `execute_task_by_id` then skips past during dispatch (so workers spun
+/// "Task not found in registry").
+#[tokio::test]
+async fn pooled_worker_handles_delay_in_chain() {
+    let (_c, _backend, url) = setup().await;
+
+    let backend_w = PostgresBackend::<JsonCodec>::connect(&url).await.unwrap();
+    let backend_client = PostgresBackend::<JsonCodec>::connect(&url).await.unwrap();
+
+    let workflow = WorkflowBuilder::new(ctx())
+        .then("accept", |i: u32| async move { Ok(i + 1) })
+        .delay("sleep", Duration::from_millis(200))
+        .then("wake", |i: u32| async move { Ok(i * 2) })
+        .build()
+        .unwrap();
+
+    let wf = Arc::new(workflow);
+    let def_hash = *wf.definition_hash();
+
+    let client = WorkflowClient::new(backend_client);
+    let (status, _) = client
+        .submit(wf.as_ref(), "delay-1", 5u32)
+        .await
+        .unwrap();
+    assert!(matches!(status, WorkflowStatus::InProgress));
+
+    let registry = sayiir_core::registry::TaskRegistry::new();
+    let worker = PooledWorker::new("delay-w-0", backend_w, registry)
+        .with_claim_ttl(Some(Duration::from_secs(30)));
+    let handle = worker.spawn(
+        Duration::from_millis(50),
+        vec![(def_hash, Arc::clone(&wf))],
+    );
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
+    loop {
+        if tokio::time::Instant::now() > deadline {
+            let snap = client.backend().load_snapshot("delay-1").await.unwrap();
+            panic!(
+                "Timed out: status={:?} position_kind={:?}",
+                snap.state,
+                snap.position_kind()
+            );
+        }
+        let snap = client.backend().load_snapshot("delay-1").await.unwrap();
+        if snap.state.is_completed() {
+            let out: u32 = JsonCodec
+                .decode(snap.state.completed_output().unwrap().clone())
+                .unwrap();
+            // (5 + 1) * 2 = 12
+            assert_eq!(out, 12);
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    handle.shutdown();
+    let _ = tokio::time::timeout(Duration::from_secs(5), handle.join()).await;
+}


### PR DESCRIPTION
`update_position_after_task` blindly called `first_task_hint().id` on the next continuation. For a `Delay` or `AwaitSignal` node that returns the node's *own* id, so the worker persisted `AtTask(delay_hash)` but `execute_task_by_id` skips past delay / signal nodes during dispatch, so subsequent polls failed with "Task '<delay_hash>' not found in registry" and the workflow stalled forever.

Fix: when the next continuation is a `Delay`, enter `AtDelay` directly (computing `wake_at` from the duration, recording `next_task_id`, and marking the delay as completed with the previous task's output so the output-chain stays continuous). When it's an `AwaitSignal`, enter `AtSignal`. Other heads keep the `first_task_hint` path.

Adds `pooled_worker_handles_delay_in_chain` integration test covering the regression.