### PR TITLE
👷 Post benchmark vs-main comparison to PR comments

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -8,6 +8,9 @@ on:
 
 permissions:
   contents: read
+  # bench-pr-comment needs pull-requests:write so it can post / update
+  # the sticky comment on the PR. push-to-main runs never use this.
+  pull-requests: write
 
 concurrency:
   group: benchmarks-${{ github.event.pull_request.number || github.ref }}
@@ -42,7 +45,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.bench == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
 
     services:
       postgres:
@@ -62,6 +65,18 @@ jobs:
     env:
       SAYIIR_BENCH_POSTGRES_URL: postgresql://postgres:postgres@127.0.0.1:5432/sayiir_bench
       RUST_LOG: warn,sayiir_bench=info
+      # Bench parity across PR-vs-main: every scenario invocation in
+      # this workflow uses the same numbers regardless of trigger, so
+      # the comparison apples-to-apples. Keep these here, not duplicated
+      # per step, so a future tweak only edits one place.
+      LINEAR_WORKFLOWS: "5000"
+      LINEAR_WARMUP: "200"
+      LINEAR_STEPS: "4"
+      FANOUT_WORKFLOWS: "500"
+      FANOUT_CHILDREN: "10"
+      SIGNAL_WORKFLOWS: "1000"
+      SLEEPING_WORKFLOWS: "1000"
+      SLEEPING_SLEEP_SECS: "3"
 
     steps:
       - uses: actions/checkout@v6
@@ -78,38 +93,60 @@ jobs:
       - name: Build sayiir-bench
         run: cargo build --release --manifest-path benchmarks/Cargo.toml --bin sayiir-bench
 
-      # Sized so the post-warmup window dominates: at ~400+ wf/s sustained
-      # in CI, 5000 wf takes ~12s — the 5s warmup eats roughly the first
-      # 2k completions, leaving a 3k-completion steady state for the
-      # latency percentiles. Total step time stays under ~30s.
-      - name: Throughput smoke (5000 wf, 8 workers)
+      # ── Run scenarios ───────────────────────────────────────────────
+      # Each scenario writes one JSON to benchmarks/results/. Order:
+      # cheapest first so a misconfigured run fails fast on `linear`.
+      - name: Linear (steps=${{ env.LINEAR_STEPS }})
         run: |
           ./benchmarks/target/release/sayiir-bench \
             --results-dir benchmarks/results \
-            throughput \
-              --workflows 5000 \
+            linear \
+              --workflows "$LINEAR_WORKFLOWS" \
+              --warmup-workflows "$LINEAR_WARMUP" \
+              --steps "$LINEAR_STEPS" \
               --concurrency 32 \
               --workers 8 \
               --poll-ms 5 \
               --batch-size 64
 
-      # 1000 sleepers at 3s sleep stress the durable-parking path (all
-      # workflows go AtDelay at once, then wake-storm). Submission +
-      # sleep + drain fits in ~10s; the wake-phase latency percentiles
-      # are the marketing-grade number.
-      - name: Sleeping-giants smoke (1000 wf x 3s sleep, 8 workers)
+      - name: Fanout (children=${{ env.FANOUT_CHILDREN }})
+        run: |
+          ./benchmarks/target/release/sayiir-bench \
+            --results-dir benchmarks/results \
+            fanout \
+              --workflows "$FANOUT_WORKFLOWS" \
+              --warmup-workflows 50 \
+              --children "$FANOUT_CHILDREN" \
+              --concurrency 32 \
+              --workers 8 \
+              --poll-ms 5 \
+              --batch-size 64
+
+      - name: Signal-driven
+        run: |
+          ./benchmarks/target/release/sayiir-bench \
+            --results-dir benchmarks/results \
+            signal-driven \
+              --workflows "$SIGNAL_WORKFLOWS" \
+              --concurrency 32 \
+              --workers 8 \
+              --poll-ms 5 \
+              --batch-size 64
+
+      - name: Sleeping-giants (${{ env.SLEEPING_WORKFLOWS }} wf x ${{ env.SLEEPING_SLEEP_SECS }}s)
         run: |
           ./benchmarks/target/release/sayiir-bench \
             --results-dir benchmarks/results \
             sleeping-giants \
-              --workflows 1000 \
+              --workflows "$SLEEPING_WORKFLOWS" \
               --concurrency 32 \
               --workers 8 \
-              --sleep-secs 3 \
+              --sleep-secs "$SLEEPING_SLEEP_SECS" \
               --poll-ms 50 \
               --batch-size 32
 
-      - name: Upload result JSONs
+      # ── Per-run artifact (always uploaded) ─────────────────────────
+      - name: Upload result JSONs (per-run)
         if: always()
         uses: actions/upload-artifact@v4
         with:
@@ -117,3 +154,111 @@ jobs:
           path: benchmarks/results/*.json
           if-no-files-found: warn
           retention-days: 30
+
+      # ── Main-only: refresh the stable "baseline" artifact ──────────
+      # `overwrite: true` makes the artifact name stable across main
+      # pushes — PR jobs always fetch the latest. 90-day retention so
+      # a slow-moving PR can still find a baseline if main hasn't
+      # changed in months.
+      - name: Upload main baseline artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-baseline-main
+          path: benchmarks/results/*.json
+          retention-days: 90
+          overwrite: true
+
+      # ── PR-only: compare against the latest main baseline ──────────
+      # Skips silently if no main baseline exists yet (first run on a
+      # fresh repo, or before this workflow lands). Downloads via
+      # dawidd6/action-download-artifact because the stock
+      # actions/download-artifact only fetches from the current run.
+      - name: Fetch main baseline (PR only)
+        id: fetch_baseline
+        if: github.event_name == 'pull_request'
+        uses: dawidd6/action-download-artifact@v6
+        with:
+          name: bench-baseline-main
+          workflow: benchmarks.yml
+          branch: main
+          event: push
+          path: benchmarks/baseline-main
+          if_no_artifact_found: warn
+
+      # Render one markdown block per scenario, concatenate, post as
+      # a single sticky comment. `--report-only` so a regression
+      # doesn't fail the workflow (the marketing-grade gate is the
+      # commented diff itself; merge protection is a separate
+      # concern). The `header` argument to the sticky-comment action
+      # is what makes updates replace the previous body instead of
+      # stacking.
+      #
+      # PR_SHA goes through `env:` not inline ${{ }} interpolation:
+      # head.sha is sanitized by GitHub but the workflow-injection
+      # guidance is to never interpolate `github.event.*` into a
+      # `run:` body — env-var the value once, reference $PR_SHA below.
+      - name: Build PR comment body
+        id: render
+        if: github.event_name == 'pull_request' && steps.fetch_baseline.outcome == 'success'
+        env:
+          PR_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          OUT=benchmarks/results/pr-comment.md
+          : > "$OUT"
+          BASE_SHA="$(jq -r '.git_sha // "unknown"' benchmarks/baseline-main/linear-*.json 2>/dev/null | head -1)"
+          {
+            echo "## Benchmark vs \`main\`"
+            echo
+            echo "Candidate: \`${PR_SHA:0:12}\` · Baseline: \`${BASE_SHA:0:12}\`"
+            echo
+          } >> "$OUT"
+
+          # Pick the most-recent JSON per scenario (sweep / repeat runs
+          # would produce more than one). The bench writes filenames
+          # of shape "<scenario>-<UTC timestamp>.json" — sort lex,
+          # take the last; that's the newest.
+          for scenario in linear fanout signal-driven sleeping-giants; do
+            baseline_file="$(ls -1 benchmarks/baseline-main/${scenario}-*.json 2>/dev/null | tail -1 || true)"
+            candidate_file="$(ls -1 benchmarks/results/${scenario}-*.json 2>/dev/null | tail -1 || true)"
+            if [[ -z "$baseline_file" || -z "$candidate_file" ]]; then
+              echo "(no baseline or candidate for ${scenario}; skipping)" >> "$OUT"
+              echo >> "$OUT"
+              continue
+            fi
+            ./benchmarks/target/release/sayiir-bench compare \
+              --scenario "$scenario" \
+              --baseline "$baseline_file" \
+              --candidate "$candidate_file" \
+              --format markdown \
+              --report-only \
+              --output /tmp/cmp-"$scenario".md > /dev/null
+            cat /tmp/cmp-"$scenario".md >> "$OUT"
+            echo >> "$OUT"
+          done
+
+          {
+            echo "<sub>Bench: \`linear --steps ${LINEAR_STEPS}\` (${LINEAR_WORKFLOWS} wf), "
+            echo "\`fanout --children ${FANOUT_CHILDREN}\` (${FANOUT_WORKFLOWS} wf), "
+            echo "\`signal-driven\` (${SIGNAL_WORKFLOWS} wf), "
+            echo "\`sleeping-giants ${SLEEPING_WORKFLOWS} wf × ${SLEEPING_SLEEP_SECS}s\`. "
+            echo "Hardware: GitHub-hosted \`ubuntu-latest\` (2-core / 7 GB / Postgres 17 service container). "
+            echo "Single-run noise on this hardware is ±10%; treat individual rows as directional, "
+            echo "and watch the trend across multiple PR pushes.</sub>"
+          } >> "$OUT"
+
+          # Sticky-comment expects body via input. Stage it for the
+          # next step rather than inlining a heredoc into the action.
+          echo "body_path=$OUT" >> "$GITHUB_OUTPUT"
+
+      - name: Post sticky PR comment
+        if: github.event_name == 'pull_request' && steps.render.outcome == 'success'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          # The header anchors the comment so subsequent runs *replace*
+          # this one instead of stacking. Keep it unique to this
+          # workflow — if we ever add a second sticky comment (e.g.
+          # coverage), it needs a different header.
+          header: sayiir-bench-vs-main
+          path: ${{ steps.render.outputs.body_path }}

--- a/benchmarks/Cargo.lock
+++ b/benchmarks/Cargo.lock
@@ -301,6 +301,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "comfy-table"
+version = "7.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
+dependencies = [
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2129,6 +2139,7 @@ dependencies = [
  "bytes",
  "chrono",
  "clap",
+ "comfy-table",
  "futures",
  "hdrhistogram",
  "metrics",
@@ -3009,6 +3020,18 @@ name = "unicode-properties"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "untrusted"

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -34,6 +34,12 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
+# Markdown table rendering for `compare --format markdown` (the PR
+# comment body). `ASCII_MARKDOWN` preset emits GFM-compatible pipe
+# tables with right-alignment for numerics — better than hand-rolling
+# the `writeln!` chains, which silently break alignment when a
+# scenario introduces a longer metric name.
+comfy-table = { version = "7", default-features = false }
 
 # Logging
 tracing = "0.1"

--- a/benchmarks/src/compare.rs
+++ b/benchmarks/src/compare.rs
@@ -19,6 +19,7 @@ use std::fmt::Write as _;
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
+use comfy_table::{Cell, CellAlignment, ContentArrangement, Table, presets};
 use serde::Serialize;
 
 use crate::report::Report;
@@ -263,8 +264,22 @@ fn render_markdown(
         baseline.timestamp_utc, candidate.timestamp_utc,
     );
     let _ = writeln!(s);
-    let _ = writeln!(s, "| Metric | Baseline | Candidate | Δ | Status |");
-    let _ = writeln!(s, "|---|---:|---:|---:|:---:|");
+
+    // Body table — comfy-table with `ASCII_MARKDOWN` preset renders
+    // GFM-compatible pipe tables, including the separator row. We set
+    // per-column alignment (metric left, numerics right, status
+    // center) — alignment that hand-rolled `writeln!` chains can't
+    // easily encode without manual `:---:` math per row.
+    let mut t = Table::new();
+    t.load_preset(presets::ASCII_MARKDOWN)
+        .set_content_arrangement(ContentArrangement::Disabled);
+    t.set_header(vec![
+        Cell::new("Metric").set_alignment(CellAlignment::Left),
+        Cell::new("Baseline").set_alignment(CellAlignment::Right),
+        Cell::new("Candidate").set_alignment(CellAlignment::Right),
+        Cell::new("Δ").set_alignment(CellAlignment::Right),
+        Cell::new("Status").set_alignment(CellAlignment::Center),
+    ]);
     for r in rows {
         let status = match r.regressed {
             Some(true) => "🔴 regressed",
@@ -279,13 +294,17 @@ fn render_markdown(
         } else {
             format!("{:.2}%", r.delta_pct)
         };
-        let _ = writeln!(
-            s,
-            "| `{}` | {:.3} | {:.3} | {} | {} |",
-            r.metric, r.baseline, r.candidate, delta, status,
-        );
+        t.add_row(vec![
+            Cell::new(format!("`{}`", r.metric)).set_alignment(CellAlignment::Left),
+            Cell::new(format!("{:.3}", r.baseline)).set_alignment(CellAlignment::Right),
+            Cell::new(format!("{:.3}", r.candidate)).set_alignment(CellAlignment::Right),
+            Cell::new(delta).set_alignment(CellAlignment::Right),
+            Cell::new(status).set_alignment(CellAlignment::Center),
+        ]);
     }
+    let _ = writeln!(s, "{t}");
     let _ = writeln!(s);
+
     // Hardware footer is what makes this comparable across PRs — the
     // CI runner is the same image, but expressing it inline avoids
     // "wait, was the baseline on the M2 mac?" confusion.


### PR DESCRIPTION
## Summary
- Adds `compare --format markdown` to `sayiir-bench` (table rendered via `comfy-table`'s `ASCII_MARKDOWN` preset).
- Extends `.github/workflows/benchmarks.yml` so push-to-main re-uploads a stable `bench-baseline-main` artifact (`overwrite: true`, 90-day retention).
- On every PR push, the same workflow downloads the latest main baseline, runs `compare --format markdown --report-only` per scenario (`linear`, `fanout`, `signal-driven`, `sleeping-giants`), stitches the per-scenario blocks, and posts/updates one sticky PR comment via `marocchino/sticky-pull-request-comment@v2`.
- `--report-only` so a regression flag in the comment doesn't fail the workflow; the merge gate is a separate concern.

## Stacked on
[`perf/notify-listen-optim`](../tree/perf/notify-listen-optim) — depends on the bench scenarios from that branch. Merge that one first.

## Sample comment body
```markdown
## Benchmark vs `main`

Candidate: `abc123abc123` · Baseline: `def456def456`

### ✅ `linear` — within thresholds

Thresholds: throughput drop ≤ 10%, latency rise ≤ 25%.
Baseline: `2026-05-20T10:00:00+00:00` · Candidate: `2026-05-25T14:00:00+00:00`

| Metric                      | Baseline | Candidate |       Δ |  Status |
|-----------------------------|----------|-----------|---------|---------|
| `sustained_wf_per_sec`      |  450.000 |   414.000 |  -8.00% |  🟢 ok  |
| `e2e_p99_ms`                |  150.000 |   172.500 | +15.00% |  🟢 ok  |
...
```

## Test plan
- [ ] Land a no-op commit on main → confirm `bench-baseline-main` artifact appears, marked latest.
- [ ] Open a PR against main → confirm sticky comment posts, table renders correctly.
- [ ] Push another commit to the same PR → confirm the comment is replaced (not stacked).
- [ ] Push a commit that intentionally regresses (e.g. bump `poll_ms` to 200) → confirm 🔴 `regressed` rows appear and the comment header switches to ⚠️.