### PR TITLE
🔇 Stop ERROR-logging expected `Snapshot not found` from `load_snapshot`

### DIFF
--- a/sayiir-postgres/src/snapshot_store.rs
+++ b/sayiir-postgres/src/snapshot_store.rs
@@ -250,10 +250,16 @@ where
         name = "db.load_snapshot",
         skip(self),
         fields(db.system = "postgresql"),
-        err(level = tracing::Level::ERROR),
     )]
     async fn load_snapshot(&self, instance_id: &str) -> Result<WorkflowSnapshot, BackendError> {
         tracing::debug!("loading snapshot");
+        // `NotFound` from the snapshots-row lookup is a regular control-flow
+        // return — `check_existing_instance` calls `load_snapshot` on every
+        // fresh `WorkflowClient::submit` to probe for a pre-existing instance.
+        // Logging that at ERROR floods CI / production logs with one red line
+        // per submission. Demote the "no such instance" case to DEBUG, but
+        // keep ERROR for the "instance exists but its history row is missing"
+        // inconsistency case (which is a real bug).
         let row = sqlx::query(
             "SELECT history_version, trace_parent
              FROM sayiir_workflow_snapshots
@@ -262,13 +268,21 @@ where
         .bind(instance_id)
         .fetch_optional(&self.pool)
         .await
-        .map_err(PgError)?
-        .ok_or_else(|| BackendError::NotFound(instance_id.to_string()))?;
+        .inspect_err(|e| tracing::error!(error = %e, "load_snapshot: snapshots scan failed"))
+        .map_err(PgError)?;
+
+        let Some(row) = row else {
+            tracing::debug!(%instance_id, "snapshot not found");
+            return Err(BackendError::NotFound(instance_id.to_string()));
+        };
 
         let history_version: i32 = row.get("history_version");
         let data = self
             .fetch_blob(&self.pool, instance_id, history_version)
-            .await?;
+            .await
+            .inspect_err(|e| {
+                tracing::error!(error = %e, history_version, "load_snapshot: history blob fetch failed")
+            })?;
         let mut snapshot = self.decode(&data)?;
         snapshot.trace_parent = row.get("trace_parent");
         Ok(snapshot)


### PR DESCRIPTION
`WorkflowClient::submit` → `check_existing_instance` calls `load_snapshot(instance_id)` on every fresh submission to probe for a pre-existing instance; a `BackendError::NotFound` from that probe is the green-path "instance does not exist, go submit it" signal. The `#[instrument(err(level = ERROR))]` annotation auto-logged every Err return at ERROR, so a 500-workflow benchmark run emitted 500 red "Snapshot not found: wf-N" lines that look like failures.

Split the logging by case:

- snapshots-row lookup returns no row → `debug!("snapshot not found")`. Expected control flow.
- history blob fetch fails → `error!` with `history_version` context. This indicates real data inconsistency (snapshot row exists, history row points nowhere) and should stay loud.
- pool / SQL error → `error!` with the underlying error.

Drops the misleading red lines from the bench CI logs without suppressing any actual failure mode.