### PR TITLE
Perf lot2

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -61,7 +61,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:17-alpine
+        image: postgres:18-alpine
         env:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: sayiir_bench

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,15 +202,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "block-buffer"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
-dependencies = [
- "hybrid-array",
-]
-
-[[package]]
 name = "bollard"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -400,12 +391,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
-name = "const-oid"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
-
-[[package]]
 name = "convert_case"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -489,15 +474,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-common"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
-dependencies = [
- "hybrid-array",
-]
-
-[[package]]
 name = "ctor"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -543,7 +519,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid 0.9.6",
+ "const-oid",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -564,21 +540,10 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
- "const-oid 0.9.6",
- "crypto-common 0.1.7",
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
  "subtle",
-]
-
-[[package]]
-name = "digest"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
-dependencies = [
- "block-buffer 0.12.0",
- "const-oid 0.10.2",
- "crypto-common 0.2.1",
 ]
 
 [[package]]
@@ -637,7 +602,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -996,7 +961,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -1063,15 +1028,6 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
-name = "hybrid-array"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
-dependencies = [
- "typenum",
-]
 
 [[package]]
 name = "hyper"
@@ -1486,7 +1442,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -1748,9 +1704,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "opentelemetry"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1762,9 +1718,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1775,9 +1731,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
  "http",
  "opentelemetry",
@@ -1789,14 +1745,14 @@ dependencies = [
  "thiserror",
  "tokio",
  "tonic",
- "tracing",
+ "tonic-types",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
@@ -1807,15 +1763,16 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.31.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
 dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
  "opentelemetry",
  "percent-encoding",
+ "portable-atomic",
  "rand 0.9.4",
  "thiserror",
  "tokio",
@@ -2327,9 +2284,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64",
  "bytes",
@@ -2345,9 +2302,6 @@ dependencies = [
  "log",
  "percent-encoding",
  "pin-project-lite",
- "serde",
- "serde_json",
- "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tower",
@@ -2409,8 +2363,8 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid 0.9.6",
- "digest 0.10.7",
+ "const-oid",
+ "digest",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
@@ -2439,7 +2393,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2551,9 +2505,10 @@ dependencies = [
  "hex",
  "proptest",
  "rkyv",
+ "rustc-hash",
  "serde",
  "serde_json",
- "sha2 0.11.0",
+ "sha2",
  "strum 0.28.0",
  "thiserror",
  "tokio",
@@ -2646,7 +2601,7 @@ dependencies = [
  "sayiir-persistence",
  "sayiir-runtime",
  "serde_json",
- "sha2 0.11.0",
+ "sha2",
  "sqlx",
  "testcontainers",
  "testcontainers-modules",
@@ -2894,7 +2849,7 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -2905,18 +2860,7 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "sha2"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.0",
- "digest 0.11.3",
+ "digest",
 ]
 
 [[package]]
@@ -2950,7 +2894,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest 0.10.7",
+ "digest",
  "rand_core 0.6.4",
 ]
 
@@ -3043,7 +2987,7 @@ dependencies = [
  "percent-encoding",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2",
  "smallvec",
  "thiserror",
  "tokio",
@@ -3105,7 +3049,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2",
  "sqlx-core",
  "sqlx-mysql",
  "sqlx-postgres",
@@ -3128,7 +3072,7 @@ dependencies = [
  "bytes",
  "chrono",
  "crc",
- "digest 0.10.7",
+ "digest",
  "dotenvy",
  "either",
  "futures-channel",
@@ -3149,7 +3093,7 @@ dependencies = [
  "rsa",
  "serde",
  "sha1",
- "sha2 0.10.9",
+ "sha2",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -3187,7 +3131,7 @@ dependencies = [
  "rand 0.8.6",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -3368,7 +3312,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3646,6 +3590,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic-types"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab1b02061f83d519bba3caa167f88f261ef05720ab8ebc954ade70de3348e8"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3740,9 +3695,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.32.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
 dependencies = [
  "js-sys",
  "opentelemetry",
@@ -4181,7 +4136,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,10 +44,10 @@ tracing-subscriber = { version = "0.3", features = [
     "fmt",
     "registry",
 ] }
-opentelemetry = "0.31"
-opentelemetry_sdk = { version = "0.31", features = ["rt-tokio"] }
-opentelemetry-otlp = { version = "0.31", features = ["grpc-tonic"] }
-tracing-opentelemetry = "0.32"
+opentelemetry = "0.32"
+opentelemetry_sdk = { version = "0.32", features = ["rt-tokio"] }
+opentelemetry-otlp = { version = "0.32", features = ["grpc-tonic"] }
+tracing-opentelemetry = "0.33"
 bytes = { version = "1", features = ["serde"] }
 chrono = { version = "0.4", default-features = false, features = [
     "std",
@@ -59,7 +59,7 @@ serde_json = "1"
 rkyv = { version = "0.8", features = ["std", "bytecheck", "bytes-1"] }
 bytecheck = "0.8"
 tokio = { version = "1", features = ["rt"] }
-sha2 = "0.11"
+sha2 = "0.10"
 hex = "0.4"
 strum = { version = "0.28", features = ["derive"] }
 thiserror = "2"
@@ -69,3 +69,4 @@ proptest = "1"
 backon = "1"
 nanoserde = "0.2"
 flume = "0.12"
+rustc-hash = "2"

--- a/benchmarks/docker-compose.yml
+++ b/benchmarks/docker-compose.yml
@@ -23,7 +23,7 @@ volumes:
 
 services:
   postgres:
-    image: postgres:17-alpine
+    image: postgres:18-alpine
     container_name: sayiir-bench-postgres
     networks: [bench]
     ports:

--- a/sayiir-core/Cargo.toml
+++ b/sayiir-core/Cargo.toml
@@ -28,6 +28,7 @@ tokio = { workspace = true, optional = true }
 serde = { workspace = true }
 sha2 = { workspace = true }
 hex = { workspace = true }
+rustc-hash = { workspace = true }
 strum = { workspace = true }
 thiserror = { workspace = true }
 rkyv = { workspace = true, optional = true }

--- a/sayiir-core/src/snapshot.rs
+++ b/sayiir-core/src/snapshot.rs
@@ -14,8 +14,8 @@ use std::sync::Arc;
 use crate::task::RetryPolicy;
 
 /// Completed-task results keyed by [`TaskId`](crate::TaskId). `FxHashMap`, not
-/// the std default: `TaskId` is already a 32-byte SHA-256, so SipHash is wasted
-/// work on this hot, frequently-rebuilt/probed map.
+/// the std default: `TaskId` is already a 32-byte SHA-256, so `SipHash` is
+/// wasted work on this hot, frequently-rebuilt/probed map.
 type CompletedTasks = FxHashMap<crate::TaskId, TaskResult>;
 
 /// Pre-computed metadata about the next task to execute.

--- a/sayiir-core/src/snapshot.rs
+++ b/sayiir-core/src/snapshot.rs
@@ -13,14 +13,9 @@ use std::sync::Arc;
 
 use crate::task::RetryPolicy;
 
-/// Completed-task results keyed by [`TaskId`](crate::TaskId).
-///
-/// Uses `FxHashMap` rather than the default `HashMap`: `TaskId` is a 32-byte
-/// SHA-256 (already uniformly distributed), so the cryptographic `SipHash`
-/// the std map defaults to is wasted work. This map is on the hot path — rebuilt
-/// on every snapshot decode and probed by `hydrate_task_outputs` /
-/// `find_available_tasks` once per task — where the faster hasher measurably
-/// cuts CPU.
+/// Completed-task results keyed by [`TaskId`](crate::TaskId). `FxHashMap`, not
+/// the std default: `TaskId` is already a 32-byte SHA-256, so SipHash is wasted
+/// work on this hot, frequently-rebuilt/probed map.
 type CompletedTasks = FxHashMap<crate::TaskId, TaskResult>;
 
 /// Pre-computed metadata about the next task to execute.
@@ -557,19 +552,13 @@ pub struct WorkflowSnapshot {
     /// Postgres reads/writes it from a dedicated column.
     #[serde(skip)]
     pub trace_parent: Option<String>,
-    /// Whether `last_completed_task_id`'s output is still unflushed to the
-    /// backend's task sidecar table.
-    ///
-    /// Implementation detail — `pub` only so the struct stays constructible
-    /// by literal (like [`trace_parent`](Self::trace_parent)); treat it as
-    /// internal. In-memory only (never serialized): set by
-    /// [`mark_task_completed`](Self::mark_task_completed) when a fresh output
-    /// is produced, cleared by a persistence backend once it has durably
-    /// written that output, and read by `save_snapshot` to decide whether to
-    /// ship the output bytes. A freshly-loaded snapshot defaults to `false` —
-    /// its outputs were already hydrated from the sidecar, so position-only
-    /// saves skip re-shipping the last completed payload on every dispatch
-    /// tick.
+    /// Whether `last_completed_task_id`'s output still needs flushing to the
+    /// backend's task sidecar. In-memory only; set by
+    /// [`mark_task_completed`](Self::mark_task_completed), cleared by the
+    /// backend after a durable write, and read by `save_snapshot` to skip
+    /// re-shipping bytes on position-only saves. A loaded snapshot defaults to
+    /// `false` (outputs already persisted). `pub` only so the struct stays
+    /// literal-constructible — treat as internal.
     #[serde(skip)]
     pub output_unflushed: bool,
 }

--- a/sayiir-core/src/snapshot.rs
+++ b/sayiir-core/src/snapshot.rs
@@ -685,6 +685,31 @@ impl WorkflowSnapshot {
         }
     }
 
+    /// Move every completed task's `output` out of the snapshot, leaving
+    /// each one empty, and return them keyed by task id.
+    ///
+    /// Pairs with [`hydrate_task_outputs`](Self::hydrate_task_outputs) to
+    /// restore: `take → encode → hydrate`. This lets a sidecar-staging
+    /// backend encode the outputs-stripped blob without cloning the whole
+    /// snapshot — the moves are cheap (no `Bytes` refcount churn) and the
+    /// snapshot is left logically unchanged once the outputs are hydrated
+    /// back. Empty outputs are skipped, so a round-trip with nothing to
+    /// strip allocates nothing.
+    #[must_use]
+    pub fn take_task_outputs(&mut self) -> Vec<(crate::TaskId, Bytes)> {
+        let Some(completed) = self.completed_tasks_mut() else {
+            return Vec::new();
+        };
+        let mut taken = Vec::with_capacity(completed.len());
+        for result in completed.values_mut() {
+            let output = std::mem::take(&mut result.output);
+            if !output.is_empty() {
+                taken.push((result.task_id, output));
+            }
+        }
+        taken
+    }
+
     /// Patch outputs back onto completed-task results from an external
     /// source (e.g. the `workflow_tasks` sidecar table). Outputs for
     /// task IDs not currently in `completed_tasks` are silently
@@ -741,6 +766,15 @@ impl WorkflowSnapshot {
     #[must_use]
     pub fn output_unflushed(&self) -> bool {
         self.output_unflushed
+    }
+
+    /// Clear the [`output_unflushed`](Self::output_unflushed) marker.
+    ///
+    /// Called by a persistence backend once it has durably written the
+    /// last completed task's output, so a subsequent save of the same
+    /// in-memory snapshot doesn't re-ship bytes that are already persisted.
+    pub fn mark_output_flushed(&mut self) {
+        self.output_unflushed = false;
     }
 
     /// ID of the most recently completed task, if any. Set by
@@ -1259,6 +1293,39 @@ mod tests {
         assert!(result.is_some());
         assert_eq!(result.unwrap().output, Bytes::from("output1"));
         assert_eq!(result.unwrap().task_id, crate::TaskId::from("task-1"));
+    }
+
+    #[test]
+    fn test_take_and_restore_task_outputs() {
+        let mut snapshot = WorkflowSnapshot::new("inst-1", "hash-1".into());
+        snapshot.mark_task_completed(crate::TaskId::from("t1"), Bytes::from("out1"));
+        snapshot.mark_task_completed(crate::TaskId::from("t2"), Bytes::from("out2"));
+
+        // Take moves outputs out, leaving the completed-task entries empty.
+        let taken = snapshot.take_task_outputs();
+        assert_eq!(taken.len(), 2);
+        assert!(
+            snapshot
+                .get_task_result(&crate::TaskId::from("t1"))
+                .unwrap()
+                .output
+                .is_empty()
+        );
+
+        // Hydrating the taken outputs back restores the snapshot exactly.
+        snapshot.hydrate_task_outputs(taken);
+        assert_eq!(
+            snapshot.get_task_result_bytes(&crate::TaskId::from("t1")),
+            Some(Bytes::from("out1"))
+        );
+        assert_eq!(
+            snapshot.get_task_result_bytes(&crate::TaskId::from("t2")),
+            Some(Bytes::from("out2"))
+        );
+
+        // Nothing left to take after outputs are already empty.
+        snapshot.strip_task_outputs();
+        assert!(snapshot.take_task_outputs().is_empty());
     }
 
     #[test]

--- a/sayiir-core/src/snapshot.rs
+++ b/sayiir-core/src/snapshot.rs
@@ -6,11 +6,22 @@
 
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
+use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::task::RetryPolicy;
+
+/// Completed-task results keyed by [`TaskId`](crate::TaskId).
+///
+/// Uses `FxHashMap` rather than the default `HashMap`: `TaskId` is a 32-byte
+/// SHA-256 (already uniformly distributed), so the cryptographic `SipHash`
+/// the std map defaults to is wasted work. This map is on the hot path — rebuilt
+/// on every snapshot decode and probed by `hydrate_task_outputs` /
+/// `find_available_tasks` once per task — where the faster hasher measurably
+/// cuts CPU.
+type CompletedTasks = FxHashMap<crate::TaskId, TaskResult>;
 
 /// Pre-computed metadata about the next task to execute.
 ///
@@ -293,7 +304,7 @@ pub enum WorkflowSnapshotState {
         /// Current execution position.
         position: ExecutionPosition,
         /// Results from completed tasks (by task ID).
-        completed_tasks: HashMap<crate::TaskId, TaskResult>,
+        completed_tasks: CompletedTasks,
         /// ID of the last completed task (for deterministic resume).
         /// This is needed because `HashMap` iteration order is not guaranteed.
         last_completed_task_id: Option<crate::TaskId>,
@@ -317,7 +328,7 @@ pub enum WorkflowSnapshotState {
         /// Timestamp when the workflow was cancelled.
         cancelled_at: DateTime<Utc>,
         /// Results from tasks that completed before cancellation.
-        completed_tasks: HashMap<crate::TaskId, TaskResult>,
+        completed_tasks: CompletedTasks,
         /// The task ID that was interrupted (if any).
         interrupted_at_task: Option<crate::TaskId>,
     },
@@ -332,7 +343,7 @@ pub enum WorkflowSnapshotState {
         /// Timestamp when the workflow was paused.
         paused_at: DateTime<Utc>,
         /// Results from tasks that completed before pausing.
-        completed_tasks: HashMap<crate::TaskId, TaskResult>,
+        completed_tasks: CompletedTasks,
         /// Execution position at the time of pause (for exact resume).
         position: ExecutionPosition,
         /// ID of the last completed task (for deterministic resume).
@@ -549,14 +560,18 @@ pub struct WorkflowSnapshot {
     /// Whether `last_completed_task_id`'s output is still unflushed to the
     /// backend's task sidecar table.
     ///
-    /// In-memory only (never serialized): set by [`mark_task_completed`](
-    /// Self::mark_task_completed) when a fresh output is produced, and read by
-    /// persistence backends to decide whether `save_snapshot` must ship the
-    /// output bytes. A freshly-loaded snapshot defaults to `false` — its
-    /// outputs were already hydrated from the sidecar, so position-only saves
-    /// skip re-shipping the last completed payload on every dispatch tick.
+    /// Implementation detail — `pub` only so the struct stays constructible
+    /// by literal (like [`trace_parent`](Self::trace_parent)); treat it as
+    /// internal. In-memory only (never serialized): set by
+    /// [`mark_task_completed`](Self::mark_task_completed) when a fresh output
+    /// is produced, cleared by a persistence backend once it has durably
+    /// written that output, and read by `save_snapshot` to decide whether to
+    /// ship the output bytes. A freshly-loaded snapshot defaults to `false` —
+    /// its outputs were already hydrated from the sidecar, so position-only
+    /// saves skip re-shipping the last completed payload on every dispatch
+    /// tick.
     #[serde(skip)]
-    output_unflushed: bool,
+    pub output_unflushed: bool,
 }
 
 impl WorkflowSnapshot {
@@ -582,7 +597,7 @@ impl WorkflowSnapshot {
             definition_hash,
             state: WorkflowSnapshotState::InProgress {
                 position: ExecutionPosition::NotStarted,
-                completed_tasks: HashMap::new(),
+                completed_tasks: CompletedTasks::default(),
                 last_completed_task_id: None,
             },
             created_at: now,
@@ -611,7 +626,7 @@ impl WorkflowSnapshot {
             definition_hash,
             state: WorkflowSnapshotState::InProgress {
                 position: ExecutionPosition::NotStarted,
-                completed_tasks: HashMap::new(),
+                completed_tasks: CompletedTasks::default(),
                 last_completed_task_id: None,
             },
             created_at: now,
@@ -659,7 +674,7 @@ impl WorkflowSnapshot {
     /// retain `completed_tasks`), and `None` for `Completed` and `Failed` states
     /// (where task results have been discarded).
     #[must_use]
-    pub fn get_all_task_results(&self) -> Option<&HashMap<crate::TaskId, TaskResult>> {
+    pub fn get_all_task_results(&self) -> Option<&CompletedTasks> {
         match &self.state {
             WorkflowSnapshotState::InProgress {
                 completed_tasks, ..
@@ -728,7 +743,7 @@ impl WorkflowSnapshot {
         }
     }
 
-    fn completed_tasks_mut(&mut self) -> Option<&mut HashMap<crate::TaskId, TaskResult>> {
+    fn completed_tasks_mut(&mut self) -> Option<&mut CompletedTasks> {
         match &mut self.state {
             WorkflowSnapshotState::InProgress {
                 completed_tasks, ..
@@ -758,23 +773,6 @@ impl WorkflowSnapshot {
             // the next `save_snapshot` must ship it. See `output_unflushed`.
             self.output_unflushed = true;
         }
-    }
-
-    /// Whether the last completed task's output still needs flushing to the
-    /// backend's task sidecar table. See [`output_unflushed`](
-    /// Self::output_unflushed) (the field) for the full contract.
-    #[must_use]
-    pub fn output_unflushed(&self) -> bool {
-        self.output_unflushed
-    }
-
-    /// Clear the [`output_unflushed`](Self::output_unflushed) marker.
-    ///
-    /// Called by a persistence backend once it has durably written the
-    /// last completed task's output, so a subsequent save of the same
-    /// in-memory snapshot doesn't re-ship bytes that are already persisted.
-    pub fn mark_output_flushed(&mut self) {
-        self.output_unflushed = false;
     }
 
     /// ID of the most recently completed task, if any. Set by
@@ -1040,7 +1038,7 @@ impl WorkflowSnapshot {
             WorkflowSnapshotState::InProgress {
                 completed_tasks, ..
             } => completed_tasks.clone(),
-            _ => HashMap::new(),
+            _ => CompletedTasks::default(),
         };
 
         self.task_deadline = None;
@@ -1332,18 +1330,28 @@ mod tests {
     fn test_output_unflushed_marker() {
         // Fresh snapshot: nothing completed, nothing to flush.
         let mut snapshot = WorkflowSnapshot::new("inst-1", "hash-1".into());
-        assert!(!snapshot.output_unflushed());
+        assert!(!snapshot.output_unflushed);
 
         // Completing a task flags its output as needing a flush.
         snapshot.mark_task_completed(crate::TaskId::from("task-1"), Bytes::from("out1"));
-        assert!(snapshot.output_unflushed());
+        assert!(snapshot.output_unflushed);
+
+        // One-shot gate: a backend clears the marker after durably writing
+        // the output (this is what `save_snapshot` does post-execute), so a
+        // later save of the same in-memory snapshot won't re-ship the bytes.
+        snapshot.output_unflushed = false;
+        assert!(!snapshot.output_unflushed);
+
+        // Completing another task re-arms it for the next flush.
+        snapshot.mark_task_completed(crate::TaskId::from("task-2"), Bytes::from("out2"));
+        assert!(snapshot.output_unflushed);
 
         // The marker is in-memory only: a decoded snapshot (serde-skipped
         // field) defaults to clean, since its outputs were already persisted
         // and are hydrated from the sidecar on load.
         let json = serde_json::to_string(&snapshot).unwrap();
         let decoded: WorkflowSnapshot = serde_json::from_str(&json).unwrap();
-        assert!(!decoded.output_unflushed());
+        assert!(!decoded.output_unflushed);
     }
 
     #[test]
@@ -1552,7 +1560,7 @@ mod tests {
     fn test_state_transitions() {
         let state = WorkflowSnapshotState::InProgress {
             position: ExecutionPosition::NotStarted,
-            completed_tasks: HashMap::new(),
+            completed_tasks: CompletedTasks::default(),
             last_completed_task_id: None,
         };
         assert!(state.is_in_progress());
@@ -1578,7 +1586,7 @@ mod tests {
             reason: None,
             cancelled_by: None,
             cancelled_at: Utc::now(),
-            completed_tasks: HashMap::new(),
+            completed_tasks: CompletedTasks::default(),
             interrupted_at_task: None,
         };
         assert!(state.is_cancelled());
@@ -1692,12 +1700,13 @@ mod proptests {
     }
 
     /// Strategy for arbitrary `HashMap<TaskId, TaskResult>`.
-    fn arb_completed_tasks() -> impl Strategy<Value = HashMap<crate::TaskId, TaskResult>> {
+    fn arb_completed_tasks() -> impl Strategy<Value = CompletedTasks> {
         proptest::collection::hash_map(
             "[a-z0-9]{1,8}".prop_map(|s| crate::TaskId::from(s.as_str())),
             arb_task_result(),
             0..4,
         )
+        .prop_map(|m| m.into_iter().collect())
     }
 
     /// Strategy for arbitrary `WorkflowSnapshotState`.

--- a/sayiir-core/src/snapshot.rs
+++ b/sayiir-core/src/snapshot.rs
@@ -546,6 +546,17 @@ pub struct WorkflowSnapshot {
     /// Postgres reads/writes it from a dedicated column.
     #[serde(skip)]
     pub trace_parent: Option<String>,
+    /// Whether `last_completed_task_id`'s output is still unflushed to the
+    /// backend's task sidecar table.
+    ///
+    /// In-memory only (never serialized): set by [`mark_task_completed`](
+    /// Self::mark_task_completed) when a fresh output is produced, and read by
+    /// persistence backends to decide whether `save_snapshot` must ship the
+    /// output bytes. A freshly-loaded snapshot defaults to `false` — its
+    /// outputs were already hydrated from the sidecar, so position-only saves
+    /// skip re-shipping the last completed payload on every dispatch tick.
+    #[serde(skip)]
+    output_unflushed: bool,
 }
 
 impl WorkflowSnapshot {
@@ -583,6 +594,7 @@ impl WorkflowSnapshot {
             task_priority: None,
             task_tags: vec![],
             trace_parent: None,
+            output_unflushed: false,
         }
     }
 
@@ -611,6 +623,7 @@ impl WorkflowSnapshot {
             task_priority: None,
             task_tags: vec![],
             trace_parent: None,
+            output_unflushed: false,
         }
     }
 
@@ -716,7 +729,18 @@ impl WorkflowSnapshot {
             completed_tasks.insert(task_id, TaskResult { task_id, output });
             *last_completed_task_id = Some(task_id);
             self.updated_at = Self::current_timestamp();
+            // The new output has not yet reached the backend's task sidecar;
+            // the next `save_snapshot` must ship it. See `output_unflushed`.
+            self.output_unflushed = true;
         }
+    }
+
+    /// Whether the last completed task's output still needs flushing to the
+    /// backend's task sidecar table. See [`output_unflushed`](
+    /// Self::output_unflushed) (the field) for the full contract.
+    #[must_use]
+    pub fn output_unflushed(&self) -> bool {
+        self.output_unflushed
     }
 
     /// ID of the most recently completed task, if any. Set by
@@ -1235,6 +1259,24 @@ mod tests {
         assert!(result.is_some());
         assert_eq!(result.unwrap().output, Bytes::from("output1"));
         assert_eq!(result.unwrap().task_id, crate::TaskId::from("task-1"));
+    }
+
+    #[test]
+    fn test_output_unflushed_marker() {
+        // Fresh snapshot: nothing completed, nothing to flush.
+        let mut snapshot = WorkflowSnapshot::new("inst-1", "hash-1".into());
+        assert!(!snapshot.output_unflushed());
+
+        // Completing a task flags its output as needing a flush.
+        snapshot.mark_task_completed(crate::TaskId::from("task-1"), Bytes::from("out1"));
+        assert!(snapshot.output_unflushed());
+
+        // The marker is in-memory only: a decoded snapshot (serde-skipped
+        // field) defaults to clean, since its outputs were already persisted
+        // and are hydrated from the sidecar on load.
+        let json = serde_json::to_string(&snapshot).unwrap();
+        let decoded: WorkflowSnapshot = serde_json::from_str(&json).unwrap();
+        assert!(!decoded.output_unflushed());
     }
 
     #[test]

--- a/sayiir-d1/src/snapshot_store.rs
+++ b/sayiir-d1/src/snapshot_store.rs
@@ -12,7 +12,7 @@ where
     for<'c> &'c T: Executor<'c, Database = crate::backend::BackendDB>,
     T: Clone + Send + Sync,
 {
-    async fn save_snapshot(&self, snapshot: &WorkflowSnapshot) -> Result<(), BackendError> {
+    async fn save_snapshot(&self, snapshot: &mut WorkflowSnapshot) -> Result<(), BackendError> {
         let data = self.encode(snapshot)?;
         let status = snapshot.state.as_ref();
         let task_id = snapshot.current_task_id().map(|t| t.to_hex());
@@ -96,7 +96,7 @@ where
         // Single-Worker: no concurrency, so sequential load → mutate → save is safe.
         let mut snapshot = self.load_snapshot(instance_id).await?;
         snapshot.mark_task_completed(*task_id, output);
-        self.save_snapshot(&snapshot).await
+        self.save_snapshot(&mut snapshot).await
     }
 
     async fn load_snapshot(&self, instance_id: &str) -> Result<WorkflowSnapshot, BackendError> {

--- a/sayiir-node/src/backend.rs
+++ b/sayiir-node/src/backend.rs
@@ -165,7 +165,7 @@ macro_rules! dispatch {
 type BResult<T> = std::result::Result<T, BackendError>;
 
 impl SnapshotStore for BackendKind {
-    async fn save_snapshot(&self, snapshot: &WorkflowSnapshot) -> BResult<()> {
+    async fn save_snapshot(&self, snapshot: &mut WorkflowSnapshot) -> BResult<()> {
         dispatch!(self, |b| b.save_snapshot(snapshot).await)
     }
 

--- a/sayiir-nodejs/__test__/worker.integration.test.ts
+++ b/sayiir-nodejs/__test__/worker.integration.test.ts
@@ -68,7 +68,7 @@ describe("Worker integration (Postgres)", () => {
   let connectionUrl: string;
 
   beforeAll(async () => {
-    container = await new PostgreSqlContainer("postgres:17-alpine").start();
+    container = await new PostgreSqlContainer("postgres:18-alpine").start();
     connectionUrl = container.getConnectionUri();
   }, 60_000);
 

--- a/sayiir-persistence/src/backend.rs
+++ b/sayiir-persistence/src/backend.rs
@@ -179,9 +179,14 @@ pub trait SnapshotStore: Send + Sync {
     /// Save a workflow snapshot.
     ///
     /// If a snapshot with the same instance_id already exists, it should be overwritten.
+    ///
+    /// Takes `&mut` so backends can encode the blob without cloning the
+    /// snapshot (strip task outputs in place, encode, restore) and clear
+    /// any in-memory "output unflushed" marker once the write lands. The
+    /// snapshot is logically unchanged on return.
     fn save_snapshot(
         &self,
-        snapshot: &WorkflowSnapshot,
+        snapshot: &mut WorkflowSnapshot,
     ) -> impl Future<Output = Result<(), BackendError>> + Send;
 
     /// Save a single task result atomically.
@@ -286,7 +291,7 @@ pub trait SignalStore: SnapshotStore {
                 return Ok(false);
             }
             snapshot.mark_cancelled(request.reason, request.requested_by, interrupted_at_task);
-            self.save_snapshot(&snapshot).await?;
+            self.save_snapshot(&mut snapshot).await?;
             self.clear_signal(instance_id, SignalKind::Cancel).await?;
             Ok(true)
         }
@@ -309,7 +314,7 @@ pub trait SignalStore: SnapshotStore {
             }
             let pause_request: PauseRequest = request.into();
             snapshot.mark_paused(&pause_request);
-            self.save_snapshot(&snapshot).await?;
+            self.save_snapshot(&mut snapshot).await?;
             self.clear_signal(instance_id, SignalKind::Pause).await?;
             Ok(true)
         }
@@ -335,7 +340,7 @@ pub trait SignalStore: SnapshotStore {
                 )));
             }
             snapshot.mark_unpaused();
-            self.save_snapshot(&snapshot).await?;
+            self.save_snapshot(&mut snapshot).await?;
             Ok(snapshot)
         }
     }

--- a/sayiir-persistence/src/in_memory.rs
+++ b/sayiir-persistence/src/in_memory.rs
@@ -62,7 +62,7 @@ impl InMemoryBackend {
 // ---------------------------------------------------------------------------
 
 impl SnapshotStore for InMemoryBackend {
-    async fn save_snapshot(&self, snapshot: &WorkflowSnapshot) -> Result<(), BackendError> {
+    async fn save_snapshot(&self, snapshot: &mut WorkflowSnapshot) -> Result<(), BackendError> {
         let mut snapshots = self.snapshots.write().map_err(Self::lock_error)?;
 
         // When transitioning to Completed/Failed, cache the previous snapshot's
@@ -752,9 +752,9 @@ mod tests {
     #[tokio::test]
     async fn test_save_and_load() {
         let backend = InMemoryBackend::new();
-        let snapshot = WorkflowSnapshot::new("test-123", "hash-abc".into());
+        let mut snapshot = WorkflowSnapshot::new("test-123", "hash-abc".into());
 
-        backend.save_snapshot(&snapshot).await.unwrap();
+        backend.save_snapshot(&mut snapshot).await.unwrap();
         let loaded = backend.load_snapshot("test-123").await.unwrap();
 
         assert_eq!(snapshot.instance_id, loaded.instance_id);
@@ -771,9 +771,9 @@ mod tests {
     #[tokio::test]
     async fn test_delete() {
         let backend = InMemoryBackend::new();
-        let snapshot = WorkflowSnapshot::new("test-123", "hash-abc".into());
+        let mut snapshot = WorkflowSnapshot::new("test-123", "hash-abc".into());
 
-        backend.save_snapshot(&snapshot).await.unwrap();
+        backend.save_snapshot(&mut snapshot).await.unwrap();
         backend.delete_snapshot("test-123").await.unwrap();
 
         let result = backend.load_snapshot("test-123").await;
@@ -785,11 +785,11 @@ mod tests {
         let backend = InMemoryBackend::new();
 
         backend
-            .save_snapshot(&WorkflowSnapshot::new("test-1", "hash-1".into()))
+            .save_snapshot(&mut WorkflowSnapshot::new("test-1", "hash-1".into()))
             .await
             .unwrap();
         backend
-            .save_snapshot(&WorkflowSnapshot::new("test-2", "hash-2".into()))
+            .save_snapshot(&mut WorkflowSnapshot::new("test-2", "hash-2".into()))
             .await
             .unwrap();
 
@@ -1093,8 +1093,8 @@ mod tests {
     #[tokio::test]
     async fn test_store_signal_cancel_success() {
         let backend = InMemoryBackend::new();
-        let snapshot = WorkflowSnapshot::new("test-123", "hash-abc".into());
-        backend.save_snapshot(&snapshot).await.unwrap();
+        let mut snapshot = WorkflowSnapshot::new("test-123", "hash-abc".into());
+        backend.save_snapshot(&mut snapshot).await.unwrap();
 
         let result = backend
             .store_signal(
@@ -1140,7 +1140,7 @@ mod tests {
         let backend = InMemoryBackend::new();
         let mut snapshot = WorkflowSnapshot::new("test-123", "hash-abc".into());
         snapshot.mark_completed(bytes::Bytes::from("result"));
-        backend.save_snapshot(&snapshot).await.unwrap();
+        backend.save_snapshot(&mut snapshot).await.unwrap();
 
         let result = backend
             .store_signal(
@@ -1160,7 +1160,7 @@ mod tests {
         let backend = InMemoryBackend::new();
         let mut snapshot = WorkflowSnapshot::new("test-123", "hash-abc".into());
         snapshot.mark_failed("Some error".to_string());
-        backend.save_snapshot(&snapshot).await.unwrap();
+        backend.save_snapshot(&mut snapshot).await.unwrap();
 
         let result = backend
             .store_signal(
@@ -1180,7 +1180,7 @@ mod tests {
         let backend = InMemoryBackend::new();
         let mut snapshot = WorkflowSnapshot::new("test-123", "hash-abc".into());
         snapshot.mark_cancelled(Some("First cancel".to_string()), None, None);
-        backend.save_snapshot(&snapshot).await.unwrap();
+        backend.save_snapshot(&mut snapshot).await.unwrap();
 
         let result = backend
             .store_signal(
@@ -1212,8 +1212,8 @@ mod tests {
     #[tokio::test]
     async fn test_clear_signal_cancel() {
         let backend = InMemoryBackend::new();
-        let snapshot = WorkflowSnapshot::new("test-123", "hash-abc".into());
-        backend.save_snapshot(&snapshot).await.unwrap();
+        let mut snapshot = WorkflowSnapshot::new("test-123", "hash-abc".into());
+        backend.save_snapshot(&mut snapshot).await.unwrap();
 
         backend
             .store_signal(
@@ -1253,7 +1253,7 @@ mod tests {
         let backend = InMemoryBackend::new();
         let mut snapshot = WorkflowSnapshot::new("test-123", "hash-abc".into());
         snapshot.mark_completed(bytes::Bytes::from("result"));
-        backend.save_snapshot(&snapshot).await.unwrap();
+        backend.save_snapshot(&mut snapshot).await.unwrap();
 
         let result = backend
             .store_signal(
@@ -1273,7 +1273,7 @@ mod tests {
         let backend = InMemoryBackend::new();
         let mut snapshot = WorkflowSnapshot::new("test-123", "hash-abc".into());
         snapshot.mark_failed("Some error".to_string());
-        backend.save_snapshot(&snapshot).await.unwrap();
+        backend.save_snapshot(&mut snapshot).await.unwrap();
 
         let result = backend
             .store_signal(
@@ -1293,7 +1293,7 @@ mod tests {
         let backend = InMemoryBackend::new();
         let mut snapshot = WorkflowSnapshot::new("test-123", "hash-abc".into());
         snapshot.mark_cancelled(Some("done".to_string()), None, None);
-        backend.save_snapshot(&snapshot).await.unwrap();
+        backend.save_snapshot(&mut snapshot).await.unwrap();
 
         let result = backend
             .store_signal(
@@ -1313,7 +1313,7 @@ mod tests {
         let backend = InMemoryBackend::new();
         let mut snapshot = WorkflowSnapshot::new("test-123", "hash-abc".into());
         snapshot.mark_paused(&PauseRequest::new(Some("first".to_string()), None));
-        backend.save_snapshot(&snapshot).await.unwrap();
+        backend.save_snapshot(&mut snapshot).await.unwrap();
 
         let result = backend
             .store_signal(
@@ -1347,8 +1347,8 @@ mod tests {
     #[tokio::test]
     async fn test_check_and_cancel_success() {
         let backend = InMemoryBackend::new();
-        let snapshot = WorkflowSnapshot::new("test-123", "hash-abc".into());
-        backend.save_snapshot(&snapshot).await.unwrap();
+        let mut snapshot = WorkflowSnapshot::new("test-123", "hash-abc".into());
+        backend.save_snapshot(&mut snapshot).await.unwrap();
 
         backend
             .store_signal(
@@ -1403,8 +1403,8 @@ mod tests {
     #[tokio::test]
     async fn test_check_and_cancel_no_request() {
         let backend = InMemoryBackend::new();
-        let snapshot = WorkflowSnapshot::new("test-123", "hash-abc".into());
-        backend.save_snapshot(&snapshot).await.unwrap();
+        let mut snapshot = WorkflowSnapshot::new("test-123", "hash-abc".into());
+        backend.save_snapshot(&mut snapshot).await.unwrap();
 
         let result = backend.check_and_cancel("test-123", None).await.unwrap();
         assert!(
@@ -1424,7 +1424,7 @@ mod tests {
         let backend = InMemoryBackend::new();
         let mut snapshot = WorkflowSnapshot::new("test-123", "hash-abc".into());
         snapshot.mark_completed(bytes::Bytes::from("done"));
-        backend.save_snapshot(&snapshot).await.unwrap();
+        backend.save_snapshot(&mut snapshot).await.unwrap();
 
         // Add a cancel signal directly (bypassing state check)
         {
@@ -1456,13 +1456,13 @@ mod tests {
         snapshot1.update_position(ExecutionPosition::AtTask {
             task_id: sayiir_core::TaskId::from("task-1"),
         });
-        backend.save_snapshot(&snapshot1).await.unwrap();
+        backend.save_snapshot(&mut snapshot1).await.unwrap();
 
         let mut snapshot2 = WorkflowSnapshot::new("workflow-2", "hash-abc".into());
         snapshot2.update_position(ExecutionPosition::AtTask {
             task_id: sayiir_core::TaskId::from("task-2"),
         });
-        backend.save_snapshot(&snapshot2).await.unwrap();
+        backend.save_snapshot(&mut snapshot2).await.unwrap();
 
         backend
             .store_signal(
@@ -1491,8 +1491,8 @@ mod tests {
     #[tokio::test]
     async fn test_check_and_pause_success() {
         let backend = InMemoryBackend::new();
-        let snapshot = WorkflowSnapshot::new("test-123", "hash-abc".into());
-        backend.save_snapshot(&snapshot).await.unwrap();
+        let mut snapshot = WorkflowSnapshot::new("test-123", "hash-abc".into());
+        backend.save_snapshot(&mut snapshot).await.unwrap();
 
         backend
             .store_signal(
@@ -1534,8 +1534,8 @@ mod tests {
     #[tokio::test]
     async fn test_check_and_pause_no_request() {
         let backend = InMemoryBackend::new();
-        let snapshot = WorkflowSnapshot::new("test-123", "hash-abc".into());
-        backend.save_snapshot(&snapshot).await.unwrap();
+        let mut snapshot = WorkflowSnapshot::new("test-123", "hash-abc".into());
+        backend.save_snapshot(&mut snapshot).await.unwrap();
 
         let result = backend.check_and_pause("test-123").await.unwrap();
         assert!(
@@ -1555,7 +1555,7 @@ mod tests {
         let backend = InMemoryBackend::new();
         let mut snapshot = WorkflowSnapshot::new("test-123", "hash-abc".into());
         snapshot.mark_completed(bytes::Bytes::from("done"));
-        backend.save_snapshot(&snapshot).await.unwrap();
+        backend.save_snapshot(&mut snapshot).await.unwrap();
 
         // Add a pause signal directly (bypassing state check)
         {
@@ -1594,7 +1594,7 @@ mod tests {
             sayiir_core::TaskId::from("task-2"),
             bytes::Bytes::from("out2"),
         );
-        backend.save_snapshot(&snapshot).await.unwrap();
+        backend.save_snapshot(&mut snapshot).await.unwrap();
 
         backend
             .store_signal(
@@ -1650,7 +1650,7 @@ mod tests {
             Some("maintenance".to_string()),
             Some("ops".to_string()),
         ));
-        backend.save_snapshot(&snapshot).await.unwrap();
+        backend.save_snapshot(&mut snapshot).await.unwrap();
 
         let result = backend.unpause("test-123").await.unwrap();
 
@@ -1686,8 +1686,8 @@ mod tests {
     #[tokio::test]
     async fn test_unpause_not_paused_errors() {
         let backend = InMemoryBackend::new();
-        let snapshot = WorkflowSnapshot::new("test-123", "hash-abc".into());
-        backend.save_snapshot(&snapshot).await.unwrap();
+        let mut snapshot = WorkflowSnapshot::new("test-123", "hash-abc".into());
+        backend.save_snapshot(&mut snapshot).await.unwrap();
 
         let result = backend.unpause("test-123").await;
         assert!(
@@ -1701,7 +1701,7 @@ mod tests {
         let backend = InMemoryBackend::new();
         let mut snapshot = WorkflowSnapshot::new("test-123", "hash-abc".into());
         snapshot.mark_completed(bytes::Bytes::from("done"));
-        backend.save_snapshot(&snapshot).await.unwrap();
+        backend.save_snapshot(&mut snapshot).await.unwrap();
 
         let result = backend.unpause("test-123").await;
         assert!(
@@ -1724,8 +1724,8 @@ mod tests {
     #[tokio::test]
     async fn test_cancel_and_pause_simultaneously_cancel_wins() {
         let backend = InMemoryBackend::new();
-        let snapshot = WorkflowSnapshot::new("test-123", "hash-abc".into());
-        backend.save_snapshot(&snapshot).await.unwrap();
+        let mut snapshot = WorkflowSnapshot::new("test-123", "hash-abc".into());
+        backend.save_snapshot(&mut snapshot).await.unwrap();
 
         // Store both signals
         backend
@@ -1766,8 +1766,8 @@ mod tests {
     #[tokio::test]
     async fn test_cancel_signal_independent_of_pause_signal() {
         let backend = InMemoryBackend::new();
-        let snapshot = WorkflowSnapshot::new("test-123", "hash-abc".into());
-        backend.save_snapshot(&snapshot).await.unwrap();
+        let mut snapshot = WorkflowSnapshot::new("test-123", "hash-abc".into());
+        backend.save_snapshot(&mut snapshot).await.unwrap();
 
         // Store both signals
         backend
@@ -1826,7 +1826,7 @@ mod tests {
         snapshot1.update_position(ExecutionPosition::AtTask {
             task_id: sayiir_core::TaskId::from("task-1"),
         });
-        backend.save_snapshot(&snapshot1).await.unwrap();
+        backend.save_snapshot(&mut snapshot1).await.unwrap();
 
         let mut snapshot2 = WorkflowSnapshot::with_initial_input(
             "workflow-2",
@@ -1836,7 +1836,7 @@ mod tests {
         snapshot2.update_position(ExecutionPosition::AtTask {
             task_id: sayiir_core::TaskId::from("task-2"),
         });
-        backend.save_snapshot(&snapshot2).await.unwrap();
+        backend.save_snapshot(&mut snapshot2).await.unwrap();
 
         // Pause workflow-1
         backend
@@ -1870,8 +1870,8 @@ mod tests {
     #[tokio::test]
     async fn test_delete_snapshot_leaves_orphaned_signals() {
         let backend = InMemoryBackend::new();
-        let snapshot = WorkflowSnapshot::new("test-123", "hash-abc".into());
-        backend.save_snapshot(&snapshot).await.unwrap();
+        let mut snapshot = WorkflowSnapshot::new("test-123", "hash-abc".into());
+        backend.save_snapshot(&mut snapshot).await.unwrap();
 
         backend
             .store_signal(
@@ -1899,8 +1899,8 @@ mod tests {
     #[tokio::test]
     async fn test_store_signal_overwrites_previous() {
         let backend = InMemoryBackend::new();
-        let snapshot = WorkflowSnapshot::new("test-123", "hash-abc".into());
-        backend.save_snapshot(&snapshot).await.unwrap();
+        let mut snapshot = WorkflowSnapshot::new("test-123", "hash-abc".into());
+        backend.save_snapshot(&mut snapshot).await.unwrap();
 
         backend
             .store_signal(
@@ -1956,7 +1956,7 @@ mod tests {
             sayiir_core::TaskId::from("wait_1h"),
             bytes::Bytes::from(vec![42]),
         );
-        backend.save_snapshot(&snapshot).await.unwrap();
+        backend.save_snapshot(&mut snapshot).await.unwrap();
 
         let tasks = backend
             .find_available_tasks("worker-1", 10, chrono::Duration::seconds(300), &[])
@@ -1989,7 +1989,7 @@ mod tests {
             sayiir_core::TaskId::from("wait_done"),
             bytes::Bytes::from(vec![42]),
         );
-        backend.save_snapshot(&snapshot).await.unwrap();
+        backend.save_snapshot(&mut snapshot).await.unwrap();
 
         let tasks = backend
             .find_available_tasks("worker-1", 10, chrono::Duration::seconds(300), &[])
@@ -2035,7 +2035,7 @@ mod tests {
             sayiir_core::TaskId::from("final_wait"),
             bytes::Bytes::from(vec![42]),
         );
-        backend.save_snapshot(&snapshot).await.unwrap();
+        backend.save_snapshot(&mut snapshot).await.unwrap();
 
         let tasks = backend
             .find_available_tasks("worker-1", 10, chrono::Duration::seconds(300), &[])
@@ -2072,7 +2072,7 @@ mod tests {
             snapshot.update_position(ExecutionPosition::AtTask {
                 task_id: sayiir_core::TaskId::from("task-a"),
             });
-            backend.save_snapshot(&snapshot).await.unwrap();
+            backend.save_snapshot(&mut snapshot).await.unwrap();
         }
 
         let tasks = backend
@@ -2099,7 +2099,7 @@ mod tests {
             task_id: sayiir_core::TaskId::from("task-a"),
         });
         // updated_at stays at "now"
-        backend.save_snapshot(&high).await.unwrap();
+        backend.save_snapshot(&mut high).await.unwrap();
 
         // Low-priority workflow (priority 5) that has been waiting a long time.
         let mut low = WorkflowSnapshot::with_initial_input("wf-low", "hash".into(), input.clone());
@@ -2109,7 +2109,7 @@ mod tests {
         });
         // Simulate long wait: push updated_at 10 minutes into the past.
         low.updated_at = (chrono::Utc::now().timestamp() - 600) as u64;
-        backend.save_snapshot(&low).await.unwrap();
+        backend.save_snapshot(&mut low).await.unwrap();
 
         // With a 60s aging interval, the low-priority task's effective priority:
         //   5 - (600 / 60) = 5 - 10 = -5
@@ -2139,7 +2139,7 @@ mod tests {
         snapshot.update_position(ExecutionPosition::AtTask {
             task_id: sayiir_core::TaskId::from("task-a"),
         });
-        backend.save_snapshot(&snapshot).await.unwrap();
+        backend.save_snapshot(&mut snapshot).await.unwrap();
 
         // Zero aging interval should not panic or divide by zero.
         let tasks = backend
@@ -2163,7 +2163,7 @@ mod tests {
             task_id: sayiir_core::TaskId::from("t1"),
         });
         snap1.task_tags = vec!["gpu".into()];
-        backend.save_snapshot(&snap1).await.unwrap();
+        backend.save_snapshot(&mut snap1).await.unwrap();
 
         // Task tagged ["cpu"]
         let mut snap2 =
@@ -2172,7 +2172,7 @@ mod tests {
             task_id: sayiir_core::TaskId::from("t2"),
         });
         snap2.task_tags = vec!["cpu".into()];
-        backend.save_snapshot(&snap2).await.unwrap();
+        backend.save_snapshot(&mut snap2).await.unwrap();
 
         // Worker with ["gpu"] should only see the gpu task
         let tasks = backend
@@ -2193,14 +2193,14 @@ mod tests {
             task_id: sayiir_core::TaskId::from("t1"),
         });
         snap1.task_tags = vec!["gpu".into()];
-        backend.save_snapshot(&snap1).await.unwrap();
+        backend.save_snapshot(&mut snap1).await.unwrap();
 
         let mut snap2 =
             WorkflowSnapshot::with_initial_input("wf-plain", "h1".into(), bytes::Bytes::from("2"));
         snap2.update_position(ExecutionPosition::AtTask {
             task_id: sayiir_core::TaskId::from("t2"),
         });
-        backend.save_snapshot(&snap2).await.unwrap();
+        backend.save_snapshot(&mut snap2).await.unwrap();
 
         // Untagged worker should see both
         let tasks = backend
@@ -2220,7 +2220,7 @@ mod tests {
         snap.update_position(ExecutionPosition::AtTask {
             task_id: sayiir_core::TaskId::from("t1"),
         });
-        backend.save_snapshot(&snap).await.unwrap();
+        backend.save_snapshot(&mut snap).await.unwrap();
 
         // Tagged worker should still pick up untagged tasks
         let tasks = backend
@@ -2297,7 +2297,7 @@ mod tests {
             sayiir_core::TaskId::from("task-1"),
             bytes::Bytes::from("out1"),
         );
-        backend.save_snapshot(&snapshot).await.unwrap();
+        backend.save_snapshot(&mut snapshot).await.unwrap();
 
         let result = backend
             .load_task_result("wf-1", &sayiir_core::TaskId::from("task-1"))
@@ -2309,8 +2309,8 @@ mod tests {
     #[tokio::test]
     async fn test_load_task_result_not_found() {
         let backend = InMemoryBackend::new();
-        let snapshot = WorkflowSnapshot::new("wf-1", "hash".into());
-        backend.save_snapshot(&snapshot).await.unwrap();
+        let mut snapshot = WorkflowSnapshot::new("wf-1", "hash".into());
+        backend.save_snapshot(&mut snapshot).await.unwrap();
 
         let result = backend
             .load_task_result("wf-1", &sayiir_core::TaskId::from("no-such-task"))
@@ -2338,11 +2338,11 @@ mod tests {
             sayiir_core::TaskId::from("task-1"),
             bytes::Bytes::from("out1"),
         );
-        backend.save_snapshot(&snapshot).await.unwrap();
+        backend.save_snapshot(&mut snapshot).await.unwrap();
 
         // Complete the workflow — save_snapshot caches the task results
         snapshot.mark_completed(bytes::Bytes::from("final"));
-        backend.save_snapshot(&snapshot).await.unwrap();
+        backend.save_snapshot(&mut snapshot).await.unwrap();
 
         // Task result should still be accessible from cache
         let result = backend
@@ -2361,10 +2361,10 @@ mod tests {
             sayiir_core::TaskId::from("task-1"),
             bytes::Bytes::from("out1"),
         );
-        backend.save_snapshot(&snapshot).await.unwrap();
+        backend.save_snapshot(&mut snapshot).await.unwrap();
 
         snapshot.mark_failed("boom".into());
-        backend.save_snapshot(&snapshot).await.unwrap();
+        backend.save_snapshot(&mut snapshot).await.unwrap();
 
         let result = backend
             .load_task_result("wf-1", &sayiir_core::TaskId::from("task-1"))
@@ -2382,10 +2382,10 @@ mod tests {
             sayiir_core::TaskId::from("task-1"),
             bytes::Bytes::from("out1"),
         );
-        backend.save_snapshot(&snapshot).await.unwrap();
+        backend.save_snapshot(&mut snapshot).await.unwrap();
 
         snapshot.mark_completed(bytes::Bytes::from("final"));
-        backend.save_snapshot(&snapshot).await.unwrap();
+        backend.save_snapshot(&mut snapshot).await.unwrap();
 
         // Delete should clean both snapshot and cache
         backend.delete_snapshot("wf-1").await.unwrap();

--- a/sayiir-persistence/src/in_memory.rs
+++ b/sayiir-persistence/src/in_memory.rs
@@ -73,7 +73,12 @@ impl SnapshotStore for InMemoryBackend {
             && !tasks.is_empty()
         {
             let mut cache = self.task_results_cache.write().map_err(Self::lock_error)?;
-            cache.insert(snapshot.instance_id.clone(), tasks.clone());
+            // `get_all_task_results` returns an `FxHashMap`; the cache keeps a
+            // std `HashMap`, so collect into the cache's type.
+            cache.insert(
+                snapshot.instance_id.clone(),
+                tasks.iter().map(|(k, v)| (*k, v.clone())).collect(),
+            );
         }
 
         snapshots.insert(snapshot.instance_id.clone(), snapshot.clone());

--- a/sayiir-persistence/src/lib.rs
+++ b/sayiir-persistence/src/lib.rs
@@ -30,8 +30,8 @@
 //! let backend = InMemoryBackend::new();
 //!
 //! // Save a snapshot
-//! let snapshot = WorkflowSnapshot::new("instance-123", sayiir_core::DefinitionHash::from("hash-abc"));
-//! backend.save_snapshot(&snapshot).await?;
+//! let mut snapshot = WorkflowSnapshot::new("instance-123", sayiir_core::DefinitionHash::from("hash-abc"));
+//! backend.save_snapshot(&mut snapshot).await?;
 //!
 //! // Load it back
 //! let loaded = backend.load_snapshot("instance-123").await?;

--- a/sayiir-persistence/src/lifecycle.rs
+++ b/sayiir-persistence/src/lifecycle.rs
@@ -165,6 +165,6 @@ where
         task_id: first_task.id,
     });
     snapshot.set_task_hint(&first_task);
-    backend.save_snapshot(&snapshot).await?;
+    backend.save_snapshot(&mut snapshot).await?;
     Ok(PrepareRunOutcome::Fresh(Box::new(snapshot)))
 }

--- a/sayiir-postgres/src/backend.rs
+++ b/sayiir-postgres/src/backend.rs
@@ -214,20 +214,13 @@ where
             .map_err(|e| BackendError::Serialization(e.to_string()))
     }
 
-    /// Encode the snapshot blob in the canonical "outputs stripped" shape
-    /// and return it alongside its SHA-256 hash, without cloning.
+    /// Encode the outputs-stripped blob + its SHA-256, without cloning.
     ///
-    /// **Destructive**: strips the task outputs in place and does NOT
-    /// restore them. Use from paths that own the snapshot, read only
-    /// metadata afterwards, and drop it when the transaction commits —
-    /// `save_task_result` and the signal-store `check_and_*` paths. This is
-    /// the common case; restoring would burn an O(n) hydrate (n hash
-    /// lookups) per write for nothing, which on the fanout hot path
-    /// (`save_task_result`, one call per branch) dominates the write.
-    ///
-    /// Callers that need the outputs intact after encoding (only
-    /// `save_snapshot`, which binds the last output into the `task_output`
-    /// CTE) must use [`encode_blob_preserving`](Self::encode_blob_preserving).
+    /// Destructive: strips task outputs in place, no restore. For callers that
+    /// own the snapshot, read only metadata after, and drop it on commit
+    /// (`save_task_result`, the signal-store `check_and_*` paths). Callers that
+    /// read outputs back after encoding use
+    /// [`encode_blob_preserving`](Self::encode_blob_preserving).
     pub(crate) fn encode_blob(
         &self,
         snapshot: &mut WorkflowSnapshot,

--- a/sayiir-postgres/src/backend.rs
+++ b/sayiir-postgres/src/backend.rs
@@ -214,17 +214,35 @@ where
             .map_err(|e| BackendError::Serialization(e.to_string()))
     }
 
-    /// Encode the snapshot blob in the canonical "outputs stripped"
-    /// shape and return it alongside its SHA-256 hash, without cloning.
+    /// Encode the snapshot blob in the canonical "outputs stripped" shape
+    /// and return it alongside its SHA-256 hash, without cloning.
     ///
-    /// Moves the task outputs out, encodes the stripped blob, then
-    /// hydrates them back — the snapshot is logically unchanged on return
-    /// (including on the encode-error path), so callers may keep reading
-    /// outputs afterwards (e.g. to bind the `task_output` CTE). Takes
-    /// `&mut` to avoid cloning the whole `completed_tasks` map on every
-    /// write; every blob-mutating path (`save_snapshot`, `save_task_result`,
-    /// the signal-store check_and_* paths) owns its snapshot.
+    /// **Destructive**: strips the task outputs in place and does NOT
+    /// restore them. Use from paths that own the snapshot, read only
+    /// metadata afterwards, and drop it when the transaction commits —
+    /// `save_task_result` and the signal-store `check_and_*` paths. This is
+    /// the common case; restoring would burn an O(n) hydrate (n hash
+    /// lookups) per write for nothing, which on the fanout hot path
+    /// (`save_task_result`, one call per branch) dominates the write.
+    ///
+    /// Callers that need the outputs intact after encoding (only
+    /// `save_snapshot`, which binds the last output into the `task_output`
+    /// CTE) must use [`encode_blob_preserving`](Self::encode_blob_preserving).
     pub(crate) fn encode_blob(
+        &self,
+        snapshot: &mut WorkflowSnapshot,
+    ) -> Result<(Vec<u8>, [u8; 32]), BackendError> {
+        snapshot.strip_task_outputs();
+        let data = self.encode(snapshot)?;
+        let hash = crate::history::snapshot_hash(&data);
+        Ok((data, hash))
+    }
+
+    /// Like [`encode_blob`] but restores the task outputs after encoding,
+    /// so the snapshot is logically unchanged on return (including on the
+    /// encode-error path). Costs an extra O(n) hydrate; only use it when
+    /// the caller reads outputs back after encoding.
+    pub(crate) fn encode_blob_preserving(
         &self,
         snapshot: &mut WorkflowSnapshot,
     ) -> Result<(Vec<u8>, [u8; 32]), BackendError> {

--- a/sayiir-postgres/src/backend.rs
+++ b/sayiir-postgres/src/backend.rs
@@ -215,14 +215,23 @@ where
     }
 
     /// Encode the snapshot blob in the canonical "outputs stripped"
-    /// shape and return it alongside its SHA-256 hash.
+    /// shape and return it alongside its SHA-256 hash, without cloning.
+    ///
+    /// Moves the task outputs out, encodes the stripped blob, then
+    /// hydrates them back — the snapshot is logically unchanged on return
+    /// (including on the encode-error path), so callers may keep reading
+    /// outputs afterwards (e.g. to bind the `task_output` CTE). Takes
+    /// `&mut` to avoid cloning the whole `completed_tasks` map on every
+    /// write; every blob-mutating path (`save_snapshot`, `save_task_result`,
+    /// the signal-store check_and_* paths) owns its snapshot.
     pub(crate) fn encode_blob(
         &self,
-        snapshot: &WorkflowSnapshot,
+        snapshot: &mut WorkflowSnapshot,
     ) -> Result<(Vec<u8>, [u8; 32]), BackendError> {
-        let mut stripped = snapshot.clone();
-        stripped.strip_task_outputs();
-        let data = self.encode(&stripped)?;
+        let outputs = snapshot.take_task_outputs();
+        let encoded = self.encode(snapshot);
+        snapshot.hydrate_task_outputs(outputs);
+        let data = encoded?;
         let hash = crate::history::snapshot_hash(&data);
         Ok((data, hash))
     }

--- a/sayiir-postgres/src/history.rs
+++ b/sayiir-postgres/src/history.rs
@@ -39,7 +39,7 @@ use crate::error::PgError;
 pub(crate) async fn fetch_task_outputs<'e, E>(
     executor: E,
     instance_id: &str,
-) -> Result<HashMap<sayiir_core::TaskId, Bytes>, BackendError>
+) -> Result<Vec<(sayiir_core::TaskId, Bytes)>, BackendError>
 where
     E: sqlx::PgExecutor<'e>,
 {
@@ -52,7 +52,10 @@ where
     .await
     .map_err(PgError)?;
 
-    let mut outputs = HashMap::with_capacity(rows.len());
+    // Collected into a `Vec`, not a `HashMap`: the only consumer is
+    // `hydrate_task_outputs`, which just iterates — keying it here would
+    // hash every TaskId for nothing.
+    let mut outputs = Vec::with_capacity(rows.len());
     for row in rows {
         let task_id_bytes: &[u8] = row.get("task_id");
         let task_id = sayiir_core::TaskId::from_slice(task_id_bytes).map_err(|_| {
@@ -72,7 +75,7 @@ where
             ))
         })?;
         let output: Vec<u8> = row.get("output");
-        outputs.insert(task_id, Bytes::from(output));
+        outputs.push((task_id, Bytes::from(output)));
     }
     Ok(outputs)
 }
@@ -83,7 +86,7 @@ where
 pub(crate) async fn fetch_task_outputs_batched<'e, E>(
     executor: E,
     instance_ids: &[&str],
-) -> Result<HashMap<String, HashMap<sayiir_core::TaskId, Bytes>>, BackendError>
+) -> Result<HashMap<String, Vec<(sayiir_core::TaskId, Bytes)>>, BackendError>
 where
     E: sqlx::PgExecutor<'e>,
 {
@@ -99,7 +102,7 @@ where
     .await
     .map_err(PgError)?;
 
-    let mut grouped: HashMap<String, HashMap<sayiir_core::TaskId, Bytes>> = HashMap::new();
+    let mut grouped: HashMap<String, Vec<(sayiir_core::TaskId, Bytes)>> = HashMap::new();
     for row in rows {
         let instance_id: String = row.get("instance_id");
         let task_id_bytes: &[u8] = row.get("task_id");
@@ -118,7 +121,7 @@ where
         grouped
             .entry(instance_id)
             .or_default()
-            .insert(task_id, Bytes::from(output));
+            .push((task_id, Bytes::from(output)));
     }
     Ok(grouped)
 }
@@ -260,7 +263,8 @@ where
         let mut snapshot = self.decode(&data)?;
         let task_ids: Vec<Vec<u8>> = row.get("task_ids");
         let outputs_vec: Vec<Vec<u8>> = row.get("outputs");
-        let mut outputs = std::collections::HashMap::with_capacity(task_ids.len());
+        // `Vec`, not `HashMap`: `hydrate_task_outputs` only iterates these.
+        let mut outputs = Vec::with_capacity(task_ids.len());
         for (tid_bytes, output) in task_ids.into_iter().zip(outputs_vec) {
             // task_id is always a 32-byte SHA-256 (see migration 008
             // and every save_task_result write path). A wrong-sized
@@ -273,7 +277,7 @@ where
                     tid_bytes.len()
                 ))
             })?;
-            outputs.insert(task_id, Bytes::from(output));
+            outputs.push((task_id, Bytes::from(output)));
         }
         snapshot.hydrate_task_outputs(outputs);
         Ok(Some((snapshot, history_version)))

--- a/sayiir-postgres/src/lib.rs
+++ b/sayiir-postgres/src/lib.rs
@@ -40,7 +40,7 @@
 //! let backend = PostgresBackend::<JsonCodec>::connect("postgresql://localhost/sayiir").await?;
 //!
 //! let snapshot = WorkflowSnapshot::new("order-123", sayiir_core::DefinitionHash::from("hash-abc"));
-//! backend.save_snapshot(&snapshot).await?;
+//! backend.save_snapshot(&mut snapshot).await?;
 //!
 //! let loaded = backend.load_snapshot("order-123").await?;
 //! # Ok(())

--- a/sayiir-postgres/src/lib.rs
+++ b/sayiir-postgres/src/lib.rs
@@ -39,7 +39,7 @@
 //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 //! let backend = PostgresBackend::<JsonCodec>::connect("postgresql://localhost/sayiir").await?;
 //!
-//! let snapshot = WorkflowSnapshot::new("order-123", sayiir_core::DefinitionHash::from("hash-abc"));
+//! let mut snapshot = WorkflowSnapshot::new("order-123", sayiir_core::DefinitionHash::from("hash-abc"));
 //! backend.save_snapshot(&mut snapshot).await?;
 //!
 //! let loaded = backend.load_snapshot("order-123").await?;

--- a/sayiir-postgres/src/signal_store.rs
+++ b/sayiir-postgres/src/signal_store.rs
@@ -224,7 +224,7 @@ where
             // via the `task_output` CTE — without that UPSERT the
             // outputs-stripped blob loses the signal payload entirely
             // and the next dispatch hands the join an empty input.
-            let (data, data_hash) = self.encode_blob(&snapshot)?;
+            let (data, data_hash) = self.encode_blob(&mut snapshot)?;
             let status = snapshot.state.as_ref();
             let task_id_bytes: Option<[u8; 32]> = snapshot.current_task_id().map(|t| *t.as_bytes());
             let task_id: Option<&[u8]> = task_id_bytes.as_ref().map(<[u8; 32]>::as_slice);
@@ -406,7 +406,7 @@ where
         let requested_by: Option<String> = signal_row.get("requested_by");
         snapshot.mark_cancelled(reason, requested_by, interrupted_at_task);
 
-        let (data, data_hash) = self.encode_blob(&snapshot)?;
+        let (data, data_hash) = self.encode_blob(&mut snapshot)?;
         let status = snapshot.state.as_ref();
         let error = snapshot.error_message().map(ToString::to_string);
         let pos_kind = snapshot.position_kind();
@@ -535,7 +535,7 @@ where
         let pause_request = PauseRequest::new(reason, requested_by);
         snapshot.mark_paused(&pause_request);
 
-        let (data, data_hash) = self.encode_blob(&snapshot)?;
+        let (data, data_hash) = self.encode_blob(&mut snapshot)?;
         let status = snapshot.state.as_ref();
         let task_id_bytes: Option<[u8; 32]> = snapshot.current_task_id().map(|t| *t.as_bytes());
         let task_id: Option<&[u8]> = task_id_bytes.as_ref().map(<[u8; 32]>::as_slice);
@@ -630,7 +630,7 @@ where
 
         snapshot.mark_unpaused();
 
-        let (data, data_hash) = self.encode_blob(&snapshot)?;
+        let (data, data_hash) = self.encode_blob(&mut snapshot)?;
         let status = snapshot.state.as_ref();
         let task_id_bytes: Option<[u8; 32]> = snapshot.current_task_id().map(|t| *t.as_bytes());
         let task_id: Option<&[u8]> = task_id_bytes.as_ref().map(<[u8; 32]>::as_slice);

--- a/sayiir-postgres/src/snapshot_store.rs
+++ b/sayiir-postgres/src/snapshot_store.rs
@@ -56,22 +56,28 @@ where
         // output into the sidecar table here too, so dispatch can
         // hydrate `completed_tasks[*].output` from `workflow_tasks`.
         //
-        // `task_output` CTE's `WHERE … IS DISTINCT FROM EXCLUDED.output`
-        // gate suppresses the row write when bytes match, but the bytes
-        // still travel the wire. PERF TODO: thread an unflushed-output
-        // marker through the snapshot (requires `save_snapshot(&mut
-        // WorkflowSnapshot)` and SnapshotStore trait change) so
-        // position-only saves bind NULL here instead of re-shipping the
-        // last completed task's payload on every dispatch tick. The
-        // major position-only offender (worker.rs deadline save) is
-        // gone post review-fix #6.
-        let last_completed_bytes: Option<[u8; 32]> =
-            snapshot.last_completed_task_id().map(|t| *t.as_bytes());
+        // Ship the output ONLY when the snapshot flags it unflushed.
+        // `mark_task_completed` sets that flag; a freshly-loaded snapshot
+        // clears it (its outputs were already hydrated from the sidecar).
+        // Position-only saves (pause/cancel/delay/signal parking, which
+        // never call `mark_task_completed`) therefore bind NULL for both
+        // the task id and the payload, so the `task_output` CTE no-ops via
+        // `WHERE $18 IS NOT NULL` instead of re-shipping the last completed
+        // task's bytes on every dispatch tick. Skipping is always safe: an
+        // unflagged output is, by construction, already in `workflow_tasks`.
+        let output_unflushed = snapshot.output_unflushed();
+        let last_completed_task_id: Option<[u8; 32]> = output_unflushed
+            .then(|| snapshot.last_completed_task_id().map(|t| *t.as_bytes()))
+            .flatten();
         let last_completed_slice: Option<&[u8]> =
-            last_completed_bytes.as_ref().map(<[u8; 32]>::as_slice);
-        let last_completed_output: Option<bytes::Bytes> = snapshot
-            .last_completed_task_id()
-            .and_then(|id| snapshot.get_task_result(&id).map(|r| r.output.clone()));
+            last_completed_task_id.as_ref().map(<[u8; 32]>::as_slice);
+        let last_completed_output: Option<bytes::Bytes> = output_unflushed
+            .then(|| {
+                snapshot
+                    .last_completed_task_id()
+                    .and_then(|id| snapshot.get_task_result(&id).map(|r| r.output.clone()))
+            })
+            .flatten();
         let last_completed_output_slice: Option<&[u8]> = last_completed_output.as_deref();
 
         // One round-trip via a CTE chain: bump the snapshot version,

--- a/sayiir-postgres/src/snapshot_store.rs
+++ b/sayiir-postgres/src/snapshot_store.rs
@@ -229,12 +229,23 @@ where
         let current: Option<&[u8]> = current_bytes.as_ref().map(<[u8; 32]>::as_slice);
         let task_count = snapshot.completed_task_count();
         let next_history_version = prev_history_version + 1;
-        let notify_payload = build_task_ready_payload(&snapshot);
 
-        // UPDATE snapshots + INSERT history + UPSERT workflow_tasks +
-        // pg_notify in one CTE — the lock acquired above by
+        // UPDATE snapshots + INSERT history + UPSERT workflow_tasks in
+        // one CTE — the lock acquired above by
         // lock_snapshot_for_mutation is still held in this same tx, so
-        // all four writes commit together.
+        // all three writes commit together.
+        //
+        // NOTIFY is deliberately NOT emitted here: `current_task_id`
+        // has just been marked completed in `completed_tasks` but the
+        // snapshot row's `current_task_id` still points at it (the
+        // position advance happens in the immediately-following
+        // `save_snapshot` from `commit_task_result`). A NOTIFY here
+        // would carry a stale hint — recipients would call
+        // `find_hinted_task`, hydrate workflow_tasks, see the task
+        // already completed in `completed_tasks`, and bail. On the
+        // linear bench this stale half doubled NOTIFY pressure and
+        // blew through the 16 384-slot mpmc channel (~9 600 drops on
+        // CI), forcing workers onto the slower polling fallback.
         sqlx::query(
             "WITH upd AS (
                  UPDATE sayiir_workflow_snapshots
@@ -265,11 +276,7 @@ where
              -- them unconditionally regardless of references, but any
              -- future refactor that converts one to a non-DML CTE
              -- would silently drop the write without this anchor.
-             -- pg_notify in the outer projection only fires when the
-             -- payload is non-NULL.
-             SELECT pg_notify($10, $11) FROM upd WHERE $11 IS NOT NULL
-             UNION ALL
-             SELECT NULL::void FROM upd WHERE $11 IS NULL",
+             SELECT 1 FROM upd",
         )
         .bind(status) // $1
         .bind(current) // $2
@@ -280,8 +287,6 @@ where
         .bind(&data) // $7
         .bind(task_id.as_bytes().as_slice()) // $8
         .bind(output_bytes.as_ref()) // $9
-        .bind(TASK_READY_CHANNEL) // $10
-        .bind(notify_payload.as_deref()) // $11
         .execute(&mut *tx)
         .await
         .map_err(PgError)?;

--- a/sayiir-postgres/src/snapshot_store.rs
+++ b/sayiir-postgres/src/snapshot_store.rs
@@ -50,20 +50,12 @@ where
         };
         let notify_payload = build_task_ready_payload(snapshot);
 
-        // The runtime calls `mark_task_completed` then `save_snapshot`
-        // (not `save_task_result`); persist the just-completed task's
-        // output into the sidecar table here too, so dispatch can
-        // hydrate `completed_tasks[*].output` from `workflow_tasks`.
-        //
-        // Ship the output ONLY when the snapshot flags it unflushed.
-        // `mark_task_completed` sets that flag; a freshly-loaded snapshot
-        // clears it (its outputs were already hydrated from the sidecar).
-        // Position-only saves (pause/cancel/delay/signal parking, which
-        // never call `mark_task_completed`) therefore bind NULL for both
-        // the task id and the payload, so the `task_output` CTE no-ops via
-        // `WHERE $18 IS NOT NULL` instead of re-shipping the last completed
-        // task's bytes on every dispatch tick. Skipping is always safe: an
-        // unflagged output is, by construction, already in `workflow_tasks`.
+        // Ship the just-completed output to the sidecar ONLY when flagged
+        // unflushed (set by `mark_task_completed`, cleared post-write). On
+        // position-only saves (pause/cancel/delay/signal parking) the flag is
+        // false, so both binds are NULL and the `task_output` CTE no-ops via
+        // `WHERE $18 IS NOT NULL` — no re-shipping. Safe: an unflagged output
+        // is already in `workflow_tasks`.
         let output_unflushed = snapshot.output_unflushed;
         let last_completed_task_id: Option<[u8; 32]> = output_unflushed
             .then(|| snapshot.last_completed_task_id().map(|t| *t.as_bytes()))

--- a/sayiir-postgres/src/snapshot_store.rs
+++ b/sayiir-postgres/src/snapshot_store.rs
@@ -27,7 +27,7 @@ where
         err(level = tracing::Level::ERROR),
     )]
     #[allow(clippy::too_many_lines)]
-    async fn save_snapshot(&self, snapshot: &WorkflowSnapshot) -> Result<(), BackendError> {
+    async fn save_snapshot(&self, snapshot: &mut WorkflowSnapshot) -> Result<(), BackendError> {
         tracing::debug!("saving snapshot");
         let (data, data_hash) = self.encode_blob(snapshot)?;
         let status = snapshot.state.as_ref();
@@ -200,6 +200,10 @@ where
             .execute(&self.pool)
             .await
             .map_err(PgError)?;
+        // The last completed output (if any) is now durable in
+        // `workflow_tasks`; clear the marker so a later save of this same
+        // in-memory snapshot binds NULL instead of re-shipping the bytes.
+        snapshot.mark_output_flushed();
         Ok(())
     }
 
@@ -229,7 +233,7 @@ where
         let output_bytes = output.clone();
         snapshot.mark_task_completed(*task_id, output);
 
-        let (data, data_hash) = self.encode_blob(&snapshot)?;
+        let (data, data_hash) = self.encode_blob(&mut snapshot)?;
         let status = snapshot.state.as_ref();
         let current_bytes: Option<[u8; 32]> = snapshot.current_task_id().map(|t| *t.as_bytes());
         let current: Option<&[u8]> = current_bytes.as_ref().map(<[u8; 32]>::as_slice);

--- a/sayiir-postgres/src/snapshot_store.rs
+++ b/sayiir-postgres/src/snapshot_store.rs
@@ -29,7 +29,7 @@ where
     #[allow(clippy::too_many_lines)]
     async fn save_snapshot(&self, snapshot: &mut WorkflowSnapshot) -> Result<(), BackendError> {
         tracing::debug!("saving snapshot");
-        let (data, data_hash) = self.encode_blob(snapshot)?;
+        let (data, data_hash) = self.encode_blob_preserving(snapshot)?;
         let status = snapshot.state.as_ref();
         let task_id_bytes: Option<[u8; 32]> = snapshot.current_task_id().map(|t| *t.as_bytes());
         let task_id: Option<&[u8]> = task_id_bytes.as_ref().map(<[u8; 32]>::as_slice);
@@ -39,11 +39,10 @@ where
         let pos_kind = snapshot.position_kind();
         let wake_at = snapshot.delay_wake_at();
         let task_priority = i16::from(snapshot.current_task_priority());
-        let task_tags: Vec<&str> = snapshot
-            .current_task_tags()
-            .iter()
-            .map(String::as_str)
-            .collect();
+        // Bind the `&[String]` slice directly — sqlx encodes it as `text[]`,
+        // so the intermediate `Vec<&str>` collect (one alloc per save) is
+        // unnecessary.
+        let task_tags = snapshot.current_task_tags();
         let terminal_status = match SnapshotStatus::from(&snapshot.state) {
             SnapshotStatus::Failed => "failed",
             SnapshotStatus::Cancelled => "cancelled",
@@ -65,7 +64,7 @@ where
         // `WHERE $18 IS NOT NULL` instead of re-shipping the last completed
         // task's bytes on every dispatch tick. Skipping is always safe: an
         // unflagged output is, by construction, already in `workflow_tasks`.
-        let output_unflushed = snapshot.output_unflushed();
+        let output_unflushed = snapshot.output_unflushed;
         let last_completed_task_id: Option<[u8; 32]> = output_unflushed
             .then(|| snapshot.last_completed_task_id().map(|t| *t.as_bytes()))
             .flatten();
@@ -189,7 +188,7 @@ where
             .bind(wake_at) // $9
             .bind(snapshot.trace_parent.as_deref()) // $10
             .bind(task_priority) // $11
-            .bind(&task_tags) // $12
+            .bind(task_tags) // $12
             .bind(data_hash.as_slice()) // $13
             .bind(&data) // $14
             .bind(terminal_status) // $15
@@ -203,7 +202,7 @@ where
         // The last completed output (if any) is now durable in
         // `workflow_tasks`; clear the marker so a later save of this same
         // in-memory snapshot binds NULL instead of re-shipping the bytes.
-        snapshot.mark_output_flushed();
+        snapshot.output_unflushed = false;
         Ok(())
     }
 

--- a/sayiir-postgres/src/task_claim_store.rs
+++ b/sayiir-postgres/src/task_claim_store.rs
@@ -517,7 +517,8 @@ where
         let task_ids: Option<Vec<Vec<u8>>> = row.get("task_ids");
         let task_outputs: Option<Vec<Vec<u8>>> = row.get("task_outputs");
         if let (Some(ids), Some(outs)) = (task_ids, task_outputs) {
-            let mut outputs = std::collections::HashMap::with_capacity(ids.len());
+            // `Vec`, not `HashMap`: `hydrate_task_outputs` only iterates these.
+            let mut outputs = Vec::with_capacity(ids.len());
             for (id_bytes, out_bytes) in ids.into_iter().zip(outs.into_iter()) {
                 let tid = sayiir_core::TaskId::from_slice(&id_bytes).map_err(|_| {
                     BackendError::Backend(format!(
@@ -526,7 +527,7 @@ where
                         id_bytes.len()
                     ))
                 })?;
-                outputs.insert(tid, bytes::Bytes::from(out_bytes));
+                outputs.push((tid, bytes::Bytes::from(out_bytes)));
             }
             snapshot.hydrate_task_outputs(outputs);
         }

--- a/sayiir-postgres/src/task_claim_store.rs
+++ b/sayiir-postgres/src/task_claim_store.rs
@@ -397,7 +397,7 @@ where
                     let delay_id_owned = *delay_id;
                     if let Some(next_id) = next_id_opt {
                         snapshot.update_position(ExecutionPosition::AtTask { task_id: next_id });
-                        self.save_snapshot(&snapshot).await?;
+                        self.save_snapshot(&mut snapshot).await?;
                         next_id
                     } else {
                         // Delay is the last node — complete the workflow.
@@ -405,7 +405,7 @@ where
                             .get_task_result_bytes(&delay_id_owned)
                             .unwrap_or_default();
                         snapshot.mark_completed(output);
-                        self.save_snapshot(&snapshot).await?;
+                        self.save_snapshot(&mut snapshot).await?;
                         continue;
                     }
                 }

--- a/sayiir-postgres/tests/integration.rs
+++ b/sayiir-postgres/tests/integration.rs
@@ -21,7 +21,7 @@ use testcontainers_modules::postgres::Postgres;
 const MIN_PG_VERSION: &str = "13-alpine";
 
 /// Default PostgreSQL version used by most tests.
-const DEFAULT_PG_VERSION: &str = "17-alpine";
+const DEFAULT_PG_VERSION: &str = "18-alpine";
 
 async fn setup_with(
     tag: &str,

--- a/sayiir-postgres/tests/integration.rs
+++ b/sayiir-postgres/tests/integration.rs
@@ -66,7 +66,7 @@ async fn seed_snapshot_at_task(
 ) {
     let mut snapshot = WorkflowSnapshot::new(instance_id, "test-hash".into());
     snapshot.update_position(ExecutionPosition::AtTask { task_id: *task_id });
-    backend.save_snapshot(&snapshot).await.unwrap();
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 }
 
 // ─── SnapshotStore ───────────────────────────────────────────────────────────
@@ -74,9 +74,9 @@ async fn seed_snapshot_at_task(
 #[tokio::test]
 async fn save_and_load_snapshot() {
     let (_c, backend) = setup().await;
-    let snapshot = WorkflowSnapshot::new("test-1", "hash-1".into());
+    let mut snapshot = WorkflowSnapshot::new("test-1", "hash-1".into());
 
-    backend.save_snapshot(&snapshot).await.unwrap();
+    backend.save_snapshot(&mut snapshot).await.unwrap();
     let loaded = backend.load_snapshot("test-1").await.unwrap();
 
     assert_eq!(&*loaded.instance_id, "test-1");
@@ -98,12 +98,12 @@ async fn load_not_found() {
 async fn save_snapshot_overwrites() {
     let (_c, backend) = setup().await;
     let mut snapshot = WorkflowSnapshot::new("test-1", "hash-1".into());
-    backend.save_snapshot(&snapshot).await.unwrap();
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 
     snapshot.update_position(ExecutionPosition::AtTask {
         task_id: sayiir_core::TaskId::from("step-2"),
     });
-    backend.save_snapshot(&snapshot).await.unwrap();
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 
     let loaded = backend.load_snapshot("test-1").await.unwrap();
     match &loaded.state {
@@ -121,8 +121,8 @@ async fn save_snapshot_overwrites() {
 #[tokio::test]
 async fn delete_snapshot() {
     let (_c, backend) = setup().await;
-    let snapshot = WorkflowSnapshot::new("test-1", "hash-1".into());
-    backend.save_snapshot(&snapshot).await.unwrap();
+    let mut snapshot = WorkflowSnapshot::new("test-1", "hash-1".into());
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 
     backend.delete_snapshot("test-1").await.unwrap();
     let result = backend.load_snapshot("test-1").await;
@@ -141,11 +141,11 @@ async fn list_snapshots() {
     let (_c, backend) = setup().await;
 
     backend
-        .save_snapshot(&WorkflowSnapshot::new("wf-1", "h".into()))
+        .save_snapshot(&mut WorkflowSnapshot::new("wf-1", "h".into()))
         .await
         .unwrap();
     backend
-        .save_snapshot(&WorkflowSnapshot::new("wf-2", "h".into()))
+        .save_snapshot(&mut WorkflowSnapshot::new("wf-2", "h".into()))
         .await
         .unwrap();
 
@@ -161,7 +161,7 @@ async fn save_task_result() {
     snapshot.update_position(ExecutionPosition::AtTask {
         task_id: sayiir_core::TaskId::from("task-1"),
     });
-    backend.save_snapshot(&snapshot).await.unwrap();
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 
     backend
         .save_task_result(
@@ -194,7 +194,7 @@ async fn history_is_canonical_data_column_stays_null() {
     let task_id = sayiir_core::TaskId::from("task-can");
     let mut snapshot = WorkflowSnapshot::new("wf-can", "hash-can".into());
     snapshot.update_position(ExecutionPosition::AtTask { task_id });
-    backend.save_snapshot(&snapshot).await.unwrap();
+    backend.save_snapshot(&mut snapshot).await.unwrap();
     backend
         .save_task_result("wf-can", &task_id, Bytes::from_static(b"first-result"))
         .await
@@ -256,7 +256,7 @@ async fn save_task_result_dual_writes_output_column() {
     let task_id = sayiir_core::TaskId::from("task-dw");
     let mut snapshot = WorkflowSnapshot::new("wf-dw", "hash-dw".into());
     snapshot.update_position(ExecutionPosition::AtTask { task_id });
-    backend.save_snapshot(&snapshot).await.unwrap();
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 
     let payload = Bytes::from_static(b"\x00\x01\x02hello");
     backend
@@ -288,8 +288,8 @@ async fn save_task_result_dual_writes_output_column() {
 #[tokio::test]
 async fn store_and_get_cancel_signal() {
     let (_c, backend) = setup().await;
-    let snapshot = WorkflowSnapshot::new("wf-1", "hash-1".into());
-    backend.save_snapshot(&snapshot).await.unwrap();
+    let mut snapshot = WorkflowSnapshot::new("wf-1", "hash-1".into());
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 
     backend
         .store_signal(
@@ -328,7 +328,7 @@ async fn store_cancel_on_completed_workflow() {
     let (_c, backend) = setup().await;
     let mut snapshot = WorkflowSnapshot::new("wf-1", "hash-1".into());
     snapshot.mark_completed(Bytes::from("result"));
-    backend.save_snapshot(&snapshot).await.unwrap();
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 
     let result = backend
         .store_signal("wf-1", SignalKind::Cancel, SignalRequest::new(None, None))
@@ -341,7 +341,7 @@ async fn store_pause_on_completed_workflow() {
     let (_c, backend) = setup().await;
     let mut snapshot = WorkflowSnapshot::new("wf-1", "hash-1".into());
     snapshot.mark_completed(Bytes::from("result"));
-    backend.save_snapshot(&snapshot).await.unwrap();
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 
     let result = backend
         .store_signal("wf-1", SignalKind::Pause, SignalRequest::new(None, None))
@@ -352,8 +352,8 @@ async fn store_pause_on_completed_workflow() {
 #[tokio::test]
 async fn clear_signal() {
     let (_c, backend) = setup().await;
-    let snapshot = WorkflowSnapshot::new("wf-1", "hash-1".into());
-    backend.save_snapshot(&snapshot).await.unwrap();
+    let mut snapshot = WorkflowSnapshot::new("wf-1", "hash-1".into());
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 
     backend
         .store_signal(
@@ -391,8 +391,8 @@ async fn get_signal_returns_none_when_absent() {
 #[tokio::test]
 async fn check_and_cancel_success() {
     let (_c, backend) = setup().await;
-    let snapshot = WorkflowSnapshot::new("wf-1", "hash-1".into());
-    backend.save_snapshot(&snapshot).await.unwrap();
+    let mut snapshot = WorkflowSnapshot::new("wf-1", "hash-1".into());
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 
     backend
         .store_signal(
@@ -427,8 +427,8 @@ async fn check_and_cancel_success() {
 #[tokio::test]
 async fn check_and_cancel_no_signal() {
     let (_c, backend) = setup().await;
-    let snapshot = WorkflowSnapshot::new("wf-1", "hash-1".into());
-    backend.save_snapshot(&snapshot).await.unwrap();
+    let mut snapshot = WorkflowSnapshot::new("wf-1", "hash-1".into());
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 
     let cancelled = backend.check_and_cancel("wf-1", None).await.unwrap();
     assert!(!cancelled);
@@ -440,8 +440,8 @@ async fn check_and_cancel_no_signal() {
 #[tokio::test]
 async fn check_and_pause_success() {
     let (_c, backend) = setup().await;
-    let snapshot = WorkflowSnapshot::new("wf-1", "hash-1".into());
-    backend.save_snapshot(&snapshot).await.unwrap();
+    let mut snapshot = WorkflowSnapshot::new("wf-1", "hash-1".into());
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 
     backend
         .store_signal(
@@ -466,8 +466,8 @@ async fn check_and_pause_success() {
 #[tokio::test]
 async fn unpause_success() {
     let (_c, backend) = setup().await;
-    let snapshot = WorkflowSnapshot::new("wf-1", "hash-1".into());
-    backend.save_snapshot(&snapshot).await.unwrap();
+    let mut snapshot = WorkflowSnapshot::new("wf-1", "hash-1".into());
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 
     // Pause it first
     backend
@@ -734,7 +734,7 @@ async fn find_available_tasks_basic() {
     snapshot.update_position(ExecutionPosition::AtTask {
         task_id: sayiir_core::TaskId::from("task-1"),
     });
-    backend.save_snapshot(&snapshot).await.unwrap();
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 
     let tasks = backend
         .find_available_tasks("worker-1", 10, chrono::Duration::seconds(300), &[])
@@ -755,7 +755,7 @@ async fn find_available_tasks_skips_cancelled() {
     snapshot1.update_position(ExecutionPosition::AtTask {
         task_id: sayiir_core::TaskId::from("task-1"),
     });
-    backend.save_snapshot(&snapshot1).await.unwrap();
+    backend.save_snapshot(&mut snapshot1).await.unwrap();
     backend
         .store_signal("wf-1", SignalKind::Cancel, SignalRequest::new(None, None))
         .await
@@ -767,7 +767,7 @@ async fn find_available_tasks_skips_cancelled() {
     snapshot2.update_position(ExecutionPosition::AtTask {
         task_id: sayiir_core::TaskId::from("task-2"),
     });
-    backend.save_snapshot(&snapshot2).await.unwrap();
+    backend.save_snapshot(&mut snapshot2).await.unwrap();
 
     let tasks = backend
         .find_available_tasks("worker-1", 10, chrono::Duration::seconds(300), &[])
@@ -783,7 +783,7 @@ async fn find_available_tasks_skips_completed() {
 
     let mut snapshot = WorkflowSnapshot::new("wf-1", "hash-1".into());
     snapshot.mark_completed(Bytes::from("done"));
-    backend.save_snapshot(&snapshot).await.unwrap();
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 
     let tasks = backend
         .find_available_tasks("worker-1", 10, chrono::Duration::seconds(300), &[])
@@ -805,7 +805,7 @@ async fn find_available_tasks_filters_by_worker_tags() {
         task_id: sayiir_core::TaskId::from("t1"),
     });
     snap1.task_tags = vec!["gpu".into()];
-    backend.save_snapshot(&snap1).await.unwrap();
+    backend.save_snapshot(&mut snap1).await.unwrap();
 
     // Task tagged ["cpu"]
     let mut snap2 =
@@ -814,7 +814,7 @@ async fn find_available_tasks_filters_by_worker_tags() {
         task_id: sayiir_core::TaskId::from("t2"),
     });
     snap2.task_tags = vec!["cpu".into()];
-    backend.save_snapshot(&snap2).await.unwrap();
+    backend.save_snapshot(&mut snap2).await.unwrap();
 
     // Worker with ["gpu"] should only see the gpu task
     let tasks = backend
@@ -835,14 +835,14 @@ async fn find_available_tasks_untagged_worker_accepts_all() {
         task_id: sayiir_core::TaskId::from("t1"),
     });
     snap1.task_tags = vec!["gpu".into()];
-    backend.save_snapshot(&snap1).await.unwrap();
+    backend.save_snapshot(&mut snap1).await.unwrap();
 
     let mut snap2 =
         WorkflowSnapshot::with_initial_input("wf-plain", "h1".into(), Bytes::from(r#""2""#));
     snap2.update_position(ExecutionPosition::AtTask {
         task_id: sayiir_core::TaskId::from("t2"),
     });
-    backend.save_snapshot(&snap2).await.unwrap();
+    backend.save_snapshot(&mut snap2).await.unwrap();
 
     // Untagged worker should see both
     let tasks = backend
@@ -862,7 +862,7 @@ async fn find_available_tasks_untagged_tasks_accepted_by_tagged_worker() {
     snap.update_position(ExecutionPosition::AtTask {
         task_id: sayiir_core::TaskId::from("t1"),
     });
-    backend.save_snapshot(&snap).await.unwrap();
+    backend.save_snapshot(&mut snap).await.unwrap();
 
     // Tagged worker should still pick up untagged tasks
     let tasks = backend
@@ -884,7 +884,7 @@ async fn find_available_tasks_multi_tag_subset() {
         task_id: sayiir_core::TaskId::from("t1"),
     });
     snap1.task_tags = vec!["gpu".into(), "cuda".into()];
-    backend.save_snapshot(&snap1).await.unwrap();
+    backend.save_snapshot(&mut snap1).await.unwrap();
 
     // Task requiring only ["gpu"]
     let mut snap2 =
@@ -893,7 +893,7 @@ async fn find_available_tasks_multi_tag_subset() {
         task_id: sayiir_core::TaskId::from("t2"),
     });
     snap2.task_tags = vec!["gpu".into()];
-    backend.save_snapshot(&snap2).await.unwrap();
+    backend.save_snapshot(&mut snap2).await.unwrap();
 
     // Worker with ["gpu"] cannot run ["gpu","cuda"] (not a superset), but can run ["gpu"]
     let tasks = backend
@@ -926,7 +926,7 @@ async fn find_available_tasks_tags_persist_through_save_load() {
         task_id: sayiir_core::TaskId::from("t1"),
     });
     snap.task_tags = vec!["gpu".into(), "cuda".into()];
-    backend.save_snapshot(&snap).await.unwrap();
+    backend.save_snapshot(&mut snap).await.unwrap();
 
     // Load and verify tags survived the roundtrip
     let loaded = backend.load_snapshot("wf-persist").await.unwrap();
@@ -947,7 +947,7 @@ async fn find_available_tasks_disjoint_tags_no_match() {
         task_id: sayiir_core::TaskId::from("t1"),
     });
     snap.task_tags = vec!["cpu".into()];
-    backend.save_snapshot(&snap).await.unwrap();
+    backend.save_snapshot(&mut snap).await.unwrap();
 
     // Worker with ["gpu"] should not see cpu tasks
     let tasks = backend
@@ -967,7 +967,7 @@ async fn load_task_result_in_progress() {
         sayiir_core::TaskId::from("task-1"),
         Bytes::from(r#""out1""#),
     );
-    backend.save_snapshot(&snapshot).await.unwrap();
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 
     let result = backend
         .load_task_result("wf-1", &sayiir_core::TaskId::from("task-1"))
@@ -979,8 +979,8 @@ async fn load_task_result_in_progress() {
 #[tokio::test]
 async fn load_task_result_not_found() {
     let (_c, backend) = setup().await;
-    let snapshot = WorkflowSnapshot::new("wf-1", "hash-1".into());
-    backend.save_snapshot(&snapshot).await.unwrap();
+    let mut snapshot = WorkflowSnapshot::new("wf-1", "hash-1".into());
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 
     let result = backend
         .load_task_result("wf-1", &sayiir_core::TaskId::from("no-such-task"))
@@ -1008,11 +1008,11 @@ async fn load_task_result_after_completion() {
         sayiir_core::TaskId::from("task-1"),
         Bytes::from(r#""out1""#),
     );
-    backend.save_snapshot(&snapshot).await.unwrap();
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 
     // Complete the workflow
     snapshot.mark_completed(Bytes::from(r#""final""#));
-    backend.save_snapshot(&snapshot).await.unwrap();
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 
     // Task result should still be accessible from history
     let result = backend
@@ -1031,15 +1031,15 @@ async fn works_on_minimum_pg_version() {
     let (_c, backend) = setup_with(MIN_PG_VERSION).await;
 
     // Snapshot CRUD
-    let snapshot = WorkflowSnapshot::new("min-pg-1", "hash".into());
-    backend.save_snapshot(&snapshot).await.unwrap();
+    let mut snapshot = WorkflowSnapshot::new("min-pg-1", "hash".into());
+    backend.save_snapshot(&mut snapshot).await.unwrap();
     let loaded = backend.load_snapshot("min-pg-1").await.unwrap();
     assert_eq!(&*loaded.instance_id, "min-pg-1");
     backend.delete_snapshot("min-pg-1").await.unwrap();
 
     // Signals
-    let snapshot = WorkflowSnapshot::new("min-pg-2", "hash".into());
-    backend.save_snapshot(&snapshot).await.unwrap();
+    let mut snapshot = WorkflowSnapshot::new("min-pg-2", "hash".into());
+    backend.save_snapshot(&mut snapshot).await.unwrap();
     backend
         .store_signal(
             "min-pg-2",
@@ -1096,8 +1096,8 @@ async fn save_snapshot_emits_notify_only_when_poll_eligible() {
     listener.listen("sayiir_task_ready").await.unwrap();
 
     // 1) Fresh NotStarted snapshot — must not notify.
-    let snapshot = WorkflowSnapshot::new("wf-notify", "h".into());
-    backend.save_snapshot(&snapshot).await.unwrap();
+    let mut snapshot = WorkflowSnapshot::new("wf-notify", "h".into());
+    backend.save_snapshot(&mut snapshot).await.unwrap();
     let no_notify = tokio::time::timeout(Duration::from_millis(150), listener.recv()).await;
     assert!(
         no_notify.is_err(),
@@ -1112,7 +1112,7 @@ async fn save_snapshot_emits_notify_only_when_poll_eligible() {
     snapshot.update_position(ExecutionPosition::AtTask {
         task_id: sayiir_core::TaskId::from("step-1"),
     });
-    backend.save_snapshot(&snapshot).await.unwrap();
+    backend.save_snapshot(&mut snapshot).await.unwrap();
     let notif = tokio::time::timeout(Duration::from_secs(1), listener.recv())
         .await
         .expect("AtTask save should emit a NOTIFY within 1s")
@@ -1133,7 +1133,7 @@ async fn save_snapshot_emits_notify_only_when_poll_eligible() {
     // 3) Terminal completion — must not notify.
     let mut snapshot = backend.load_snapshot("wf-notify").await.unwrap();
     snapshot.mark_completed(Bytes::from("done"));
-    backend.save_snapshot(&snapshot).await.unwrap();
+    backend.save_snapshot(&mut snapshot).await.unwrap();
     let no_notify = tokio::time::timeout(Duration::from_millis(150), listener.recv()).await;
     assert!(
         no_notify.is_err(),
@@ -1164,7 +1164,7 @@ async fn wait_for_wakeup_returns_on_notify() {
         snapshot.update_position(ExecutionPosition::AtTask {
             task_id: sayiir_core::TaskId::from("step-1"),
         });
-        backend2.save_snapshot(&snapshot).await.unwrap();
+        backend2.save_snapshot(&mut snapshot).await.unwrap();
     });
 
     let started = Instant::now();
@@ -1227,7 +1227,7 @@ async fn wait_for_wakeup_delivers_parsed_hint() {
         snapshot.update_position(ExecutionPosition::AtTask {
             task_id: sayiir_core::TaskId::from("task-a"),
         });
-        backend2.save_snapshot(&snapshot).await.unwrap();
+        backend2.save_snapshot(&mut snapshot).await.unwrap();
     });
 
     let hint = backend
@@ -1263,7 +1263,7 @@ async fn find_hinted_task_returns_available_task() {
     snapshot.update_position(ExecutionPosition::AtTask {
         task_id: sayiir_core::TaskId::from("first"),
     });
-    backend.save_snapshot(&snapshot).await.unwrap();
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 
     let hint = TaskWakeupHint {
         instance_id: "wf-hint-found".into(),
@@ -1296,7 +1296,7 @@ async fn find_hinted_task_returns_none_when_stale() {
     snapshot.update_position(ExecutionPosition::AtTask {
         task_id: sayiir_core::TaskId::from("second"),
     });
-    backend.save_snapshot(&snapshot).await.unwrap();
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 
     // Hint targets a task the workflow is no longer at — should be skipped.
     let hint = TaskWakeupHint {
@@ -1320,7 +1320,7 @@ async fn find_hinted_task_returns_none_when_claimed() {
     snapshot.update_position(ExecutionPosition::AtTask {
         task_id: sayiir_core::TaskId::from("first"),
     });
-    backend.save_snapshot(&snapshot).await.unwrap();
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 
     backend
         .claim_task(
@@ -1360,7 +1360,7 @@ async fn seed_snapshot_at_signal(
         wake_at: None,
         next_task_id,
     });
-    backend.save_snapshot(&snapshot).await.unwrap();
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 }
 
 /// Park at AtSignal, send the matching signal, assert the workflow

--- a/sayiir-py/src/backend.rs
+++ b/sayiir-py/src/backend.rs
@@ -176,7 +176,7 @@ macro_rules! dispatch {
 }
 
 impl SnapshotStore for BackendKind {
-    async fn save_snapshot(&self, snapshot: &WorkflowSnapshot) -> Result<(), BackendError> {
+    async fn save_snapshot(&self, snapshot: &mut WorkflowSnapshot) -> Result<(), BackendError> {
         dispatch!(self, |b| b.save_snapshot(snapshot).await)
     }
 

--- a/sayiir-python/tests/test_worker_integration.py
+++ b/sayiir-python/tests/test_worker_integration.py
@@ -55,7 +55,7 @@ def identity(x):
 @pytest.fixture(scope="module")
 def postgres_url():
     """Start a Postgres 17 container for the entire test module."""
-    with PostgresContainer("postgres:17-alpine", driver=None) as pg:
+    with PostgresContainer("postgres:18-alpine", driver=None) as pg:
         yield pg.get_connection_url()
 
 

--- a/sayiir-runtime/src/execution/fork.rs
+++ b/sayiir-runtime/src/execution/fork.rs
@@ -101,7 +101,7 @@ pub(crate) async fn park_at_fork<B: SnapshotStore>(
         completed_branches: build_completed_branches(branch_results),
         wake_at,
     });
-    if let Err(e) = backend.save_snapshot(&updated_snapshot).await {
+    if let Err(e) = backend.save_snapshot(&mut updated_snapshot).await {
         return RuntimeError::from(e);
     }
     *snapshot = updated_snapshot;
@@ -534,7 +534,7 @@ where
                     .await?;
 
                     snapshot.mark_task_completed(sayiir_core::TaskId::from(id), output.clone());
-                    backend.save_snapshot(&snapshot).await?;
+                    backend.save_snapshot(&mut snapshot).await?;
 
                     Ok(ControlFlow::Continue(output))
                 }

--- a/sayiir-runtime/src/execution/lifecycle.rs
+++ b/sayiir-runtime/src/execution/lifecycle.rs
@@ -122,7 +122,7 @@ where
         task_id: first_task.id,
     });
     snapshot.set_task_hint(&first_task);
-    backend.save_snapshot(&snapshot).await?;
+    backend.save_snapshot(&mut snapshot).await?;
     Ok(PrepareRunOutcome::Fresh(Box::new(snapshot)))
 }
 

--- a/sayiir-runtime/src/execution/tests.rs
+++ b/sayiir-runtime/src/execution/tests.rs
@@ -517,7 +517,7 @@ async fn test_checkpointing_task_timeout() {
     snapshot.update_position(ExecutionPosition::AtTask {
         task_id: sayiir_core::TaskId::from("slow"),
     });
-    backend.save_snapshot(&snapshot).await.unwrap();
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 
     let slow_task = |_id: &str, input: Bytes| async move {
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
@@ -564,7 +564,7 @@ async fn test_checkpointing_skipped_tasks_bypass_timeout() {
         task_id: sayiir_core::TaskId::from("cached"),
     });
     snapshot.mark_task_completed(sayiir_core::TaskId::from("cached"), output.clone());
-    backend.save_snapshot(&snapshot).await.unwrap();
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 
     let never_called = |_id: &str, _input: Bytes| async move {
         panic!("should not be called for cached tasks");
@@ -629,9 +629,9 @@ async fn test_prepare_run_creates_snapshot() {
 #[tokio::test]
 async fn test_prepare_resume_ready() {
     let backend = InMemoryBackend::new();
-    let snapshot =
+    let mut snapshot =
         WorkflowSnapshot::with_initial_input("inst-1", "hash-1".into(), Bytes::from("input"));
-    backend.save_snapshot(&snapshot).await.unwrap();
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 
     let outcome = prepare_resume("inst-1", &"hash-1".into(), &backend)
         .await
@@ -657,7 +657,7 @@ async fn test_prepare_resume_with_completed_tasks() {
         sayiir_core::TaskId::from("task-1"),
         Bytes::from("task1_output"),
     );
-    backend.save_snapshot(&snapshot).await.unwrap();
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 
     let outcome = prepare_resume("inst-1", &"hash-1".into(), &backend)
         .await
@@ -676,7 +676,7 @@ async fn test_prepare_resume_already_completed() {
     let backend = InMemoryBackend::new();
     let mut snapshot = WorkflowSnapshot::new("inst-1", "hash-1".into());
     snapshot.mark_completed(Bytes::from("result"));
-    backend.save_snapshot(&snapshot).await.unwrap();
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 
     let outcome = prepare_resume("inst-1", &"hash-1".into(), &backend)
         .await
@@ -692,7 +692,7 @@ async fn test_prepare_resume_already_failed() {
     let backend = InMemoryBackend::new();
     let mut snapshot = WorkflowSnapshot::new("inst-1", "hash-1".into());
     snapshot.mark_failed("err".into());
-    backend.save_snapshot(&snapshot).await.unwrap();
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 
     let outcome = prepare_resume("inst-1", &"hash-1".into(), &backend)
         .await
@@ -708,7 +708,7 @@ async fn test_prepare_resume_already_cancelled() {
     let backend = InMemoryBackend::new();
     let mut snapshot = WorkflowSnapshot::new("inst-1", "hash-1".into());
     snapshot.mark_cancelled(Some("reason".into()), Some("admin".into()), None);
-    backend.save_snapshot(&snapshot).await.unwrap();
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 
     let outcome = prepare_resume("inst-1", &"hash-1".into(), &backend)
         .await
@@ -724,8 +724,8 @@ async fn test_prepare_resume_already_cancelled() {
 #[tokio::test]
 async fn test_prepare_resume_hash_mismatch() {
     let backend = InMemoryBackend::new();
-    let snapshot = WorkflowSnapshot::new("inst-1", "hash-1".into());
-    backend.save_snapshot(&snapshot).await.unwrap();
+    let mut snapshot = WorkflowSnapshot::new("inst-1", "hash-1".into());
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 
     let result = prepare_resume("inst-1", &"wrong-hash".into(), &backend).await;
     assert!(result.is_err());
@@ -736,7 +736,7 @@ async fn test_prepare_resume_hash_mismatch() {
 async fn test_finalize_execution_success() {
     let backend = InMemoryBackend::new();
     let mut snapshot = WorkflowSnapshot::new("inst-1", "hash-1".into());
-    backend.save_snapshot(&snapshot).await.unwrap();
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 
     let (status, output) = finalize_execution(Ok(Bytes::from("output")), &mut snapshot, &backend)
         .await
@@ -756,7 +756,7 @@ async fn test_finalize_execution_success() {
 async fn test_finalize_execution_failure() {
     let backend = InMemoryBackend::new();
     let mut snapshot = WorkflowSnapshot::new("inst-1", "hash-1".into());
-    backend.save_snapshot(&snapshot).await.unwrap();
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 
     let (status, output) = finalize_execution(
         Err(RuntimeError::from(BoxError::from("task failed"))),
@@ -784,7 +784,7 @@ async fn test_finalize_execution_cancellation() {
     let mut snapshot = WorkflowSnapshot::new("inst-1", "hash-1".into());
     // Mark as cancelled in backend so finalize can reload details
     snapshot.mark_cancelled(Some("timeout".into()), Some("system".into()), None);
-    backend.save_snapshot(&snapshot).await.unwrap();
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 
     // Reset local snapshot to in-progress for finalize logic
     let mut local_snapshot = WorkflowSnapshot::new("inst-1", "hash-1".into());
@@ -821,7 +821,7 @@ async fn test_checkpointing_single_task() {
 
     let mut snapshot =
         WorkflowSnapshot::with_initial_input("inst-1", "hash-1".into(), input.clone());
-    backend.save_snapshot(&snapshot).await.unwrap();
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 
     let cont = stub_node("add_one", None);
 
@@ -862,7 +862,7 @@ async fn test_checkpointing_chain() {
 
     let mut snapshot =
         WorkflowSnapshot::with_initial_input("inst-1", "hash-1".into(), input.clone());
-    backend.save_snapshot(&snapshot).await.unwrap();
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 
     let double = stub_node("double", None);
     let add_one = stub_node("add_one", Some(Box::new(double)));
@@ -912,7 +912,7 @@ async fn test_checkpointing_skips_completed_tasks() {
         WorkflowSnapshot::with_initial_input("inst-1", "hash-1".into(), input.clone());
     // Pre-mark task as completed (simulates resume)
     snapshot.mark_task_completed(sayiir_core::TaskId::from("add_one"), encode_u32(11));
-    backend.save_snapshot(&snapshot).await.unwrap();
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 
     let double = stub_node("double", None);
     let add_one = stub_node("add_one", Some(Box::new(double)));
@@ -960,7 +960,7 @@ async fn test_checkpointing_fork_sequential() {
 
     let mut snapshot =
         WorkflowSnapshot::with_initial_input("inst-1", "hash-1".into(), input.clone());
-    backend.save_snapshot(&snapshot).await.unwrap();
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 
     let branch_a = Arc::new(stub_node("branch_a", None));
     let branch_b = Arc::new(stub_node("branch_b", None));
@@ -1013,7 +1013,7 @@ async fn test_checkpointing_cancellation() {
 
     let mut snapshot =
         WorkflowSnapshot::with_initial_input("inst-1", "hash-1".into(), input.clone());
-    backend.save_snapshot(&snapshot).await.unwrap();
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 
     // Request cancellation before execution
     backend
@@ -1187,7 +1187,7 @@ async fn test_checkpointing_delay_returns_waiting() {
 
     let mut snapshot =
         WorkflowSnapshot::with_initial_input("inst-1", "hash-1".into(), input.clone());
-    backend.save_snapshot(&snapshot).await.unwrap();
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 
     let next_task = stub_node("process", None);
     let delay = WorkflowContinuation::Delay {
@@ -1249,7 +1249,7 @@ async fn test_checkpointing_delay_skip_on_resume() {
         WorkflowSnapshot::with_initial_input("inst-1", "hash-1".into(), input.clone());
     // Pre-mark delay as completed (simulates resume after delay expired)
     snapshot.mark_task_completed(sayiir_core::TaskId::from("wait"), encode_u32(42));
-    backend.save_snapshot(&snapshot).await.unwrap();
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 
     let process = stub_node("process", None);
     let delay = WorkflowContinuation::Delay {
@@ -1291,7 +1291,7 @@ async fn test_checkpointing_delay_cancellation() {
 
     let mut snapshot =
         WorkflowSnapshot::with_initial_input("inst-1", "hash-1".into(), input.clone());
-    backend.save_snapshot(&snapshot).await.unwrap();
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 
     // Request cancellation
     backend
@@ -1346,7 +1346,7 @@ async fn test_finalize_execution_waiting() {
         wake_at,
         next_task_id: Some("next_step".into()),
     });
-    backend.save_snapshot(&snapshot).await.unwrap();
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 
     let (status, output) = finalize_execution(
         Err(WorkflowError::Waiting { wake_at }.into()),
@@ -1433,7 +1433,7 @@ async fn test_fork_with_delay_parks_at_fork() {
 
     let mut snapshot =
         WorkflowSnapshot::with_initial_input("inst-1", "hash-1".into(), input.clone());
-    backend.save_snapshot(&snapshot).await.unwrap();
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 
     let fork = fork_with_delay_in_branch();
     let callback = make_fork_callback();
@@ -1501,7 +1501,7 @@ async fn test_fork_with_delay_resumes_after_expiry() {
 
     let mut snapshot =
         WorkflowSnapshot::with_initial_input("inst-1", "hash-1".into(), input.clone());
-    backend.save_snapshot(&snapshot).await.unwrap();
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 
     // Use a very short delay so it expires immediately
     let branch_a = Arc::new(stub_node("branch_a", None));
@@ -1566,7 +1566,7 @@ async fn test_fork_with_delays_in_multiple_branches() {
 
     let mut snapshot =
         WorkflowSnapshot::with_initial_input("inst-1", "hash-1".into(), input.clone());
-    backend.save_snapshot(&snapshot).await.unwrap();
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 
     // Both branches have delays
     let after_delay_a = stub_node("after_a", None);
@@ -1650,7 +1650,7 @@ async fn test_fork_normal_branch_completes_delayed_branch_parks() {
 
     let mut snapshot =
         WorkflowSnapshot::with_initial_input("inst-1", "hash-1".into(), input.clone());
-    backend.save_snapshot(&snapshot).await.unwrap();
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 
     // branch_a: normal task (completes immediately)
     // branch_b: delay (parks)
@@ -1972,7 +1972,7 @@ async fn test_checkpointing_retry_succeeds_after_failure() {
     snapshot.update_position(ExecutionPosition::AtTask {
         task_id: sayiir_core::TaskId::from("flaky"),
     });
-    backend.save_snapshot(&snapshot).await.unwrap();
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 
     let cont = stub_node_with_retry("flaky", fast_retry(2), None);
     let attempts = Arc::new(AtomicU32::new(0));
@@ -2027,7 +2027,7 @@ async fn test_checkpointing_retry_exhaustion() {
     snapshot.update_position(ExecutionPosition::AtTask {
         task_id: sayiir_core::TaskId::from("always_fail"),
     });
-    backend.save_snapshot(&snapshot).await.unwrap();
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 
     let cont = stub_node_with_retry("always_fail", fast_retry(1), None);
     let attempts = Arc::new(AtomicU32::new(0));
@@ -2066,7 +2066,7 @@ async fn test_checkpointing_retry_state_persisted() {
     snapshot.update_position(ExecutionPosition::AtTask {
         task_id: sayiir_core::TaskId::from("flaky"),
     });
-    backend.save_snapshot(&snapshot).await.unwrap();
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 
     let cont = stub_node_with_retry("flaky", fast_retry(4), None);
     let attempts = Arc::new(AtomicU32::new(0));
@@ -2125,7 +2125,7 @@ async fn test_checkpointing_retry_with_timeout() {
     snapshot.update_position(ExecutionPosition::AtTask {
         task_id: sayiir_core::TaskId::from("slow_then_fast"),
     });
-    backend.save_snapshot(&snapshot).await.unwrap();
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 
     // Timeout of 10ms; first attempt sleeps 200ms (triggers timeout), second is instant
     let cont = stub_node_with_timeout_and_retry(
@@ -2170,7 +2170,7 @@ async fn test_checkpointing_retry_in_chain() {
     let input = encode_u32(5);
 
     let mut snapshot = WorkflowSnapshot::with_initial_input("inst-1", "hash".into(), input.clone());
-    backend.save_snapshot(&snapshot).await.unwrap();
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 
     let double = stub_node("double", None);
     let flaky = stub_node_with_retry("flaky", fast_retry(2), Some(Box::new(double)));
@@ -2313,7 +2313,7 @@ async fn test_checkpointing_timeout_mid_chain() {
     let input = encode_u32(5);
 
     let mut snapshot = WorkflowSnapshot::with_initial_input("inst-1", "hash".into(), input.clone());
-    backend.save_snapshot(&snapshot).await.unwrap();
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 
     // fast_task → slow_task (times out)
     let slow_task = WorkflowContinuation::Task {
@@ -2389,7 +2389,7 @@ async fn test_checkpointing_delay_terminal_parks() {
 
     let mut snapshot =
         WorkflowSnapshot::with_initial_input("inst-1", "hash-1".into(), input.clone());
-    backend.save_snapshot(&snapshot).await.unwrap();
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 
     let delay = WorkflowContinuation::Delay {
         id: "final_wait".into(),
@@ -2447,7 +2447,7 @@ async fn test_checkpointing_delay_after_task_chain() {
 
     let mut snapshot =
         WorkflowSnapshot::with_initial_input("inst-1", "hash-1".into(), input.clone());
-    backend.save_snapshot(&snapshot).await.unwrap();
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 
     let process = stub_node("process", None);
     let delay = WorkflowContinuation::Delay {
@@ -2903,7 +2903,7 @@ async fn test_checkpointing_loop_basic() {
 
     let mut snapshot =
         WorkflowSnapshot::with_initial_input("inst-1", "hash-1".into(), input.clone());
-    backend.save_snapshot(&snapshot).await.unwrap();
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 
     let body = stub_node("countdown", None);
     let cont = WorkflowContinuation::Loop {
@@ -2952,7 +2952,7 @@ async fn test_checkpointing_loop_resumes_from_iteration() {
 
     // Simulate: 2 iterations already completed. Next input should be 3 (5→4→3).
     snapshot.set_loop_iteration(sayiir_core::TaskId::from("loop_0"), 2);
-    backend.save_snapshot(&snapshot).await.unwrap();
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 
     let call_count = Arc::new(AtomicU32::new(0));
     let cc = call_count.clone();
@@ -3354,7 +3354,7 @@ async fn test_checkpointing_loop_caches_result_on_exit() {
 
     let mut snapshot =
         WorkflowSnapshot::with_initial_input("inst-1", "hash-1".into(), input.clone());
-    backend.save_snapshot(&snapshot).await.unwrap();
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 
     let body = stub_node("countdown", None);
     let cont = WorkflowContinuation::Loop {
@@ -3404,7 +3404,7 @@ async fn test_checkpointing_loop_short_circuits_when_cached() {
     // Pre-cache a result for the loop node.
     let cached_output = encode_u32(42);
     snapshot.mark_task_completed(sayiir_core::TaskId::from("loop_0"), cached_output.clone());
-    backend.save_snapshot(&snapshot).await.unwrap();
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 
     let body = stub_node("body", None);
     let cont = WorkflowContinuation::Loop {
@@ -3448,7 +3448,7 @@ async fn test_checkpointing_loop_exit_with_last() {
 
     let mut snapshot =
         WorkflowSnapshot::with_initial_input("inst-1", "hash-1".into(), input.clone());
-    backend.save_snapshot(&snapshot).await.unwrap();
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 
     let body = stub_node("always_again", None);
     let cont = WorkflowContinuation::Loop {
@@ -3500,7 +3500,7 @@ async fn test_checkpointing_loop_in_chain() {
 
     let mut snapshot =
         WorkflowSnapshot::with_initial_input("inst-1", "hash-1".into(), input.clone());
-    backend.save_snapshot(&snapshot).await.unwrap();
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 
     let double = stub_node("double", None);
     let body = stub_node("countdown", None);
@@ -3559,7 +3559,7 @@ async fn test_checkpointing_loop_inside_fork_branch() {
 
     let mut snapshot =
         WorkflowSnapshot::with_initial_input("inst-1", "hash-1".into(), input.clone());
-    backend.save_snapshot(&snapshot).await.unwrap();
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 
     let body = stub_node("countdown", None);
     let loop_branch = Arc::new(WorkflowContinuation::Loop {
@@ -3630,7 +3630,7 @@ async fn test_checkpointing_loop_iteration_counter_persisted() {
 
     let mut snapshot =
         WorkflowSnapshot::with_initial_input("inst-1", "hash-1".into(), input.clone());
-    backend.save_snapshot(&snapshot).await.unwrap();
+    backend.save_snapshot(&mut snapshot).await.unwrap();
 
     let body = stub_node("countdown", None);
     let cont = WorkflowContinuation::Loop {

--- a/sayiir-runtime/src/runner/distributed.rs
+++ b/sayiir-runtime/src/runner/distributed.rs
@@ -966,7 +966,7 @@ where
                                 sayiir_core::TaskId::from(id),
                                 envelope_bytes.clone(),
                             );
-                            backend.save_snapshot(&snapshot).await?;
+                            backend.save_snapshot(&mut snapshot).await?;
 
                             Ok(ControlFlow::Continue(envelope_bytes))
                         }
@@ -1039,7 +1039,7 @@ where
 
                             snapshot
                                 .mark_task_completed(sayiir_core::TaskId::from(id), output.clone());
-                            backend.save_snapshot(&snapshot).await?;
+                            backend.save_snapshot(&mut snapshot).await?;
 
                             Ok(ControlFlow::Continue(output))
                         }
@@ -1301,7 +1301,7 @@ mod tests {
         snapshot.update_position(ExecutionPosition::AtTask {
             task_id: sayiir_core::TaskId::from("step1"),
         });
-        runner.backend().save_snapshot(&snapshot).await.unwrap();
+        runner.backend().save_snapshot(&mut snapshot).await.unwrap();
 
         // Build a different workflow
         let workflow2 = WorkflowBuilder::new(ctx())
@@ -1344,7 +1344,7 @@ mod tests {
         snapshot.update_position(ExecutionPosition::AtTask {
             task_id: sayiir_core::TaskId::from("slow_task"),
         });
-        runner.backend().save_snapshot(&snapshot).await.unwrap();
+        runner.backend().save_snapshot(&mut snapshot).await.unwrap();
 
         // Request cancellation via WorkflowClient
         let client = crate::WorkflowClient::from_shared(Arc::clone(runner.backend()));
@@ -1388,7 +1388,7 @@ mod tests {
         snapshot.update_position(ExecutionPosition::AtTask {
             task_id: sayiir_core::TaskId::from("task1"),
         });
-        runner.backend().save_snapshot(&snapshot).await.unwrap();
+        runner.backend().save_snapshot(&mut snapshot).await.unwrap();
 
         let client = crate::WorkflowClient::from_shared(Arc::clone(runner.backend()));
         client

--- a/sayiir-runtime/src/worker.rs
+++ b/sayiir-runtime/src/worker.rs
@@ -35,6 +35,22 @@ use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio::time;
 
+/// Fallback poll-tick interval, phase-shifted per worker so a fleet spawned
+/// together doesn't fire the `find_available_tasks` scan in lockstep (a
+/// synchronized DB herd). Offset is `hash(worker_id) % poll_interval`. Keeps
+/// the default `Burst` missed-tick behavior: a worker that falls behind catches
+/// up immediately, which is what drives saturated back-to-back pickup.
+fn staggered_poll_interval(worker_id: &str, poll_interval: Duration) -> time::Interval {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    worker_id.hash(&mut hasher);
+    let period_ns = u64::try_from(poll_interval.as_nanos())
+        .unwrap_or(u64::MAX)
+        .max(1);
+    let offset = Duration::from_nanos(hasher.finish() % period_ns);
+    time::interval_at(time::Instant::now() + offset, poll_interval)
+}
+
 /// A list of workflow definitions keyed by their definition hash.
 pub type WorkflowRegistry<C, Input, M> =
     Vec<(sayiir_core::DefinitionHash, Arc<Workflow<C, Input, M>>)>;
@@ -497,7 +513,7 @@ where
         executor: ExternalTaskExecutor,
         mut cmd_rx: mpsc::Receiver<WorkerCommand>,
     ) -> Result<(), crate::error::RuntimeError> {
-        let mut interval = time::interval(poll_interval);
+        let mut interval = staggered_poll_interval(&self.worker_id, poll_interval);
 
         loop {
             let hint = tokio::select! {
@@ -883,7 +899,7 @@ where
             + sealed::EncodeValue<Input>
             + 'static,
     {
-        let mut interval = time::interval(poll_interval);
+        let mut interval = staggered_poll_interval(&self.worker_id, poll_interval);
 
         loop {
             // In-process mode only filters irrelevant wakes; the direct-

--- a/sayiir-runtime/src/worker.rs
+++ b/sayiir-runtime/src/worker.rs
@@ -2533,8 +2533,8 @@ mod tests {
         let registry = TaskRegistry::new();
 
         // Create a workflow snapshot so store_signal can validate it
-        let snapshot = WorkflowSnapshot::new("wf-1", "hash-1".into());
-        backend.save_snapshot(&snapshot).await.ok();
+        let mut snapshot = WorkflowSnapshot::new("wf-1", "hash-1".into());
+        backend.save_snapshot(&mut snapshot).await.ok();
 
         let worker = PooledWorker::new("test-worker", backend, registry);
         let handle = worker.spawn(Duration::from_millis(50), EmptyWorkflows::new());

--- a/tests/integration/tests/checkpointing_runner.rs
+++ b/tests/integration/tests/checkpointing_runner.rs
@@ -145,7 +145,7 @@ async fn cancel_and_resume() {
     snapshot.update_position(sayiir_core::snapshot::ExecutionPosition::AtTask {
         task_id: sayiir_core::TaskId::from("step1"),
     });
-    runner.backend().save_snapshot(&snapshot).await.unwrap();
+    runner.backend().save_snapshot(&mut snapshot).await.unwrap();
 
     // Signal cancellation via WorkflowClient
     let client = WorkflowClient::from_shared(Arc::clone(runner.backend()));
@@ -193,7 +193,7 @@ async fn pause_unpause_resume() {
     snapshot.update_position(sayiir_core::snapshot::ExecutionPosition::AtTask {
         task_id: sayiir_core::TaskId::from("step1"),
     });
-    runner.backend().save_snapshot(&snapshot).await.unwrap();
+    runner.backend().save_snapshot(&mut snapshot).await.unwrap();
 
     // Request pause via WorkflowClient
     let client = WorkflowClient::from_shared(Arc::clone(runner.backend()));
@@ -549,7 +549,7 @@ async fn definition_hash_mismatch_on_resume() {
     snapshot.update_position(sayiir_core::snapshot::ExecutionPosition::AtTask {
         task_id: sayiir_core::TaskId::from("step1"),
     });
-    runner.backend().save_snapshot(&snapshot).await.unwrap();
+    runner.backend().save_snapshot(&mut snapshot).await.unwrap();
 
     // Build a different workflow (v2 — different hash)
     let workflow_v2 = WorkflowBuilder::new(ctx())
@@ -598,7 +598,7 @@ async fn task_version_change_causes_hash_mismatch() {
     snapshot.update_position(sayiir_core::snapshot::ExecutionPosition::AtTask {
         task_id: sayiir_core::TaskId::from("process"),
     });
-    runner.backend().save_snapshot(&snapshot).await.unwrap();
+    runner.backend().save_snapshot(&mut snapshot).await.unwrap();
 
     // v2: same structure, same task ID, but different version
     let workflow_v2 = WorkflowBuilder::new(ctx())
@@ -670,7 +670,7 @@ async fn task_version_none_vs_some_causes_hash_mismatch() {
     snapshot.update_position(sayiir_core::snapshot::ExecutionPosition::AtTask {
         task_id: sayiir_core::TaskId::from("process"),
     });
-    runner.backend().save_snapshot(&snapshot).await.unwrap();
+    runner.backend().save_snapshot(&mut snapshot).await.unwrap();
 
     // Resume with v2 → mismatch
     let result = runner

--- a/tests/integration/tests/common/mod.rs
+++ b/tests/integration/tests/common/mod.rs
@@ -19,7 +19,7 @@ pub async fn setup() -> (
     String,
 ) {
     let container = Postgres::default()
-        .with_tag("17-alpine")
+        .with_tag("18-alpine")
         .start()
         .await
         .unwrap();


### PR DESCRIPTION
1. Don't re-ship task outputs on position-only saves — output_unflushed marker
2. Clone-free blob encoding — encode_blob strip-in-place
3. save_snapshot(&mut WorkflowSnapshot) trait change