### PR TITLE
⚡️ Throughput and resilience improvements for Postgres backend & distributed workers

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -249,10 +249,20 @@ jobs:
               echo >> "$OUT"
               continue
             fi
+            # sleeping-giants' sustained rate divides completions by
+            # (elapsed − sleep): on a ~9 s run with a ~6 s denominator,
+            # normal ±0.7 s runner jitter moves the metric ~12%, so the
+            # default 10% gate flags pure noise. Widen to 15%; real
+            # capacity loss in this scenario shows up well beyond that.
+            throughput_pct=10
+            if [[ "$scenario" == "sleeping-giants" ]]; then
+              throughput_pct=15
+            fi
             ./benchmarks/target/release/sayiir-bench compare \
               --scenario "$scenario" \
               --baseline "$baseline_file" \
               --candidate "$candidate_file" \
+              --throughput-pct "$throughput_pct" \
               --format markdown \
               --report-only \
               --output /tmp/cmp-"$scenario".md > /dev/null

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -197,6 +197,10 @@ jobs:
           event: push
           path: benchmarks/baseline-main
           if_no_artifact_found: warn
+          # Walk back through main runs until one actually carries the
+          # artifact — doc-only pushes skip the bench job, so the
+          # newest run frequently has no baseline attached.
+          search_artifacts: true
 
       # Render one markdown block per scenario, concatenate, post as
       # a single sticky comment. `--report-only` so a regression

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -219,7 +219,13 @@ jobs:
           set -euo pipefail
           OUT=benchmarks/results/pr-comment.md
           : > "$OUT"
-          BASE_SHA="$(jq -r '.git_sha // "unknown"' benchmarks/baseline-main/linear-*.json 2>/dev/null | head -1)"
+          # `if_no_artifact_found: warn` reports success even when no
+          # baseline artifact exists yet (fresh repo, expired artifact,
+          # or main hasn't run the bench job) — every read of
+          # baseline-main/ below must tolerate the directory being
+          # absent or empty.
+          BASE_SHA="$(jq -r '.git_sha // "unknown"' benchmarks/baseline-main/linear-*.json 2>/dev/null | head -1 || true)"
+          BASE_SHA="${BASE_SHA:-none}"
           {
             echo "## Benchmark vs \`main\`"
             echo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,7 +239,17 @@ jobs:
 
       - name: Dry-run npm publish
         working-directory: sayiir-nodejs
-        run: pnpm publish --dry-run --no-git-checks
+        # Skip when this version is already on npm — `publish --dry-run`
+        # still runs the over-publish check and would fail forever after
+        # a release.
+        run: |
+          name=$(node -p "require('./package.json').name")
+          version=$(node -p "require('./package.json').version")
+          if npm view "${name}@${version}" version >/dev/null 2>&1; then
+            echo "${name}@${version} already published — skipping dry-run"
+          else
+            pnpm publish --dry-run --no-git-checks
+          fi
 
   node-cross-build:
     name: Cross-compile addons
@@ -292,7 +302,15 @@ jobs:
 
       - name: Dry-run npm publish
         working-directory: sayiir-cloudflare-js
-        run: pnpm publish --dry-run --no-git-checks
+        # Skip when this version is already on npm (see node-binding job).
+        run: |
+          name=$(node -p "require('./package.json').name")
+          version=$(node -p "require('./package.json').version")
+          if npm view "${name}@${version}" version >/dev/null 2>&1; then
+            echo "${name}@${version} already published — skipping dry-run"
+          else
+            pnpm publish --dry-run --no-git-checks
+          fi
 
   docs-lint:
     name: Docs Lint

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ chrono = { version = "0.4", default-features = false, features = [
     "clock",
 ] }
 serde = { version = "1", features = ["derive", "rc"] }
-serde_json = "1"
+serde_json = { version = "1", features = ["raw_value"] }
 rkyv = { version = "0.8", features = ["std", "bytecheck", "bytes-1"] }
 bytecheck = "0.8"
 tokio = { version = "1", features = ["rt"] }

--- a/benchmarks/Cargo.lock
+++ b/benchmarks/Cargo.lock
@@ -168,15 +168,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "block-buffer"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
-dependencies = [
- "hybrid-array",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -326,12 +317,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
-name = "const-oid"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -342,15 +327,6 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "cpufeatures"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -423,15 +399,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-common"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
-dependencies = [
- "hybrid-array",
-]
-
-[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -471,7 +438,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid 0.9.6",
+ "const-oid",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -482,21 +449,10 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
- "const-oid 0.9.6",
- "crypto-common 0.1.7",
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
  "subtle",
-]
-
-[[package]]
-name = "digest"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
-dependencies = [
- "block-buffer 0.12.0",
- "const-oid 0.10.2",
- "crypto-common 0.2.1",
 ]
 
 [[package]]
@@ -881,7 +837,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -948,15 +904,6 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
-name = "hybrid-array"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
-dependencies = [
- "typenum",
-]
 
 [[package]]
 name = "hyper"
@@ -1300,7 +1247,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -1497,9 +1444,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "opentelemetry"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1511,22 +1458,22 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
 dependencies = [
  "async-trait",
  "bytes",
  "http",
  "opentelemetry",
- "reqwest",
+ "reqwest 0.13.4",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
  "http",
  "opentelemetry",
@@ -1534,18 +1481,18 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest",
+ "reqwest 0.13.4",
  "thiserror",
  "tokio",
  "tonic",
- "tracing",
+ "tonic-types",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
@@ -1556,15 +1503,16 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.31.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
 dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
  "opentelemetry",
  "percent-encoding",
+ "portable-atomic",
  "rand 0.9.4",
  "thiserror",
  "tokio",
@@ -1728,6 +1676,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -1982,9 +1939,7 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "futures-channel",
  "futures-core",
- "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -2012,6 +1967,37 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -2064,8 +2050,8 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid 0.9.6",
- "digest 0.10.7",
+ "const-oid",
+ "digest",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
@@ -2145,7 +2131,7 @@ dependencies = [
  "hdrhistogram",
  "metrics",
  "metrics-exporter-prometheus",
- "reqwest",
+ "reqwest 0.12.28",
  "sayiir-core",
  "sayiir-persistence",
  "sayiir-postgres",
@@ -2160,15 +2146,16 @@ dependencies = [
 
 [[package]]
 name = "sayiir-core"
-version = "0.5.0"
+version = "1.0.0"
 dependencies = [
  "bytecheck",
  "bytes",
  "chrono",
  "hex",
  "rkyv",
+ "rustc-hash",
  "serde",
- "sha2 0.11.0",
+ "sha2",
  "strum",
  "thiserror",
  "tokio",
@@ -2176,7 +2163,7 @@ dependencies = [
 
 [[package]]
 name = "sayiir-macros"
-version = "0.5.0"
+version = "1.0.0"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2186,7 +2173,7 @@ dependencies = [
 
 [[package]]
 name = "sayiir-persistence"
-version = "0.5.0"
+version = "1.0.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2198,7 +2185,7 @@ dependencies = [
 
 [[package]]
 name = "sayiir-postgres"
-version = "0.5.0"
+version = "1.0.0"
 dependencies = [
  "backon",
  "bytes",
@@ -2206,7 +2193,7 @@ dependencies = [
  "flume 0.12.0",
  "sayiir-core",
  "sayiir-persistence",
- "sha2 0.11.0",
+ "sha2",
  "sqlx",
  "thiserror",
  "tokio",
@@ -2216,7 +2203,7 @@ dependencies = [
 
 [[package]]
 name = "sayiir-runtime"
-version = "0.5.0"
+version = "1.0.0"
 dependencies = [
  "backon",
  "bytecheck",
@@ -2308,8 +2295,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -2319,19 +2306,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "sha2"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.0",
- "digest 0.11.3",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -2365,7 +2341,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest 0.10.7",
+ "digest",
  "rand_core 0.6.4",
 ]
 
@@ -2470,7 +2446,7 @@ dependencies = [
  "percent-encoding",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2",
  "smallvec",
  "thiserror",
  "tokio",
@@ -2507,7 +2483,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2",
  "sqlx-core",
  "sqlx-mysql",
  "sqlx-postgres",
@@ -2530,7 +2506,7 @@ dependencies = [
  "bytes",
  "chrono",
  "crc",
- "digest 0.10.7",
+ "digest",
  "dotenvy",
  "either",
  "futures-channel",
@@ -2551,7 +2527,7 @@ dependencies = [
  "rsa",
  "serde",
  "sha1",
- "sha2 0.10.9",
+ "sha2",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -2589,7 +2565,7 @@ dependencies = [
  "rand 0.8.6",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -2857,6 +2833,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic-types"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab1b02061f83d519bba3caa167f88f261ef05720ab8ebc954ade70de3348e8"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2951,9 +2938,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.32.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
 dependencies = [
  "js-sys",
  "opentelemetry",

--- a/benchmarks/src/compare.rs
+++ b/benchmarks/src/compare.rs
@@ -17,6 +17,7 @@
 
 use std::fmt::Write as _;
 use std::path::PathBuf;
+use std::time::Duration;
 
 use anyhow::{Context, Result};
 use comfy_table::{Cell, CellAlignment, ContentArrangement, Table, presets};
@@ -62,8 +63,8 @@ pub fn run(args: CompareArgs) -> Result<()> {
     let throughput_thresh_pct = args.throughput_pct;
     let latency_thresh_pct = args.latency_pct;
 
-    let b_sustained = baseline.results.throughput_wf_per_sec_sustained;
-    let c_sustained = candidate.results.throughput_wf_per_sec_sustained;
+    let b_sustained = sustained_rate(&baseline);
+    let c_sustained = sustained_rate(&candidate);
     let throughput_delta_pct = pct_change(b_sustained, c_sustained);
     rows.push(ComparisonRow {
         metric: "sustained_wf_per_sec",
@@ -158,6 +159,35 @@ pub fn run(args: CompareArgs) -> Result<()> {
         );
     }
     Ok(())
+}
+
+/// Window width of the workloads' sustained-throughput metric; the
+/// recomputation below must match what `best_window_rate` callers use.
+const SUSTAINED_WINDOW: Duration = Duration::from_mins(1);
+
+/// Sustained throughput under the current full-window definition.
+///
+/// Recomputed from the report's completion samples rather than read from
+/// `results`: the stored value reflects whatever definition the
+/// *producing* harness had, and the `bench-baseline-main` artifact is
+/// built by main's harness — an older main can carry the any-span
+/// burst-peak variant, inflated 50–100% vs the full-window rate, which
+/// manufactures regressions against an honest candidate. Recomputing
+/// both sides keeps the gate apples-to-apples across harness versions.
+///
+/// Falls back to the stored value when samples are missing, and for
+/// sleeping-giants, whose sustained metric (completions per *awake*
+/// second) is intentionally not derivable from the completion samples.
+fn sustained_rate(report: &Report) -> f64 {
+    if report.scenario == "sleeping-giants" || report.samples.len() < 2 {
+        return report.results.throughput_wf_per_sec_sustained;
+    }
+    let points: Vec<(Duration, usize)> = report
+        .samples
+        .iter()
+        .map(|s| (Duration::from_millis(s.t_ms), s.completed))
+        .collect();
+    crate::report::best_window_rate(&points, SUSTAINED_WINDOW)
 }
 
 /// `(candidate - baseline) / baseline * 100`. Zero baselines collapse

--- a/benchmarks/src/report.rs
+++ b/benchmarks/src/report.rs
@@ -115,6 +115,103 @@ pub struct Sample {
     pub completed: usize,
 }
 
+/// Best sustained completion rate: the highest `Δcompleted / Δt` over any
+/// window spanning at least `min(target, run length)`.
+///
+/// Requiring full-width windows is the point of this function. Maximizing
+/// over arbitrary sub-spans lets a handful of completions landing in one
+/// 100 ms sample tick report a "sustained" rate of thousands of wf/s —
+/// observed swinging the metric ±40% between identical CI runs (a 0.9 s
+/// burst at bench start once reported 140 wf/s "sustained" on a run whose
+/// true 60 s ceiling was 83). Runs shorter than `target` yield the
+/// whole-run rate.
+pub fn best_window_rate(samples: &[(Duration, usize)], target: Duration) -> f64 {
+    if samples.len() < 2 {
+        return match samples.first() {
+            Some((dt, n)) if !dt.is_zero() => *n as f64 / dt.as_secs_f64(),
+            _ => 0.0,
+        };
+    }
+    let total = samples.last().unwrap().0.saturating_sub(samples[0].0);
+    let window = if total < target { total } else { target };
+    if window.is_zero() {
+        return 0.0;
+    }
+    let mut best = 0.0f64;
+    let mut left = 0usize;
+    for right in 0..samples.len() {
+        // Narrowest window ending at `right` that still spans >= `window`.
+        while left < right && samples[right].0.saturating_sub(samples[left + 1].0) >= window {
+            left += 1;
+        }
+        let dt = samples[right].0.saturating_sub(samples[left].0);
+        if dt >= window {
+            let dn = (samples[right].1 - samples[left].1) as f64;
+            let rate = dn / dt.as_secs_f64();
+            if rate > best {
+                best = rate;
+            }
+        }
+    }
+    best
+}
+
+#[cfg(test)]
+mod best_window_tests {
+    use super::*;
+
+    fn s(t_ms: u64, n: usize) -> (Duration, usize) {
+        (Duration::from_millis(t_ms), n)
+    }
+
+    #[test]
+    fn early_burst_does_not_inflate_sustained() {
+        // 100 completions in the first second, then a 60 s stall, then
+        // 120 more over 60 s. Any-span maximization would report
+        // ~100 wf/s off the burst; full-window must not.
+        let mut samples = vec![s(0, 0), s(1_000, 100)];
+        for i in 1u64..=60 {
+            samples.push(s(61_000 + i * 1_000, 100 + (i as usize) * 2));
+        }
+        let rate = best_window_rate(&samples, Duration::from_mins(1));
+        assert!(
+            rate < 5.0,
+            "burst leaked into sustained: {rate:.1} wf/s (expected < 5)"
+        );
+    }
+
+    #[test]
+    fn run_shorter_than_target_is_whole_run_rate() {
+        let samples = vec![s(0, 0), s(5_000, 25), s(10_000, 100)];
+        let rate = best_window_rate(&samples, Duration::from_mins(1));
+        assert!((rate - 10.0).abs() < 1e-9, "expected 100/10s, got {rate}");
+    }
+
+    #[test]
+    fn picks_best_full_window_in_long_run() {
+        // 0..60 s at 1 wf/s, 60..120 s at 10 wf/s: best 60 s window is
+        // the second half.
+        let mut samples = vec![s(0, 0)];
+        for i in 1u64..=60 {
+            samples.push(s(i * 1_000, i as usize));
+        }
+        for i in 1u64..=60 {
+            samples.push(s(60_000 + i * 1_000, 60 + (i as usize) * 10));
+        }
+        let rate = best_window_rate(&samples, Duration::from_mins(1));
+        assert!((rate - 10.0).abs() < 0.2, "expected ~10 wf/s, got {rate}");
+    }
+
+    #[test]
+    fn degenerate_inputs() {
+        assert!(best_window_rate(&[], Duration::from_mins(1)).abs() < f64::EPSILON);
+        assert!(
+            (best_window_rate(&[s(2_000, 10)], Duration::from_mins(1)) - 5.0).abs() < 1e-9,
+            "single-sample fallback should be n/t"
+        );
+    }
+}
+
 #[derive(Serialize, Deserialize)]
 pub struct PrometheusSnapshot {
     pub pg_db_size_mb: Option<f64>,

--- a/benchmarks/src/workloads/fanout.rs
+++ b/benchmarks/src/workloads/fanout.rs
@@ -227,7 +227,7 @@ pub async fn run(ctx: crate::CommonContext, args: FanoutArgs) -> Result<()> {
     }
 
     let total_elapsed = bench_start.elapsed();
-    let sustained = best_window(&samples, Duration::from_secs(60));
+    let sustained = crate::report::best_window_rate(&samples, Duration::from_mins(1));
     let wakeup_drops = wakeup_drops_total().saturating_sub(wakeup_drops_baseline);
 
     let steps_per_workflow = 1 + children + 1; // pickup + branches + join
@@ -360,7 +360,7 @@ async fn build_pool(url: &str, concurrency: usize, workers: usize) -> Result<sql
     let target = (concurrency + workers * 4 + 16) as u32;
     PgPoolOptions::new()
         .max_connections(target)
-        .acquire_timeout(Duration::from_secs(60))
+        .acquire_timeout(Duration::from_mins(1))
         .connect(url)
         .await
         .with_context(|| format!("connecting to postgres at {url}"))
@@ -405,7 +405,7 @@ fn spawn_workers(
         let worker_backend = backend.clone();
         let registry = sayiir_core::registry::TaskRegistry::new();
         let worker = PooledWorker::new(format!("fo-worker-{i}"), worker_backend, registry)
-            .with_claim_ttl(Some(Duration::from_secs(120)))
+            .with_claim_ttl(Some(Duration::from_mins(2)))
             .with_batch_size(batch_size)
             .with_max_concurrent_tasks(WORKER_PARALLELISM);
         let entries = vec![(def_hash.clone(), Arc::clone(&workflow))];
@@ -414,35 +414,3 @@ fn spawn_workers(
     handles
 }
 
-fn best_window(samples: &[(Duration, usize)], target: Duration) -> f64 {
-    if samples.len() < 2 {
-        return match samples.first() {
-            Some((dt, n)) if !dt.is_zero() => *n as f64 / dt.as_secs_f64(),
-            _ => 0.0,
-        };
-    }
-    let total = samples.last().unwrap().0.saturating_sub(samples[0].0);
-    let window = if total < target { total } else { target };
-    if window.is_zero() {
-        return 0.0;
-    }
-    let mut best = 0.0f64;
-    let mut left = 0usize;
-    for right in 0..samples.len() {
-        while samples[right].0.saturating_sub(samples[left].0) > window {
-            left += 1;
-        }
-        let dt = samples[right]
-            .0
-            .saturating_sub(samples[left].0)
-            .as_secs_f64();
-        if dt > 0.0 {
-            let dn = (samples[right].1 - samples[left].1) as f64;
-            let rate = dn / dt;
-            if rate > best {
-                best = rate;
-            }
-        }
-    }
-    best
-}

--- a/benchmarks/src/workloads/fanout.rs
+++ b/benchmarks/src/workloads/fanout.rs
@@ -38,6 +38,9 @@ use crate::driver::submit_bounded;
 use crate::metrics::{COMPLETION_TX, PICKUP_TX, record_completion, record_pickup};
 use crate::report::LatencyBlock;
 
+/// In-flight task cap per bench worker.
+const WORKER_PARALLELISM: std::num::NonZeroUsize = std::num::NonZeroUsize::new(2).unwrap();
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 struct State {
     id: u64,
@@ -403,7 +406,8 @@ fn spawn_workers(
         let registry = sayiir_core::registry::TaskRegistry::new();
         let worker = PooledWorker::new(format!("fo-worker-{i}"), worker_backend, registry)
             .with_claim_ttl(Some(Duration::from_secs(120)))
-            .with_batch_size(batch_size);
+            .with_batch_size(batch_size)
+            .with_max_concurrent_tasks(WORKER_PARALLELISM);
         let entries = vec![(def_hash.clone(), Arc::clone(&workflow))];
         handles.push(worker.spawn(poll, entries));
     }

--- a/benchmarks/src/workloads/linear.rs
+++ b/benchmarks/src/workloads/linear.rs
@@ -44,6 +44,9 @@ use crate::driver::submit_bounded;
 use crate::metrics::{COMPLETION_TX, PICKUP_TX, record_completion, record_pickup};
 use crate::report::LatencyBlock;
 
+/// In-flight task cap per bench worker.
+const WORKER_PARALLELISM: std::num::NonZeroUsize = std::num::NonZeroUsize::new(2).unwrap();
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 struct State {
     id: u64,
@@ -520,7 +523,8 @@ fn spawn_workers(
         let registry = sayiir_core::registry::TaskRegistry::new();
         let worker = PooledWorker::new(format!("bench-worker-{i}"), worker_backend, registry)
             .with_claim_ttl(Some(Duration::from_secs(60)))
-            .with_batch_size(batch_size);
+            .with_batch_size(batch_size)
+            .with_max_concurrent_tasks(WORKER_PARALLELISM);
         let entries = vec![(def_hash.clone(), Arc::clone(&workflow))];
         handles.push(worker.spawn(poll, entries));
     }

--- a/benchmarks/src/workloads/linear.rs
+++ b/benchmarks/src/workloads/linear.rs
@@ -256,7 +256,7 @@ pub async fn run(ctx: crate::CommonContext, args: LinearArgs) -> Result<()> {
     }
 
     let total_elapsed = bench_start.elapsed();
-    let sustained = best_window(&samples, Duration::from_secs(60));
+    let sustained = crate::report::best_window_rate(&samples, Duration::from_mins(1));
 
     let wakeup_drops = wakeup_drops_total().saturating_sub(wakeup_drops_baseline);
 
@@ -522,51 +522,13 @@ fn spawn_workers(
         let worker_backend = backend.clone();
         let registry = sayiir_core::registry::TaskRegistry::new();
         let worker = PooledWorker::new(format!("bench-worker-{i}"), worker_backend, registry)
-            .with_claim_ttl(Some(Duration::from_secs(60)))
+            .with_claim_ttl(Some(Duration::from_mins(1)))
             .with_batch_size(batch_size)
             .with_max_concurrent_tasks(WORKER_PARALLELISM);
         let entries = vec![(def_hash.clone(), Arc::clone(&workflow))];
         handles.push(worker.spawn(poll, entries));
     }
     handles
-}
-
-/// Best sliding-window completions/sec from the (time, cumulative) samples.
-///
-/// Prefers a `target` window (e.g. 60s), but if the run is shorter than `target`,
-/// falls back to the full elapsed range so we still produce a meaningful number
-/// on short smoke tests.
-fn best_window(samples: &[(Duration, usize)], target: Duration) -> f64 {
-    if samples.len() < 2 {
-        return match samples.first() {
-            Some((dt, n)) if !dt.is_zero() => *n as f64 / dt.as_secs_f64(),
-            _ => 0.0,
-        };
-    }
-    let total = samples.last().unwrap().0.saturating_sub(samples[0].0);
-    let window = if total < target { total } else { target };
-    if window.is_zero() {
-        return 0.0;
-    }
-    let mut best = 0.0f64;
-    let mut left = 0usize;
-    for right in 0..samples.len() {
-        while samples[right].0.saturating_sub(samples[left].0) > window {
-            left += 1;
-        }
-        let dt = samples[right]
-            .0
-            .saturating_sub(samples[left].0)
-            .as_secs_f64();
-        if dt > 0.0 {
-            let dn = (samples[right].1 - samples[left].1) as f64;
-            let rate = dn / dt;
-            if rate > best {
-                best = rate;
-            }
-        }
-    }
-    best
 }
 
 fn print_summary(

--- a/benchmarks/src/workloads/signal_driven.rs
+++ b/benchmarks/src/workloads/signal_driven.rs
@@ -264,7 +264,7 @@ pub async fn run(ctx: crate::CommonContext, args: SignalDrivenArgs) -> Result<()
     }
 
     let total_elapsed = bench_start.elapsed();
-    let sustained = best_window(&samples, Duration::from_secs(60));
+    let sustained = crate::report::best_window_rate(&samples, Duration::from_mins(1));
     let wakeup_drops = wakeup_drops_total().saturating_sub(wakeup_drops_baseline);
 
     let mut latency = BTreeMap::new();
@@ -342,7 +342,7 @@ async fn build_pool(url: &str, concurrency: usize, workers: usize) -> Result<sql
     let target = (concurrency + workers * 4 + 32) as u32;
     PgPoolOptions::new()
         .max_connections(target)
-        .acquire_timeout(Duration::from_secs(60))
+        .acquire_timeout(Duration::from_mins(1))
         .connect(url)
         .await
         .with_context(|| format!("connecting to postgres at {url}"))
@@ -381,7 +381,7 @@ fn spawn_workers(
         let worker_backend = backend.clone();
         let registry = sayiir_core::registry::TaskRegistry::new();
         let worker = PooledWorker::new(format!("sd-worker-{i}"), worker_backend, registry)
-            .with_claim_ttl(Some(Duration::from_secs(120)))
+            .with_claim_ttl(Some(Duration::from_mins(2)))
             .with_batch_size(batch_size)
             .with_max_concurrent_tasks(WORKER_PARALLELISM);
         let entries = vec![(def_hash.clone(), Arc::clone(&workflow))];
@@ -390,35 +390,3 @@ fn spawn_workers(
     handles
 }
 
-fn best_window(samples: &[(Duration, usize)], target: Duration) -> f64 {
-    if samples.len() < 2 {
-        return match samples.first() {
-            Some((dt, n)) if !dt.is_zero() => *n as f64 / dt.as_secs_f64(),
-            _ => 0.0,
-        };
-    }
-    let total = samples.last().unwrap().0.saturating_sub(samples[0].0);
-    let window = if total < target { total } else { target };
-    if window.is_zero() {
-        return 0.0;
-    }
-    let mut best = 0.0f64;
-    let mut left = 0usize;
-    for right in 0..samples.len() {
-        while samples[right].0.saturating_sub(samples[left].0) > window {
-            left += 1;
-        }
-        let dt = samples[right]
-            .0
-            .saturating_sub(samples[left].0)
-            .as_secs_f64();
-        if dt > 0.0 {
-            let dn = (samples[right].1 - samples[left].1) as f64;
-            let rate = dn / dt;
-            if rate > best {
-                best = rate;
-            }
-        }
-    }
-    best
-}

--- a/benchmarks/src/workloads/signal_driven.rs
+++ b/benchmarks/src/workloads/signal_driven.rs
@@ -42,6 +42,9 @@ use crate::driver::submit_bounded;
 use crate::metrics::{COMPLETION_TX, PICKUP_TX, record_completion, record_pickup};
 use crate::report::LatencyBlock;
 
+/// In-flight task cap per bench worker.
+const WORKER_PARALLELISM: std::num::NonZeroUsize = std::num::NonZeroUsize::new(2).unwrap();
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 struct State {
     id: u64,
@@ -379,7 +382,8 @@ fn spawn_workers(
         let registry = sayiir_core::registry::TaskRegistry::new();
         let worker = PooledWorker::new(format!("sd-worker-{i}"), worker_backend, registry)
             .with_claim_ttl(Some(Duration::from_secs(120)))
-            .with_batch_size(batch_size);
+            .with_batch_size(batch_size)
+            .with_max_concurrent_tasks(WORKER_PARALLELISM);
         let entries = vec![(def_hash.clone(), Arc::clone(&workflow))];
         handles.push(worker.spawn(poll, entries));
     }

--- a/benchmarks/src/workloads/sleeping.rs
+++ b/benchmarks/src/workloads/sleeping.rs
@@ -37,6 +37,9 @@ use crate::driver::submit_bounded;
 use crate::metrics::{COMPLETION_TX, record_completion};
 use crate::report::LatencyBlock;
 
+/// In-flight task cap per bench worker.
+const WORKER_PARALLELISM: std::num::NonZeroUsize = std::num::NonZeroUsize::new(2).unwrap();
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 struct State {
     id: u64,
@@ -301,7 +304,8 @@ fn spawn_workers(
         let registry = sayiir_core::registry::TaskRegistry::new();
         let worker = PooledWorker::new(format!("sg-worker-{i}"), worker_backend, registry)
             .with_claim_ttl(Some(Duration::from_secs(120)))
-            .with_batch_size(batch_size);
+            .with_batch_size(batch_size)
+            .with_max_concurrent_tasks(WORKER_PARALLELISM);
         let entries = vec![(def_hash.clone(), Arc::clone(&workflow))];
         handles.push(worker.spawn(poll, entries));
     }

--- a/benchmarks/src/workloads/sleeping.rs
+++ b/benchmarks/src/workloads/sleeping.rs
@@ -284,7 +284,7 @@ async fn build_pool(url: &str, concurrency: usize, workers: usize) -> Result<sql
     let target = (concurrency + workers * 4 + 16) as u32;
     PgPoolOptions::new()
         .max_connections(target)
-        .acquire_timeout(Duration::from_secs(60))
+        .acquire_timeout(Duration::from_mins(1))
         .connect(url)
         .await
         .with_context(|| format!("connecting to postgres at {url}"))
@@ -303,7 +303,7 @@ fn spawn_workers(
         let worker_backend = backend.clone();
         let registry = sayiir_core::registry::TaskRegistry::new();
         let worker = PooledWorker::new(format!("sg-worker-{i}"), worker_backend, registry)
-            .with_claim_ttl(Some(Duration::from_secs(120)))
+            .with_claim_ttl(Some(Duration::from_mins(2)))
             .with_batch_size(batch_size)
             .with_max_concurrent_tasks(WORKER_PARALLELISM);
         let entries = vec![(def_hash.clone(), Arc::clone(&workflow))];

--- a/sayiir-core/src/task_claim.rs
+++ b/sayiir-core/src/task_claim.rs
@@ -167,8 +167,24 @@ pub struct AvailableTask {
     ///
     /// Wrapped in `Arc` so the dispatch loop can move the owned
     /// snapshot in once, and so workers that lose the claim race drop
-    /// their copy cheaply (refcount decrement). Only the worker that
-    /// actually executes the task pays a deep `clone()` — and only
-    /// when it needs a mutable working copy.
+    /// their copy cheaply (refcount decrement). The winning worker
+    /// extracts a mutable working copy via [`Self::take_snapshot`]
+    /// without a deep clone.
     pub snapshot: Arc<crate::snapshot::WorkflowSnapshot>,
+}
+
+impl AvailableTask {
+    /// Take ownership of the dispatch snapshot, leaving an empty
+    /// placeholder behind. Backends build one `Arc` per dispatch, so the
+    /// refcount is 1 and this is a move-out, not a deep clone (the clone
+    /// fallback only fires if the `Arc` was shared).
+    #[must_use]
+    pub fn take_snapshot(&mut self) -> crate::snapshot::WorkflowSnapshot {
+        let placeholder = Arc::new(crate::snapshot::WorkflowSnapshot::new(
+            "",
+            crate::DefinitionHash::default(),
+        ));
+        let arc = std::mem::replace(&mut self.snapshot, placeholder);
+        Arc::try_unwrap(arc).unwrap_or_else(|shared| (*shared).clone())
+    }
 }

--- a/sayiir-node/src/worker.rs
+++ b/sayiir-node/src/worker.rs
@@ -128,16 +128,18 @@ impl NapiWorker {
             })
             .collect();
 
-        // Build a ThreadsafeFunction from the JS executor.
-        let tsfn: ThreadsafeFunction<String, Promise<String>, _, _, true> = task_executor
+        // Build a ThreadsafeFunction from the JS executor. NOT callee-handled:
+        // the JS dispatcher's signature is `(payload) => Promise<string>`, so it
+        // must receive the payload directly, not Node-style `(err, payload)`.
+        let tsfn: ThreadsafeFunction<String, Promise<String>, _, _, false> = task_executor
             .build_threadsafe_function()
-            .callee_handled::<true>()
+            .callee_handled::<false>()
             .build()?;
 
         let tsfn = Arc::new(tsfn);
 
         let executor: ExternalTaskExecutor = Arc::new(move |task_id: &str, input: Bytes| {
-            let tsfn: Arc<ThreadsafeFunction<String, Promise<String>, _, _, true>> =
+            let tsfn: Arc<ThreadsafeFunction<String, Promise<String>, _, _, false>> =
                 Arc::clone(&tsfn);
             let task_id = task_id.to_string();
             let input_json = String::from_utf8_lossy(&input).into_owned();
@@ -150,7 +152,7 @@ impl NapiWorker {
                 })
                 .to_string();
                 let output_json: String = tsfn
-                    .call_async(Ok(payload))
+                    .call_async(payload)
                     .await
                     .map_err(|e| -> sayiir_core::error::BoxError { e.to_string().into() })?
                     .await

--- a/sayiir-node/src/worker.rs
+++ b/sayiir-node/src/worker.rs
@@ -30,6 +30,7 @@ pub struct NapiWorker {
     postgres: Option<(String, PoolOptions)>,
     poll_interval: Duration,
     claim_ttl: Duration,
+    max_concurrent_tasks: Option<u32>,
     tags: Vec<String>,
 }
 
@@ -43,6 +44,7 @@ impl NapiWorker {
         poll_interval_ms: Option<f64>,
         claim_ttl_ms: Option<f64>,
         tags: Option<Vec<String>>,
+        max_concurrent_tasks: Option<u32>,
     ) -> Self {
         Self {
             worker_id,
@@ -60,6 +62,7 @@ impl NapiWorker {
                     claim_ttl_ms.unwrap_or(300_000.0) as u64
                 },
             ),
+            max_concurrent_tasks,
             tags: tags.unwrap_or_default(),
         }
     }
@@ -72,6 +75,7 @@ impl NapiWorker {
         poll_interval_ms: Option<f64>,
         claim_ttl_ms: Option<f64>,
         tags: Option<Vec<String>>,
+        max_concurrent_tasks: Option<u32>,
     ) -> Self {
         Self {
             worker_id,
@@ -89,6 +93,7 @@ impl NapiWorker {
                     claim_ttl_ms.unwrap_or(300_000.0) as u64
                 },
             ),
+            max_concurrent_tasks,
             tags: tags.unwrap_or_default(),
         }
     }
@@ -162,6 +167,7 @@ impl NapiWorker {
         };
         let worker_id = self.worker_id.clone();
         let claim_ttl = self.claim_ttl;
+        let max_concurrent_tasks = self.max_concurrent_tasks;
         let poll_interval = self.poll_interval;
         let tags = self.tags.clone();
 
@@ -203,9 +209,15 @@ impl NapiWorker {
                     }
                 };
 
-                let worker = PooledWorker::new(&worker_id, backend_kind, TaskRegistry::default())
-                    .with_claim_ttl(Some(claim_ttl))
-                    .with_tags(tags);
+                let mut worker =
+                    PooledWorker::new(&worker_id, backend_kind, TaskRegistry::default())
+                        .with_claim_ttl(Some(claim_ttl))
+                        .with_tags(tags);
+                if let Some(max) =
+                    max_concurrent_tasks.and_then(|m| std::num::NonZeroUsize::new(m as usize))
+                {
+                    worker = worker.with_max_concurrent_tasks(max);
+                }
 
                 let _guard = runtime.enter();
                 let handle =

--- a/sayiir-nodejs/src/native.ts
+++ b/sayiir-nodejs/src/native.ts
@@ -221,6 +221,7 @@ export interface NativeAddon {
       pollIntervalMs?: number,
       claimTtlMs?: number,
       tags?: string[],
+      maxConcurrentTasks?: number,
     ): NapiWorker;
     withPostgres(
       workerId: string,
@@ -228,6 +229,7 @@ export interface NativeAddon {
       pollIntervalMs?: number,
       claimTtlMs?: number,
       tags?: string[],
+      maxConcurrentTasks?: number,
     ): NapiWorker;
   };
   NapiWorkflowClient: {

--- a/sayiir-nodejs/src/worker.ts
+++ b/sayiir-nodejs/src/worker.ts
@@ -35,6 +35,12 @@ export interface WorkerOptions {
   claimTtl?: Duration;
   /** Affinity tags for this worker. When set, the worker only picks up tasks whose tags are a subset of these tags. */
   tags?: string[];
+  /**
+   * How many tasks this worker executes concurrently (default: 1). Each
+   * in-flight task has its own claim and heartbeat; I/O-bound throughput
+   * scales with this knob.
+   */
+  maxConcurrentTasks?: number;
 }
 
 /** Handle for controlling a running worker. */
@@ -130,6 +136,7 @@ export class Worker {
         pollMs,
         claimMs,
         tags,
+        this.options.maxConcurrentTasks,
       );
     }
 
@@ -140,6 +147,7 @@ export class Worker {
         pollMs,
         claimMs,
         tags,
+        this.options.maxConcurrentTasks,
       );
     }
 

--- a/sayiir-persistence/src/backend.rs
+++ b/sayiir-persistence/src/backend.rs
@@ -166,6 +166,11 @@ pub enum BackendError {
     /// Cannot pause workflow in current state.
     #[error("Cannot pause workflow in state: {0}")]
     CannotPause(String),
+    /// A claim operation found the claim owned by another worker — the
+    /// caller's lease is structurally lost (stolen after expiry), not a
+    /// transient failure.
+    #[error("Claim lost: {0}")]
+    ClaimLost(String),
 }
 
 // ---------------------------------------------------------------------------
@@ -219,6 +224,16 @@ pub trait SnapshotStore: Send + Sync {
 // ---------------------------------------------------------------------------
 // SignalStore — cancel + pause via SignalKind
 // ---------------------------------------------------------------------------
+
+/// Outcome of a combined cancel-then-pause check (see
+/// [`SignalStore::check_control_signals`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ControlSignal {
+    /// A pending cancel was found and applied.
+    Cancelled,
+    /// A pending pause was found and applied.
+    Paused,
+}
 
 /// Signal storage for cancel and pause workflows.
 ///
@@ -320,6 +335,29 @@ pub trait SignalStore: SnapshotStore {
         }
     }
 
+    /// Check for a pending cancel, then a pending pause, applying the first
+    /// one found. Backends can override this to collapse the two checks into
+    /// fewer round-trips — the common case on the worker hot path is "no
+    /// signal at all", which an override can answer with a single probe.
+    fn check_control_signals(
+        &self,
+        instance_id: &str,
+        interrupted_at_task: Option<sayiir_core::TaskId>,
+    ) -> impl Future<Output = Result<Option<ControlSignal>, BackendError>> + Send {
+        async move {
+            if self
+                .check_and_cancel(instance_id, interrupted_at_task)
+                .await?
+            {
+                return Ok(Some(ControlSignal::Cancelled));
+            }
+            if self.check_and_pause(instance_id).await? {
+                return Ok(Some(ControlSignal::Paused));
+            }
+            Ok(None)
+        }
+    }
+
     /// Transition a paused workflow back to in-progress and return the updated snapshot.
     fn unpause(
         &self,
@@ -354,7 +392,12 @@ pub trait SignalStore: SnapshotStore {
 ///
 /// Only needed when using [`PooledWorker`](crate). Single-process backends
 /// (used with `CheckpointingRunner`) do not need to implement this.
-pub trait TaskClaimStore: Send + Sync {
+///
+/// `SnapshotStore` is a supertrait: claim stores hand out decoded
+/// snapshots (`find_available_tasks`) and gate snapshot writes on claim
+/// ownership (`save_snapshot_fenced`), so a claim store that can't store
+/// snapshots is incoherent.
+pub trait TaskClaimStore: SnapshotStore {
     /// Claim a task for execution by a worker node.
     ///
     /// Returns `Ok(Some(claim))` if successful, `Ok(None)` if already claimed.
@@ -431,6 +474,26 @@ pub trait TaskClaimStore: Send + Sync {
         _hint: &TaskWakeupHint,
     ) -> impl Future<Output = Result<Option<AvailableTask>, BackendError>> + Send {
         async move { Ok(None) }
+    }
+
+    /// Save `snapshot` only while `worker_id` still holds a live claim on
+    /// `(instance_id, task_id)`. Returns `Ok(false)` without writing when
+    /// the claim is gone — a worker whose lease expired mid-execution must
+    /// not overwrite the new claimant's progress.
+    ///
+    /// The default is an unfenced save (today's behaviour) for backends
+    /// without claim-aware transactions.
+    fn save_snapshot_fenced(
+        &self,
+        snapshot: &mut WorkflowSnapshot,
+        task_id: &sayiir_core::TaskId,
+        worker_id: &str,
+    ) -> impl Future<Output = Result<bool, BackendError>> + Send {
+        let _ = (task_id, worker_id);
+        async move {
+            self.save_snapshot(snapshot).await?;
+            Ok(true)
+        }
     }
 }
 

--- a/sayiir-persistence/src/backend.rs
+++ b/sayiir-persistence/src/backend.rs
@@ -417,13 +417,21 @@ pub trait TaskClaimStore: SnapshotStore {
         worker_id: &str,
     ) -> impl Future<Output = Result<(), BackendError>> + Send;
 
-    /// Extend a task claim's expiration time.
+    /// Renew a task claim's lease.
+    ///
+    /// Sets the claim's expiration to `now + ttl` (absolute renewal), so a
+    /// claim expires one TTL after the holder's last successful heartbeat
+    /// regardless of how many heartbeats preceded it. Implementations must
+    /// NOT add `ttl` to the current expiration: under periodic heartbeats
+    /// that drifts the lease arbitrarily far ahead of the wall clock, and a
+    /// crashed holder's orphaned claim would block reclaim for much longer
+    /// than one TTL. Extending a no-TTL (eternal) claim is a silent no-op.
     fn extend_task_claim(
         &self,
         instance_id: &str,
         task_id: &sayiir_core::TaskId,
         worker_id: &str,
-        additional_duration: Duration,
+        ttl: Duration,
     ) -> impl Future<Output = Result<(), BackendError>> + Send;
 
     /// Find available tasks across all workflow instances.

--- a/sayiir-persistence/src/in_memory.rs
+++ b/sayiir-persistence/src/in_memory.rs
@@ -423,8 +423,8 @@ impl TaskClaimStore for InMemoryBackend {
 
         if let Some(claim) = claims.get(&key) {
             if claim.worker_id != worker_id {
-                return Err(BackendError::Backend(format!(
-                    "Claim owned by different worker: {}",
+                return Err(BackendError::ClaimLost(format!(
+                    "claim owned by {}",
                     claim.worker_id
                 )));
             }
@@ -450,8 +450,8 @@ impl TaskClaimStore for InMemoryBackend {
 
         if let Some(claim) = claims.get_mut(&key) {
             if claim.worker_id != worker_id {
-                return Err(BackendError::Backend(format!(
-                    "Claim owned by different worker: {}",
+                return Err(BackendError::ClaimLost(format!(
+                    "claim owned by {}",
                     claim.worker_id
                 )));
             }
@@ -969,7 +969,7 @@ mod tests {
                 "worker-2",
             )
             .await;
-        assert!(matches!(result, Err(BackendError::Backend(_))));
+        assert!(matches!(result, Err(BackendError::ClaimLost(_))));
     }
 
     #[tokio::test]
@@ -1045,7 +1045,7 @@ mod tests {
                 Duration::seconds(300),
             )
             .await;
-        assert!(matches!(result, Err(BackendError::Backend(_))));
+        assert!(matches!(result, Err(BackendError::ClaimLost(_))));
     }
 
     #[tokio::test]

--- a/sayiir-persistence/src/in_memory.rs
+++ b/sayiir-persistence/src/in_memory.rs
@@ -443,7 +443,7 @@ impl TaskClaimStore for InMemoryBackend {
         instance_id: &str,
         task_id: &sayiir_core::TaskId,
         worker_id: &str,
-        additional_duration: Duration,
+        ttl: Duration,
     ) -> Result<(), BackendError> {
         let key = Self::claim_key(instance_id, task_id);
         let mut claims = self.claims.write().map_err(Self::lock_error)?;
@@ -456,11 +456,12 @@ impl TaskClaimStore for InMemoryBackend {
                 )));
             }
 
-            if let Some(expires_at) = claim.expires_at {
-                let expires_datetime = chrono::DateTime::from_timestamp(expires_at as i64, 0)
-                    .ok_or_else(|| BackendError::Backend("Invalid timestamp".to_string()))?;
-                let new_expiry = expires_datetime
-                    .checked_add_signed(additional_duration)
+            if claim.expires_at.is_some() {
+                // Absolute renewal (now + ttl), matching the Postgres
+                // backend: additive extension would drift the lease ahead
+                // of the wall clock on every heartbeat tick.
+                let new_expiry = chrono::Utc::now()
+                    .checked_add_signed(ttl)
                     .ok_or_else(|| BackendError::Backend("Time overflow".to_string()))?;
                 claim.expires_at = Some(new_expiry.timestamp() as u64);
             }
@@ -1014,11 +1015,18 @@ mod tests {
             .await
             .unwrap();
 
-        // Verify extension by checking internal state
+        // Verify extension by checking internal state. Renewal is
+        // absolute (now + 300s): the new expiry must land beyond the
+        // original now+10s, but strictly before original+300s — an
+        // additive implementation would yield exactly original+300.
         let claims = backend.claims.read().unwrap();
         let key = InMemoryBackend::claim_key("workflow-1", &sayiir_core::TaskId::from("task-1"));
-        let extended_claim = claims.get(&key).unwrap();
-        assert!(extended_claim.expires_at.unwrap() > original_expiry);
+        let extended = claims.get(&key).unwrap().expires_at.unwrap();
+        assert!(extended > original_expiry);
+        assert!(
+            extended < original_expiry + 300,
+            "extend should renew to now+ttl (absolute), not expires_at+ttl (additive)"
+        );
     }
 
     #[tokio::test]

--- a/sayiir-persistence/src/lib.rs
+++ b/sayiir-persistence/src/lib.rs
@@ -45,8 +45,8 @@ mod lifecycle;
 pub mod validation;
 
 pub use backend::{
-    BackendError, PersistentBackend, SignalStore, SnapshotStore, TaskClaimStore, TaskResultStore,
-    TaskWakeupHint,
+    BackendError, ControlSignal, PersistentBackend, SignalStore, SnapshotStore, TaskClaimStore,
+    TaskResultStore, TaskWakeupHint,
 };
 pub use in_memory::InMemoryBackend;
 pub use lifecycle::{PrepareRunOutcome, RunConflict, prepare_run};

--- a/sayiir-postgres/migrations/010_dispatch_indexes.sql
+++ b/sayiir-postgres/migrations/010_dispatch_indexes.sql
@@ -1,0 +1,9 @@
+-- Dispatch indexes.
+--
+-- find_available_tasks now fetches two LIMIT-bounded, index-ordered arms
+-- (best-priority and oldest-first) instead of sorting every InProgress row
+-- by the non-SARGable aging expression. Arm 1 is served by
+-- idx_snapshots_inprogress (008); arm 2 needs an updated_at order.
+CREATE INDEX IF NOT EXISTS idx_snapshots_inprogress_updated
+    ON sayiir_workflow_snapshots (updated_at)
+    WHERE status = 'InProgress';

--- a/sayiir-postgres/src/backend.rs
+++ b/sayiir-postgres/src/backend.rs
@@ -18,9 +18,11 @@ const MIN_PG_MAJOR_VERSION: u32 = 13;
 
 /// Connection-pool configuration for the Postgres backend.
 ///
-/// All fields are optional; unset fields fall back to sqlx defaults
-/// (e.g. `max_connections = 10`, no idle/lifetime caps, no session-level
-/// timeouts).
+/// All fields are optional; unset fields fall back to the defaults noted
+/// per field. `max_connections` defaults to 20 and `min_connections` to 2
+/// (warm connections avoid cold-start latency after idle periods); size
+/// `max_connections` to at least `workers × concurrent tasks + a few` for
+/// the signal/claim transactions.
 ///
 /// `statement_timeout` and `idle_in_transaction_session_timeout` are applied
 /// at the *session* level via `SET` on every newly-acquired connection, so
@@ -31,9 +33,9 @@ const MIN_PG_MAJOR_VERSION: u32 = 13;
 /// to [`PostgresBackend::connect_with_options`].
 #[derive(Debug, Clone, Default)]
 pub struct PoolOptions {
-    /// Maximum number of connections held by the pool. sqlx default: 10.
+    /// Maximum number of connections held by the pool. Default: 20.
     pub max_connections: Option<u32>,
-    /// Minimum number of connections kept warm. sqlx default: 0.
+    /// Minimum number of connections kept warm. Default: 2.
     pub min_connections: Option<u32>,
     /// Time to wait for a connection from the pool before erroring out.
     pub acquire_timeout: Option<Duration>,
@@ -115,13 +117,9 @@ where
         url: &str,
         options: PoolOptions,
     ) -> Result<Self, BackendError> {
-        let mut builder = PgPoolOptions::new();
-        if let Some(n) = options.max_connections {
-            builder = builder.max_connections(n);
-        }
-        if let Some(n) = options.min_connections {
-            builder = builder.min_connections(n);
-        }
+        let mut builder = PgPoolOptions::new()
+            .max_connections(options.max_connections.unwrap_or(20))
+            .min_connections(options.min_connections.unwrap_or(2));
         if let Some(d) = options.acquire_timeout {
             builder = builder.acquire_timeout(d);
         }
@@ -167,7 +165,9 @@ where
         }
 
         let pool = builder.connect(url).await.map_err(PgError)?;
-        Self::init(pool).await
+        // The listener gets its own connection (from the url) so it doesn't
+        // permanently occupy a pool slot.
+        Self::init(pool, Some(url.to_string())).await
     }
 
     /// Use an existing connection pool and run migrations.
@@ -176,14 +176,18 @@ where
     /// standard pool knobs — this method is meant for callers who need full
     /// control over the sqlx `PgPool` (custom TLS, listeners, etc.).
     ///
+    /// Note: with no URL available, the LISTEN/NOTIFY listener holds one
+    /// pooled connection for the backend's lifetime — size the pool
+    /// accordingly.
+    ///
     /// # Errors
     ///
     /// Returns an error if the migration fails.
     pub async fn connect_with(pool: PgPool) -> Result<Self, BackendError> {
-        Self::init(pool).await
+        Self::init(pool, None).await
     }
 
-    async fn init(pool: PgPool) -> Result<Self, BackendError> {
+    async fn init(pool: PgPool, url: Option<String>) -> Result<Self, BackendError> {
         check_pg_version(&pool).await?;
 
         tracing::info!("running postgres migrations");
@@ -192,7 +196,7 @@ where
             .await
             .map_err(|e| BackendError::Backend(format!("migration failed: {e}")))?;
 
-        let wakeup = WakeupListener::spawn(pool.clone());
+        let wakeup = WakeupListener::spawn(pool.clone(), url);
 
         tracing::info!("postgres backend ready");
         Ok(Self {

--- a/sayiir-postgres/src/error.rs
+++ b/sayiir-postgres/src/error.rs
@@ -1,4 +1,4 @@
-//! Error mapping from sqlx to `BackendError`.
+//! Error mapping from sqlx to `BackendError`, plus transient-error retry.
 
 use sayiir_persistence::BackendError;
 
@@ -19,4 +19,74 @@ impl From<PgError> for BackendError {
             other => BackendError::Backend(other.to_string()),
         }
     }
+}
+
+impl PgError {
+    /// True for errors that a fresh transaction is likely to clear:
+    /// serialization failures (40001), deadlocks (40P01), connection-class
+    /// SQLSTATEs (08xxx), I/O drops, and pool-acquire timeouts.
+    pub(crate) fn is_transient(&self) -> bool {
+        match &self.0 {
+            sqlx::Error::Io(_) | sqlx::Error::PoolTimedOut => true,
+            sqlx::Error::Database(db) => db
+                .code()
+                .is_some_and(|c| c == "40001" || c == "40P01" || c.starts_with("08")),
+            _ => false,
+        }
+    }
+}
+
+/// Error type for retryable transaction bodies: keeps the sqlx error
+/// classifiable until the retry decision is made, then collapses into
+/// [`BackendError`].
+pub(crate) enum TxError {
+    Pg(PgError),
+    Other(BackendError),
+}
+
+impl From<PgError> for TxError {
+    fn from(e: PgError) -> Self {
+        Self::Pg(e)
+    }
+}
+
+impl From<BackendError> for TxError {
+    fn from(e: BackendError) -> Self {
+        Self::Other(e)
+    }
+}
+
+impl From<TxError> for BackendError {
+    fn from(e: TxError) -> Self {
+        match e {
+            TxError::Pg(p) => p.into(),
+            TxError::Other(b) => b,
+        }
+    }
+}
+
+/// Run `op` (a whole transaction) with up to two exponential-backoff
+/// retries on transient Postgres errors. Transactions roll back on
+/// failure, so re-running is safe.
+pub(crate) async fn with_transient_retry<T, F, Fut>(op_name: &str, op: F) -> Result<T, BackendError>
+where
+    F: Fn() -> Fut,
+    Fut: Future<Output = Result<T, TxError>>,
+{
+    use backon::{BackoffBuilder, Retryable};
+    op.retry(
+        backon::ExponentialBuilder::default()
+            .with_min_delay(std::time::Duration::from_millis(10))
+            .with_factor(4.0)
+            .with_max_times(2)
+            .build(),
+    )
+    .when(|e| matches!(e, TxError::Pg(p) if p.is_transient()))
+    .notify(|e, delay| {
+        if let TxError::Pg(p) = e {
+            tracing::warn!(op = op_name, ?delay, error = %p.0, "transient pg error, retrying");
+        }
+    })
+    .await
+    .map_err(Into::into)
 }

--- a/sayiir-postgres/src/history.rs
+++ b/sayiir-postgres/src/history.rs
@@ -80,6 +80,33 @@ where
     Ok(outputs)
 }
 
+/// Single-task variant of [`fetch_task_outputs`]: one PK lookup, no blob
+/// decode. Keeps the "completed with durable output" predicate in this
+/// module alongside the other two fetchers.
+pub(crate) async fn fetch_task_output<'e, E>(
+    executor: E,
+    instance_id: &str,
+    task_id: &sayiir_core::TaskId,
+) -> Result<Option<Bytes>, BackendError>
+where
+    E: sqlx::PgExecutor<'e>,
+{
+    let row = sqlx::query(
+        "SELECT output FROM sayiir_workflow_tasks
+         WHERE instance_id = $1 AND task_id = $2
+           AND status = 'completed' AND output IS NOT NULL",
+    )
+    .bind(instance_id)
+    .bind(task_id.as_bytes().as_slice())
+    .fetch_optional(executor)
+    .await
+    .map_err(PgError)?;
+    Ok(row.map(|r| {
+        let raw: Vec<u8> = r.get("output");
+        Bytes::from(raw)
+    }))
+}
+
 /// Batched variant of [`fetch_task_outputs`] for dispatch SELECTs that
 /// load multiple snapshots at once. Returns rows grouped by
 /// `instance_id` so each snapshot can be hydrated independently.

--- a/sayiir-postgres/src/lib.rs
+++ b/sayiir-postgres/src/lib.rs
@@ -77,8 +77,8 @@ pub use wakeup::wakeup_drops_total;
 
 /// Per-instance child tables — i.e. everything that holds rows keyed by
 /// `instance_id` other than `sayiir_workflow_snapshots` itself. Source
-/// of truth for both `delete_snapshot`'s cleanup loop and the
-/// benchmark's `reset_sayiir_tables` truncate.
+/// of truth for `delete_snapshot` and the benchmark's
+/// `reset_sayiir_tables` truncate.
 pub const WORKFLOW_CHILD_TABLES: &[&str] = &[
     "sayiir_workflow_snapshot_history",
     "sayiir_workflow_tasks",
@@ -86,3 +86,17 @@ pub const WORKFLOW_CHILD_TABLES: &[&str] = &[
     "sayiir_workflow_signals",
     "sayiir_workflow_claims",
 ];
+
+/// Build the `d{i} AS (DELETE FROM {table} WHERE {predicate}),` CTE chain
+/// covering every [`WORKFLOW_CHILD_TABLES`] entry (trailing comma included).
+/// Table names come from the const, never from input.
+pub(crate) fn child_delete_ctes(predicate: &str) -> String {
+    use std::fmt::Write;
+    WORKFLOW_CHILD_TABLES
+        .iter()
+        .enumerate()
+        .fold(String::new(), |mut acc, (i, table)| {
+            let _ = write!(acc, "d{i} AS (DELETE FROM {table} WHERE {predicate}),");
+            acc
+        })
+}

--- a/sayiir-postgres/src/signal_store.rs
+++ b/sayiir-postgres/src/signal_store.rs
@@ -6,7 +6,7 @@
 use sayiir_core::codec;
 use sayiir_core::snapshot::{PauseRequest, SignalKind, SignalRequest, WorkflowSnapshot};
 use sayiir_persistence::validation::validate_signal_allowed;
-use sayiir_persistence::{BackendError, SignalStore};
+use sayiir_persistence::{BackendError, ControlSignal, SignalStore};
 use sqlx::Row;
 
 use crate::backend::PostgresBackend;
@@ -594,6 +594,42 @@ where
         tx.commit().await.map_err(PgError)?;
         tracing::info!(instance_id, "workflow paused");
         Ok(true)
+    }
+
+    #[tracing::instrument(
+        name = "db.check_control_signals",
+        skip(self),
+        fields(db.system = "postgresql"),
+        err(level = tracing::Level::ERROR),
+    )]
+    async fn check_control_signals(
+        &self,
+        instance_id: &str,
+        interrupted_at_task: Option<sayiir_core::TaskId>,
+    ) -> Result<Option<ControlSignal>, BackendError> {
+        // Dispatch eligibility already excludes instances with any signal
+        // row, so the overwhelmingly common case here is "no signal": one
+        // PK probe, no transaction, instead of two FOR UPDATE transactions.
+        let row =
+            sqlx::query("SELECT 1 FROM sayiir_workflow_signals WHERE instance_id = $1 LIMIT 1")
+                .bind(instance_id)
+                .fetch_optional(&self.pool)
+                .await
+                .map_err(PgError)?;
+        if row.is_none() {
+            return Ok(None);
+        }
+
+        if self
+            .check_and_cancel(instance_id, interrupted_at_task)
+            .await?
+        {
+            return Ok(Some(ControlSignal::Cancelled));
+        }
+        if self.check_and_pause(instance_id).await? {
+            return Ok(Some(ControlSignal::Paused));
+        }
+        Ok(None)
     }
 
     #[tracing::instrument(

--- a/sayiir-postgres/src/snapshot_store.rs
+++ b/sayiir-postgres/src/snapshot_store.rs
@@ -6,25 +6,25 @@ use sayiir_persistence::{BackendError, SnapshotStore};
 use sqlx::Row;
 
 use crate::backend::PostgresBackend;
-use crate::error::PgError;
+use crate::error::{PgError, with_transient_retry};
 use crate::wakeup::{TASK_READY_CHANNEL, build_task_ready_payload};
 
-impl<C> SnapshotStore for PostgresBackend<C>
+impl<C> PostgresBackend<C>
 where
     C: codec::SnapshotCodec,
 {
-    #[tracing::instrument(
-        name = "db.save_snapshot",
-        skip(self, snapshot),
-        fields(
-            db.system = "postgresql",
-            instance_id = %snapshot.instance_id,
-            status = %snapshot.state.as_ref(),
-        ),
-        err(level = tracing::Level::ERROR),
-    )]
+    /// The full save-snapshot CTE, generic over the executor so it can run
+    /// either directly on the pool or inside a fencing transaction (see
+    /// `save_snapshot_fenced`).
     #[allow(clippy::too_many_lines)]
-    async fn save_snapshot(&self, snapshot: &mut WorkflowSnapshot) -> Result<(), BackendError> {
+    pub(crate) async fn exec_save_snapshot<'e, E>(
+        &self,
+        executor: E,
+        snapshot: &mut WorkflowSnapshot,
+    ) -> Result<(), BackendError>
+    where
+        E: sqlx::PgExecutor<'e>,
+    {
         tracing::debug!("saving snapshot");
         let (data, data_hash) = self.encode_blob_preserving(snapshot)?;
         let status = snapshot.state.as_ref();
@@ -186,7 +186,7 @@ where
             .bind(notify_payload.as_deref()) // $17
             .bind(last_completed_slice) // $18
             .bind(last_completed_output_slice) // $19
-            .execute(&self.pool)
+            .execute(executor)
             .await
             .map_err(PgError)?;
         // The last completed output (if any) is now durable in
@@ -196,19 +196,14 @@ where
         Ok(())
     }
 
-    #[tracing::instrument(
-        name = "db.save_task_result",
-        skip(self, output),
-        fields(db.system = "postgresql"),
-        err(level = tracing::Level::ERROR),
-    )]
-    async fn save_task_result(
+    /// One attempt of `save_task_result`; retried on transient errors by
+    /// the trait method.
+    async fn save_task_result_once(
         &self,
         instance_id: &str,
         task_id: &sayiir_core::TaskId,
         output: bytes::Bytes,
-    ) -> Result<(), BackendError> {
-        tracing::debug!("saving task result");
+    ) -> Result<(), crate::error::TxError> {
         let mut tx = self.pool.begin().await.map_err(PgError)?;
 
         // FOR UPDATE on s serialises read-modify-write across this path
@@ -293,6 +288,46 @@ where
         tx.commit().await.map_err(PgError)?;
         Ok(())
     }
+}
+
+impl<C> SnapshotStore for PostgresBackend<C>
+where
+    C: codec::SnapshotCodec,
+{
+    #[tracing::instrument(
+        name = "db.save_snapshot",
+        skip(self, snapshot),
+        fields(
+            db.system = "postgresql",
+            instance_id = %snapshot.instance_id,
+            status = %snapshot.state.as_ref(),
+        ),
+        err(level = tracing::Level::ERROR),
+    )]
+    async fn save_snapshot(&self, snapshot: &mut WorkflowSnapshot) -> Result<(), BackendError> {
+        self.exec_save_snapshot(&self.pool, snapshot).await
+    }
+
+    #[tracing::instrument(
+        name = "db.save_task_result",
+        skip(self, output),
+        fields(db.system = "postgresql"),
+        err(level = tracing::Level::ERROR),
+    )]
+    async fn save_task_result(
+        &self,
+        instance_id: &str,
+        task_id: &sayiir_core::TaskId,
+        output: bytes::Bytes,
+    ) -> Result<(), BackendError> {
+        tracing::debug!("saving task result");
+        // The transaction rolls back on failure, so re-running on a
+        // serialization failure / deadlock / connection drop is safe.
+        with_transient_retry("save_task_result", || {
+            self.save_task_result_once(instance_id, task_id, output.clone())
+        })
+        .await
+    }
 
     #[tracing::instrument(
         name = "db.load_snapshot",
@@ -333,25 +368,21 @@ where
     async fn delete_snapshot(&self, instance_id: &str) -> Result<(), BackendError> {
         tracing::debug!("deleting snapshot");
 
-        let mut tx = self.pool.begin().await.map_err(PgError)?;
-
-        for table in crate::WORKFLOW_CHILD_TABLES {
-            sqlx::query(&format!("DELETE FROM {table} WHERE instance_id = $1"))
-                .bind(instance_id)
-                .execute(&mut *tx)
-                .await
-                .map_err(PgError)?;
-        }
-
-        let result = sqlx::query("DELETE FROM sayiir_workflow_snapshots WHERE instance_id = $1")
+        // One round-trip: child-table DELETEs and the snapshot DELETE are
+        // sibling DML CTEs (always executed), atomic without an explicit tx.
+        let child_ctes = crate::child_delete_ctes("instance_id = $1");
+        let query = format!(
+            "WITH {child_ctes}
+             del AS (DELETE FROM sayiir_workflow_snapshots WHERE instance_id = $1 RETURNING 1)
+             SELECT EXISTS (SELECT 1 FROM del) AS deleted"
+        );
+        let row = sqlx::query(&query)
             .bind(instance_id)
-            .execute(&mut *tx)
+            .fetch_one(&self.pool)
             .await
             .map_err(PgError)?;
 
-        tx.commit().await.map_err(PgError)?;
-
-        if result.rows_affected() == 0 {
+        if !row.get::<bool, _>("deleted") {
             return Err(BackendError::NotFound(instance_id.to_string()));
         }
         Ok(())
@@ -365,11 +396,40 @@ where
     )]
     async fn list_snapshots(&self) -> Result<Vec<String>, BackendError> {
         tracing::debug!("listing snapshots");
-        let rows = sqlx::query("SELECT instance_id FROM sayiir_workflow_snapshots")
-            .fetch_all(&self.pool)
-            .await
-            .map_err(PgError)?;
+        let rows =
+            sqlx::query("SELECT instance_id FROM sayiir_workflow_snapshots ORDER BY instance_id")
+                .fetch_all(&self.pool)
+                .await
+                .map_err(PgError)?;
 
+        Ok(rows.iter().map(|r| r.get("instance_id")).collect())
+    }
+}
+
+impl<C> PostgresBackend<C> {
+    /// Keyset-paginated variant of `list_snapshots` for large tables:
+    /// returns up to `limit` instance ids strictly after `after` (pass the
+    /// last id of the previous page; `None` starts from the beginning).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the query fails.
+    pub async fn list_snapshots_page(
+        &self,
+        after: Option<&str>,
+        limit: i64,
+    ) -> Result<Vec<String>, BackendError> {
+        let rows = sqlx::query(
+            "SELECT instance_id FROM sayiir_workflow_snapshots
+             WHERE ($1::text IS NULL OR instance_id > $1)
+             ORDER BY instance_id
+             LIMIT $2",
+        )
+        .bind(after)
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(PgError)?;
         Ok(rows.iter().map(|r| r.get("instance_id")).collect())
     }
 }

--- a/sayiir-postgres/src/task_claim_store.rs
+++ b/sayiir-postgres/src/task_claim_store.rs
@@ -230,9 +230,13 @@ where
         instance_id: &str,
         task_id: &sayiir_core::TaskId,
         worker_id: &str,
-        additional_duration: Duration,
+        ttl: Duration,
     ) -> Result<(), BackendError> {
-        // Heartbeat. A no-TTL claim is eternal-until-released; mirror
+        // Heartbeat. Renewal is absolute (`now() + ttl`), not additive:
+        // adding to `expires_at` would let the lease drift ahead of the
+        // wall clock by ~ttl per tick, so an orphaned claim from a
+        // crashed worker would block reclaim for far longer than one
+        // TTL. A no-TTL claim is eternal-until-released; mirror
         // the in-memory backend by silently no-op'ing the extension in
         // that case (no `COALESCE` — that would *introduce* a TTL).
         // When the row exists with our worker AND our task_id but
@@ -250,7 +254,7 @@ where
         let row = sqlx::query(
             "WITH upd AS (
                  UPDATE sayiir_workflow_claims
-                 SET expires_at = expires_at + $3
+                 SET expires_at = now() + $3
                  WHERE instance_id = $1
                    AND worker_id = $2
                    AND task_id = $4
@@ -269,7 +273,7 @@ where
         )
         .bind(instance_id)
         .bind(worker_id)
-        .bind(additional_duration)
+        .bind(ttl)
         .bind(task_id.as_bytes().as_slice())
         .fetch_one(&self.pool)
         .await

--- a/sayiir-postgres/src/task_claim_store.rs
+++ b/sayiir-postgres/src/task_claim_store.rs
@@ -292,72 +292,106 @@ where
         aging_interval: Duration,
         worker_tags: &[String],
     ) -> Result<Vec<AvailableTask>, BackendError> {
-        // Expired claims are picked up implicitly via the eligibility
-        // predicate's `c.expires_at > now()` check — no explicit
-        // garbage-collect needed here.
+        // Expired claims are reclaimable via the eligibility predicate's
+        // `c.expires_at > now()` check; dead rows linger until the next
+        // successful claim on the instance overwrites them (steal path).
 
         let aging_secs = (aging_interval.num_milliseconds() as f64 / 1000.0).max(1.0);
         let worker_tags_vec: Vec<&str> = worker_tags.iter().map(String::as_str).collect();
         let tag_filter = if worker_tags.is_empty() {
             ""
         } else {
-            "AND s.task_tags <@ $3"
+            "AND s.task_tags <@ $2"
         };
 
+        // Two LIMIT-bounded index-order arms instead of one full-set sort.
+        // The old single query ordered by the aging expression
+        // `(task_priority - age/interval)`, which is non-SARGable: every
+        // poll tick sorted ALL InProgress rows (~190ms at 200k rows).
+        // Each arm below is satisfied by an index in order — arm 1 by
+        // idx_snapshots_inprogress (task_priority, updated_at), arm 2 by
+        // idx_snapshots_inprogress_updated (updated_at) — so PG stops
+        // after `limit` rows per arm. The exact aging score is then
+        // computed in Rust over <= 2*limit candidates.
+        //
+        // Aging becomes approximate: the true score-optimal row is almost
+        // always in one of the two arms (best-priority or oldest), and the
+        // oldest-first arm guarantees starved rows are eventually offered,
+        // which is what aging exists for.
+        //
         // `FOR UPDATE OF s SKIP LOCKED` keeps statement-scope dedup —
         // two pollers running simultaneously skip each other's rows
-        // instead of returning the full set in duplicate. The actual
+        // instead of returning the full set in duplicate. Both arms run
+        // in the same transaction, so arm 2 sees arm 1's own locks as its
+        // own and may return the same row; DISTINCT ON dedups. The actual
         // claim race is resolved by the conditional UPDATE in
-        // `claim_task` plus its advisory lock.
-        //
-        // The inner subquery filters, sorts and locks snapshots without
-        // pulling the 1 KB history blob through the sort. JOINing
-        // history outside the LIMIT means only `$limit` blob rows are
-        // ever materialised — at 200k InProgress rows this drops
-        // EXPLAIN ANALYZE from ~615ms / 214 MB temp-file spill down to
-        // ~190ms / 11 MB on the bench fixture. The order-by expression
-        // is non-SARGable either way, but sorting narrow rows
-        // (instance_id + i32 + nullable text) keeps the spill (if any)
-        // small enough to stay inside work_mem on a reasonably tuned
-        // PG. `FOR UPDATE OF s SKIP LOCKED` stays scoped to the
-        // snapshot row; the outer history join is a non-locking read.
-        let query = format!(
-            "SELECT r.instance_id, h.data, r.trace_parent
-             FROM (
-                 SELECT s.instance_id, s.history_version, s.trace_parent
-                 FROM sayiir_workflow_snapshots s
-                 WHERE s.status = 'InProgress'
+        // `claim_task` plus its advisory lock. The history JOIN stays
+        // outside the locking subqueries so only candidate blob rows are
+        // materialised.
+        let dispatchable = "s.status = 'InProgress'
                    AND (
                        s.position_kind = 'AtTask'
                        OR (s.position_kind = 'AtDelay'
                            AND s.delay_wake_at IS NOT NULL
                            AND s.delay_wake_at <= now())
-                   )
-                   AND {ELIGIBILITY_PREDICATE}
-                   {tag_filter}
-                 ORDER BY
-                   (s.task_priority - EXTRACT(EPOCH FROM (now() - s.updated_at)) / $2) ASC,
-                   s.updated_at ASC
-                 LIMIT $1
-                 FOR UPDATE OF s SKIP LOCKED
+                   )";
+        let arm = |order_by: &str, alias: &str| {
+            format!(
+                "SELECT * FROM
+                     (SELECT s.instance_id, s.history_version, s.trace_parent,
+                             s.task_priority, s.updated_at
+                      FROM sayiir_workflow_snapshots s
+                      WHERE {dispatchable}
+                        AND {ELIGIBILITY_PREDICATE}
+                        {tag_filter}
+                      ORDER BY {order_by}
+                      LIMIT $1
+                      FOR UPDATE OF s SKIP LOCKED) {alias}"
+            )
+        };
+        let arm_priority = arm("s.task_priority ASC, s.updated_at ASC", "arm_priority");
+        let arm_oldest = arm("s.updated_at ASC", "arm_oldest");
+        let query = format!(
+            "SELECT r.instance_id, r.task_priority, r.updated_at, h.data, r.trace_parent
+             FROM (
+                 SELECT DISTINCT ON (u.instance_id)
+                        u.instance_id, u.history_version, u.trace_parent,
+                        u.task_priority, u.updated_at
+                 FROM ({arm_priority} UNION ALL {arm_oldest}) u
+                 ORDER BY u.instance_id
              ) r
              JOIN sayiir_workflow_snapshot_history h
                ON h.instance_id = r.instance_id AND h.version = r.history_version"
         );
 
-        let mut q = sqlx::query(&query)
-            .bind(i64::try_from(limit).unwrap_or(i64::MAX))
-            .bind(aging_secs);
+        let mut q = sqlx::query(&query).bind(i64::try_from(limit).unwrap_or(i64::MAX));
         if !worker_tags.is_empty() {
             q = q.bind(&worker_tags_vec);
         }
         let rows = q.fetch_all(&self.pool).await.map_err(PgError)?;
 
+        // Score on the narrow columns first and truncate to `limit` —
+        // the two arms can return up to 2*limit candidates, and only the
+        // survivors are worth the blob decode + outputs hydration below.
+        let now = Utc::now();
+        let mut scored: Vec<(f64, &sqlx::postgres::PgRow)> = rows
+            .iter()
+            .map(|row| {
+                let priority: i16 = row.get("task_priority");
+                let updated_at: chrono::DateTime<Utc> = row.get("updated_at");
+                let age_secs = (now - updated_at).num_milliseconds() as f64 / 1000.0;
+                (f64::from(priority) - age_secs / aging_secs, row)
+            })
+            .collect();
+        scored.sort_by(|(a, _), (b, _)| a.total_cmp(b));
+        scored.truncate(limit);
+
         // Decode-then-hydrate: outputs no longer live in the snapshot
         // blob, so batch-fetch them from `sayiir_workflow_tasks` once for
-        // every candidate before the match loop touches `completed_tasks`.
-        let mut decoded: Vec<WorkflowSnapshot> = Vec::with_capacity(rows.len());
-        for row in &rows {
+        // every surviving candidate before the match loop touches
+        // `completed_tasks`.
+        let mut decoded: Vec<WorkflowSnapshot> = Vec::with_capacity(scored.len());
+        for (_, row) in &scored {
             let raw: &[u8] = row.get("data");
             let mut snapshot = self.decode(raw)?;
             snapshot.trace_parent = row.get("trace_parent");
@@ -544,6 +578,58 @@ where
 
         Ok(build_available_task(snapshot, hint_task_id))
     }
+
+    #[tracing::instrument(
+        name = "db.save_snapshot_fenced",
+        skip(self, snapshot),
+        fields(
+            db.system = "postgresql",
+            instance_id = %snapshot.instance_id,
+            status = %snapshot.state.as_ref(),
+        ),
+        err(level = tracing::Level::ERROR),
+    )]
+    async fn save_snapshot_fenced(
+        &self,
+        snapshot: &mut WorkflowSnapshot,
+        task_id: &sayiir_core::TaskId,
+        worker_id: &str,
+    ) -> Result<bool, BackendError> {
+        // Fencing: lock our claim row first. FOR UPDATE makes a concurrent
+        // expired-claim steal (claim_task's ON CONFLICT UPDATE) wait until
+        // this commit, so "claim verified live" holds for the whole save.
+        // No live claim row for (instance, task, us) → the lease expired or
+        // was stolen; refuse the write so a slow worker can't clobber the
+        // new claimant's progress.
+        let mut tx = self.pool.begin().await.map_err(PgError)?;
+        let owned = sqlx::query(
+            "SELECT 1 FROM sayiir_workflow_claims
+             WHERE instance_id = $1 AND worker_id = $2 AND task_id = $3
+               AND (expires_at IS NULL OR expires_at > now())
+             FOR UPDATE",
+        )
+        .bind(&*snapshot.instance_id)
+        .bind(worker_id)
+        .bind(task_id.as_bytes().as_slice())
+        .fetch_optional(&mut *tx)
+        .await
+        .map_err(PgError)?;
+
+        if owned.is_none() {
+            tx.rollback().await.map_err(PgError)?;
+            tracing::warn!(
+                instance_id = %snapshot.instance_id,
+                %task_id,
+                worker_id,
+                "claim no longer held; snapshot save fenced off"
+            );
+            return Ok(false);
+        }
+
+        self.exec_save_snapshot(&mut *tx, snapshot).await?;
+        tx.commit().await.map_err(PgError)?;
+        Ok(true)
+    }
 }
 
 /// Decode the `(done, owner, current_task_id)` shape returned by the
@@ -578,8 +664,8 @@ fn disambiguate_writeback(
         return Err(BackendError::NotFound(format!("{instance_id}:{task_id}")));
     };
     if owner != worker_id {
-        return Err(BackendError::Backend(format!(
-            "Claim owned by different worker: {owner}"
+        return Err(BackendError::ClaimLost(format!(
+            "claim on {instance_id}:{task_id} owned by {owner}"
         )));
     }
     // owner == self: verify the row's task_id matches the request.

--- a/sayiir-postgres/src/task_result_store.rs
+++ b/sayiir-postgres/src/task_result_store.rs
@@ -28,6 +28,15 @@ where
         instance_id: &str,
         task_id: &sayiir_core::TaskId,
     ) -> Result<Option<bytes::Bytes>, BackendError> {
+        // Fast path: outputs live denormalised in sayiir_workflow_tasks —
+        // a single PK lookup, no blob decode. The snapshot/history walk
+        // below only runs for results that never reached the sidecar.
+        if let Some(output) =
+            crate::history::fetch_task_output(&self.pool, instance_id, task_id).await?
+        {
+            return Ok(Some(output));
+        }
+
         let snapshot = self.load_snapshot(instance_id).await?;
 
         // Non-terminal states carry completed_tasks directly.

--- a/sayiir-postgres/src/wakeup.rs
+++ b/sayiir-postgres/src/wakeup.rs
@@ -83,19 +83,36 @@ pub(crate) fn build_task_ready_payload(
     )
 }
 
+/// Dedup key for in-flight hints: one queued hint per (instance, task).
+type PendingKey = (String, [u8; 32]);
+type PendingSet = std::sync::Arc<std::sync::Mutex<std::collections::HashSet<PendingKey>>>;
+
 pub(crate) struct WakeupListener {
     rx: flume::Receiver<TaskWakeupHint>,
+    pending: PendingSet,
     shutdown: CancellationToken,
 }
 
 impl WakeupListener {
     /// Spawn the listener task and return a shared handle. Must be called
-    /// from a tokio runtime.
-    pub(crate) fn spawn(pool: PgPool) -> std::sync::Arc<Self> {
+    /// from a tokio runtime. When `url` is provided, the listener opens its
+    /// own connection instead of permanently occupying a pool slot.
+    pub(crate) fn spawn(pool: PgPool, url: Option<String>) -> std::sync::Arc<Self> {
         let (tx, rx) = flume::bounded(WAKEUP_CHANNEL_CAPACITY);
         let shutdown = CancellationToken::new();
-        tokio::spawn(run_listener(pool, tx, shutdown.clone()));
-        std::sync::Arc::new(Self { rx, shutdown })
+        let pending: PendingSet = std::sync::Arc::default();
+        tokio::spawn(run_listener(
+            pool,
+            url,
+            tx,
+            std::sync::Arc::clone(&pending),
+            shutdown.clone(),
+        ));
+        std::sync::Arc::new(Self {
+            rx,
+            pending,
+            shutdown,
+        })
     }
 
     /// Wait for the next wakeup or until `timeout` elapses.
@@ -106,7 +123,12 @@ impl WakeupListener {
     /// receiver without any mutex — fan-in is mpmc.
     pub(crate) async fn wait(&self, timeout: std::time::Duration) -> Option<TaskWakeupHint> {
         match tokio::time::timeout(timeout, self.rx.recv_async()).await {
-            Ok(Ok(hint)) => Some(hint),
+            Ok(Ok(hint)) => {
+                if let Ok(mut pending) = self.pending.lock() {
+                    pending.remove(&(hint.instance_id.clone(), hint.task_id));
+                }
+                Some(hint)
+            }
             Ok(Err(flume::RecvError::Disconnected)) | Err(_) => None,
         }
     }
@@ -120,15 +142,17 @@ impl Drop for WakeupListener {
 
 async fn run_listener(
     pool: PgPool,
+    url: Option<String>,
     tx: flume::Sender<TaskWakeupHint>,
+    pending: PendingSet,
     shutdown: CancellationToken,
 ) {
     loop {
-        let listener = match connect_and_listen(&pool, &shutdown).await {
+        let listener = match connect_and_listen(&pool, url.as_deref(), &shutdown).await {
             ControlFlow::Break(()) => break,
             ControlFlow::Continue(l) => l,
         };
-        match recv_until_error(listener, &tx, &shutdown).await {
+        match recv_until_error(listener, &tx, &pending, &shutdown).await {
             ControlFlow::Break(()) => break,
             ControlFlow::Continue(()) => {}
         }
@@ -142,8 +166,13 @@ async fn run_listener(
 /// live subscription. The `backon` iterator is local to each call so
 /// exponential growth resets across reconnect cycles — a recovered PG
 /// isn't penalized for an earlier outage.
+///
+/// With a `url`, the listener gets a dedicated connection; otherwise it
+/// borrows one from `pool` for its lifetime. The pool is still consulted
+/// for `is_closed()` as the shutdown signal in both modes.
 async fn connect_and_listen(
     pool: &PgPool,
+    url: Option<&str>,
     shutdown: &CancellationToken,
 ) -> ControlFlow<(), PgListener> {
     let mut backoff = ExponentialBuilder::default()
@@ -159,10 +188,13 @@ async fn connect_and_listen(
             return ControlFlow::Break(());
         }
 
-        let mut listener = match shutdown
-            .run_until_cancelled(PgListener::connect_with(pool))
-            .await
-        {
+        let connect = async {
+            match url {
+                Some(u) => PgListener::connect(u).await,
+                None => PgListener::connect_with(pool).await,
+            }
+        };
+        let mut listener = match shutdown.run_until_cancelled(connect).await {
             None | Some(Err(sqlx::Error::PoolClosed)) => return ControlFlow::Break(()),
             Some(Ok(l)) => l,
             Some(Err(e)) => {
@@ -194,33 +226,49 @@ async fn connect_and_listen(
 /// socket failures and replays the LISTEN; `Err` here means recovery is
 /// exhausted. `Break` = exit; `Continue` = caller should reconnect.
 ///
+/// Hints are coalesced by `(instance_id, task_id)`: a hint identical to
+/// one still sitting in the queue is dropped without occupying a second
+/// slot, so a burst of saves for the same step can't crowd out hints for
+/// other instances.
+///
 /// Malformed payloads (base64 decode failure, nanoserde decode failure)
 /// are logged at WARN and skipped — a producer with a mismatched wire
 /// format shouldn't crash the listener.
 async fn recv_until_error(
     mut listener: PgListener,
     tx: &flume::Sender<TaskWakeupHint>,
+    pending: &PendingSet,
     shutdown: &CancellationToken,
 ) -> ControlFlow<(), ()> {
     loop {
         match shutdown.run_until_cancelled(listener.recv()).await {
             None | Some(Err(sqlx::Error::PoolClosed)) => return ControlFlow::Break(()),
             Some(Ok(notification)) => match TaskWakeupHint::decode(notification.payload()) {
-                Ok(hint) => match tx.try_send(hint) {
-                    // `Disconnected` only happens if every Receiver was
-                    // dropped — i.e. every PostgresBackend clone is
-                    // gone. At that point the shutdown CancellationToken
-                    // has also fired, so the outer loop will exit on
-                    // the next `run_until_cancelled` poll. Drop the
-                    // hint silently in either case.
-                    Ok(()) | Err(flume::TrySendError::Disconnected(_)) => {}
-                    Err(flume::TrySendError::Full(_)) => {
-                        WAKEUP_DROPS.fetch_add(1, Ordering::Relaxed);
-                        tracing::warn!(
-                            "wakeup channel full, dropping hint; worker falls back to poll",
-                        );
+                Ok(hint) => {
+                    let fresh = pending.lock().map_or(true, |mut p| {
+                        p.insert((hint.instance_id.clone(), hint.task_id))
+                    });
+                    if !fresh {
+                        continue; // identical hint already queued
                     }
-                },
+                    // On `Disconnected` every Receiver was dropped — i.e.
+                    // every PostgresBackend clone is gone and the shutdown
+                    // token has fired, so the outer loop exits on the next
+                    // `run_until_cancelled` poll. Drop the hint silently.
+                    if let Err(e) = tx.try_send(hint) {
+                        let full = matches!(e, flume::TrySendError::Full(_));
+                        let hint = e.into_inner();
+                        if let Ok(mut p) = pending.lock() {
+                            p.remove(&(hint.instance_id, hint.task_id));
+                        }
+                        if full {
+                            WAKEUP_DROPS.fetch_add(1, Ordering::Relaxed);
+                            tracing::warn!(
+                                "wakeup channel full, dropping hint; worker falls back to poll",
+                            );
+                        }
+                    }
+                }
                 Err(e) => {
                     tracing::warn!(
                         error = %e,

--- a/sayiir-postgres/tests/integration.rs
+++ b/sayiir-postgres/tests/integration.rs
@@ -771,8 +771,12 @@ async fn extend_task_claim() {
 
     // Read the column directly: a "still held" reclaim probe would
     // pass even if extend was a silent no-op (the original 10s TTL
-    // hasn't elapsed yet), so check the actual expiration moved by
-    // ~the additional duration.
+    // hasn't elapsed yet), so check the actual expiration.
+    //
+    // Renewal is absolute (now + 300s), not additive: the original
+    // expiry was now + 10s, so the delta must be ~290s. An additive
+    // implementation would yield exactly 300 — keep the upper bound
+    // below that so lease-drift regressions fail here.
     let (claim_owner, claim_expires_at): (Option<String>, Option<chrono::DateTime<chrono::Utc>>) =
         sqlx::query_as(
             "SELECT worker_id, expires_at
@@ -785,10 +789,11 @@ async fn extend_task_claim() {
 
     assert_eq!(claim_owner.as_deref(), Some("worker-1"));
     let new_expiry_secs = claim_expires_at.unwrap().timestamp().cast_unsigned();
-    assert_eq!(
-        new_expiry_secs,
-        original_expiry_secs + 300,
-        "extend should move expires_at forward by exactly 300s"
+    let delta = new_expiry_secs - original_expiry_secs;
+    assert!(
+        (289..300).contains(&delta),
+        "extend should renew expires_at to now()+300s (absolute, not additive); \
+         expected delta ~290s, got {delta}s"
     );
 }
 

--- a/sayiir-postgres/tests/integration.rs
+++ b/sayiir-postgres/tests/integration.rs
@@ -739,7 +739,7 @@ async fn release_task_claim_wrong_worker() {
     let result = backend
         .release_task_claim("wf-1", &sayiir_core::TaskId::from("task-1"), "worker-2")
         .await;
-    assert!(matches!(result, Err(BackendError::Backend(_))));
+    assert!(matches!(result, Err(BackendError::ClaimLost(_))));
 }
 
 #[tokio::test]
@@ -815,7 +815,7 @@ async fn extend_task_claim_wrong_worker() {
             Duration::seconds(300),
         )
         .await;
-    assert!(matches!(result, Err(BackendError::Backend(_))));
+    assert!(matches!(result, Err(BackendError::ClaimLost(_))));
 }
 
 #[tokio::test]

--- a/sayiir-py/src/worker.rs
+++ b/sayiir-py/src/worker.rs
@@ -36,6 +36,9 @@ use crate::flow::PyWorkflow;
 ///         worst-case latency for events NOTIFY can't cover (delay
 ///         expiry, expired claims, lost LISTEN connections).
 ///     `claim_ttl_secs`: Task claim TTL in seconds (default: 300.0)
+///     `max_concurrent_tasks`: How many tasks this worker runs at once
+///         (default: 1). Each in-flight task has its own claim and
+///         heartbeat; I/O-bound throughput scales with this knob.
 #[pyclass]
 pub struct PyWorker {
     worker_id: String,
@@ -43,19 +46,21 @@ pub struct PyWorker {
     postgres: Option<(String, PoolOptions)>,
     poll_interval: Duration,
     claim_ttl: Duration,
+    max_concurrent_tasks: Option<usize>,
     tags: Vec<String>,
 }
 
 #[pymethods]
 impl PyWorker {
     #[new]
-    #[pyo3(signature = (worker_id, backend, poll_interval_secs=30.0, claim_ttl_secs=300.0, tags=None))]
+    #[pyo3(signature = (worker_id, backend, poll_interval_secs=30.0, claim_ttl_secs=300.0, tags=None, max_concurrent_tasks=None))]
     fn new(
         worker_id: String,
         backend: &Bound<'_, PyAny>,
         poll_interval_secs: f64,
         claim_ttl_secs: f64,
         tags: Option<Vec<String>>,
+        max_concurrent_tasks: Option<usize>,
     ) -> PyResult<Self> {
         let (backend_kind, postgres) = extract_backend(backend)?;
         Ok(Self {
@@ -64,6 +69,7 @@ impl PyWorker {
             postgres,
             poll_interval: Duration::from_secs_f64(poll_interval_secs),
             claim_ttl: Duration::from_secs_f64(claim_ttl_secs),
+            max_concurrent_tasks,
             tags: tags.unwrap_or_default(),
         })
     }
@@ -126,6 +132,7 @@ impl PyWorker {
         };
         let worker_id = self.worker_id.clone();
         let claim_ttl = self.claim_ttl;
+        let max_concurrent_tasks = self.max_concurrent_tasks;
         let poll_interval = self.poll_interval;
         let tags = self.tags.clone();
 
@@ -164,9 +171,13 @@ impl PyWorker {
                     ),
                 };
 
-                let worker = PooledWorker::new(&worker_id, backend_kind, TaskRegistry::default())
-                    .with_claim_ttl(Some(claim_ttl))
-                    .with_tags(tags);
+                let mut worker =
+                    PooledWorker::new(&worker_id, backend_kind, TaskRegistry::default())
+                        .with_claim_ttl(Some(claim_ttl))
+                        .with_tags(tags);
+                if let Some(max) = max_concurrent_tasks.and_then(std::num::NonZeroUsize::new) {
+                    worker = worker.with_max_concurrent_tasks(max);
+                }
 
                 // We need to enter the runtime context before spawning.
                 let _guard = runtime.enter();

--- a/sayiir-python/sayiir/_sayiir.pyi
+++ b/sayiir-python/sayiir/_sayiir.pyi
@@ -203,6 +203,7 @@ class PyWorker:
         poll_interval_secs: float = 30.0,
         claim_ttl_secs: float = 300.0,
         tags: list[str] | None = None,
+        max_concurrent_tasks: int | None = None,
     ) -> None: ...
     def start(
         self,

--- a/sayiir-python/sayiir/worker.py
+++ b/sayiir-python/sayiir/worker.py
@@ -64,6 +64,8 @@ class Worker:
         backend: Either ``InMemoryBackend()`` or ``PostgresBackend(url)``.
         poll_interval: Seconds between polls for available tasks.
         claim_ttl: Task claim TTL in seconds.
+        max_concurrent_tasks: How many tasks this worker runs at once
+            (default: 1). I/O-bound throughput scales with this knob.
     """
 
     def __init__(
@@ -73,8 +75,15 @@ class Worker:
         *,
         poll_interval: float = 5.0,
         claim_ttl: float = 300.0,
+        max_concurrent_tasks: int | None = None,
     ) -> None:
-        self._inner = _PyWorker(worker_id, backend, poll_interval, claim_ttl)
+        self._inner = _PyWorker(
+            worker_id,
+            backend,
+            poll_interval,
+            claim_ttl,
+            max_concurrent_tasks=max_concurrent_tasks,
+        )
 
     def start(self, workflows: list[Workflow]) -> WorkerHandle:
         """Start the worker and return a handle for lifecycle control.

--- a/sayiir-runtime/src/error.rs
+++ b/sayiir-runtime/src/error.rs
@@ -72,12 +72,6 @@ impl From<RunConflict> for RuntimeError {
 }
 
 impl RuntimeError {
-    /// Returns `true` if this error is a `TaskTimedOut` workflow error.
-    #[must_use]
-    pub fn is_timeout(&self) -> bool {
-        matches!(self, Self::Workflow(WorkflowError::TaskTimedOut { .. }))
-    }
-
     /// Returns `true` if this error is a codec decode failure (schema mismatch).
     #[must_use]
     pub fn is_decode_error(&self) -> bool {

--- a/sayiir-runtime/src/serialization/json.rs
+++ b/sayiir-runtime/src/serialization/json.rs
@@ -57,10 +57,20 @@ impl sayiir_core::codec::EnvelopeCodec for JsonCodec {
     }
 
     fn encode_branch_envelope(&self, key: &str, result_bytes: &[u8]) -> Result<Bytes, BoxError> {
-        let result_value: serde_json::Value =
-            serde_json::from_slice(result_bytes).unwrap_or(serde_json::Value::Null);
-        let envelope = serde_json::json!({ "branch": key, "result": result_value });
-        Ok(Bytes::from(serde_json::to_vec(&envelope)?))
+        #[derive(Serialize)]
+        struct Envelope<'a> {
+            branch: &'a str,
+            result: &'a serde_json::value::RawValue,
+        }
+        // RawValue splices the already-encoded result without building a
+        // Value tree (validate-only parse, no per-node allocation).
+        // Invalid result bytes degrade to a null result, as before.
+        let result = serde_json::from_slice::<&serde_json::value::RawValue>(result_bytes)
+            .or_else(|_| serde_json::from_slice(b"null"))?;
+        Ok(Bytes::from(serde_json::to_vec(&Envelope {
+            branch: key,
+            result,
+        })?))
     }
 
     fn encode_named_results(&self, results: &[(String, Bytes)]) -> Result<Bytes, BoxError> {

--- a/sayiir-runtime/src/worker.rs
+++ b/sayiir-runtime/src/worker.rs
@@ -26,7 +26,7 @@ use sayiir_core::snapshot::{
 };
 use sayiir_core::task_claim::AvailableTask;
 use sayiir_core::workflow::{Workflow, WorkflowContinuation, WorkflowStatus};
-use sayiir_persistence::{PersistentBackend, TaskClaimStore, TaskWakeupHint};
+use sayiir_persistence::{ControlSignal, PersistentBackend, TaskClaimStore, TaskWakeupHint};
 use std::num::NonZeroUsize;
 use std::panic::AssertUnwindSafe;
 use std::pin::Pin;
@@ -60,6 +60,7 @@ pub type WorkflowRegistry<C, Input, M> =
 /// Contains only the structural information (definition hash + continuation tree)
 /// needed by `PooledWorker` for position tracking, completion detection, retry
 /// policies, and timeouts. Task execution is delegated to an external executor.
+#[derive(Clone)]
 pub struct ExternalWorkflow {
     /// The continuation tree describing the workflow structure.
     pub continuation: Arc<WorkflowContinuation>,
@@ -113,6 +114,14 @@ pub type ExternalTaskExecutor = Arc<
 /// Internal command sent from [`WorkerHandle`] to the actor loop.
 enum WorkerCommand {
     Shutdown,
+}
+
+/// What woke an actor loop up.
+enum LoopEvent {
+    /// Shutdown requested (or every handle dropped).
+    Shutdown,
+    /// Time to look for work, with an optional targeted hint.
+    Wake(Option<TaskWakeupHint>),
 }
 
 struct WorkerHandleInner<B> {
@@ -206,7 +215,42 @@ enum ExecutionOutcome {
     Panic(Box<dyn std::any::Any + Send>),
     /// Heartbeat detected an expired deadline (active cancellation).
     Timeout(crate::error::RuntimeError),
+    /// Heartbeat saw a pending cancel signal and dropped the task future.
+    Cancelled,
+    /// The claim lease was lost mid-execution (stolen or unrenewable);
+    /// the local result must be abandoned, not persisted.
+    ClaimLost,
 }
+
+impl From<HeartbeatInterrupt> for ExecutionOutcome {
+    fn from(interrupt: HeartbeatInterrupt) -> Self {
+        match interrupt {
+            HeartbeatInterrupt::Timeout(err) => Self::Timeout(err),
+            HeartbeatInterrupt::Cancelled => Self::Cancelled,
+            HeartbeatInterrupt::ClaimLost => Self::ClaimLost,
+        }
+    }
+}
+
+/// Why `run_with_heartbeat` aborted the task future.
+enum HeartbeatInterrupt {
+    /// The task's deadline expired.
+    Timeout(crate::error::RuntimeError),
+    /// A cancel signal arrived for the instance.
+    Cancelled,
+    /// The claim could not be kept alive (stolen, released, or repeated
+    /// extension failures past the tolerance window).
+    ClaimLost,
+}
+
+/// Heartbeats fire at `claim_ttl / 4`, capped at this interval, so a
+/// crashed worker's claim expires (and a live worker's stays fresh)
+/// independently of how long the TTL is.
+const HEARTBEAT_MAX_INTERVAL: Duration = Duration::from_secs(15);
+
+/// Consecutive heartbeat-extension failures tolerated before the worker
+/// assumes the lease is lost and abandons the task.
+const HEARTBEAT_FAILURE_LIMIT: u32 = 3;
 
 /// Extract a human-readable message from a panic payload.
 fn extract_panic_message(payload: &Box<dyn std::any::Any + Send>) -> String {
@@ -267,6 +311,7 @@ pub struct PooledWorker<B> {
     registry: Arc<TaskRegistry>,
     claim_ttl: Option<Duration>,
     batch_size: NonZeroUsize,
+    max_concurrent_tasks: Option<NonZeroUsize>,
     aging_interval: Duration,
     tags: Vec<String>,
 }
@@ -285,8 +330,9 @@ where
     ///
     /// # Heartbeat
     ///
-    /// Heartbeats are derived automatically from `claim_ttl` (TTL / 2).
-    /// With the default 5-minute TTL, heartbeats fire every 2.5 minutes.
+    /// Heartbeats are derived automatically from `claim_ttl` (TTL / 4,
+    /// capped at 15 s), so a crashed worker's claim becomes reclaimable
+    /// quickly while a live worker renews well within margin.
     ///
     pub fn new(worker_id: impl Into<String>, backend: B, registry: TaskRegistry) -> Self {
         Self {
@@ -295,6 +341,7 @@ where
             registry: Arc::new(registry),
             claim_ttl: Some(Duration::from_mins(5)), // Default 5 minutes
             batch_size: NonZeroUsize::MIN,           // Default: fetch one task at a time (1)
+            max_concurrent_tasks: None,              // Default: follow batch_size
             aging_interval: Duration::from_mins(5),  // Default 5 minutes
             tags: vec![],
         }
@@ -335,17 +382,31 @@ where
         self
     }
 
-    /// Set the number of tasks to fetch per poll (default: 1).
+    /// Set the default in-flight task cap (default: 1).
     ///
-    /// With `batch_size=1`, the worker fetches one task, executes it, then polls again.
-    /// Other workers can pick up remaining tasks immediately.
-    ///
-    /// Higher values reduce polling overhead but may cause workers to hold task IDs
-    /// they won't process immediately (though other workers can still claim them).
+    /// The worker fetches up to its free concurrency slots per poll, so
+    /// this knob now seeds [`with_max_concurrent_tasks`](Self::with_max_concurrent_tasks)
+    /// when that isn't set explicitly.
     #[must_use]
     pub fn with_batch_size(mut self, size: NonZeroUsize) -> Self {
         self.batch_size = size;
         self
+    }
+
+    /// Set how many tasks this worker executes concurrently (default:
+    /// follows `batch_size`). Each in-flight task runs on its own tokio
+    /// task with its own claim + heartbeat; throughput on I/O-bound tasks
+    /// scales roughly linearly with this knob until the backend or the
+    /// executor saturates.
+    #[must_use]
+    pub fn with_max_concurrent_tasks(mut self, max: NonZeroUsize) -> Self {
+        self.max_concurrent_tasks = Some(max);
+        self
+    }
+
+    /// Effective in-flight task cap: explicit setting, else `batch_size`.
+    fn max_concurrent(&self) -> usize {
+        self.max_concurrent_tasks.unwrap_or(self.batch_size).get()
     }
 
     /// Set affinity tags for this worker.
@@ -460,8 +521,9 @@ where
     {
         let (tx, rx) = mpsc::channel(1);
         let backend = Arc::clone(&self.backend);
+        let worker = Arc::new(self);
         let join_handle =
-            tokio::spawn(async move { self.run_actor_loop(poll_interval, workflows, rx).await });
+            tokio::spawn(async move { worker.run_actor_loop(poll_interval, workflows, rx).await });
         WorkerHandle {
             inner: Arc::new(WorkerHandleInner {
                 backend,
@@ -492,8 +554,10 @@ where
     ) -> WorkerHandle<B> {
         let (tx, rx) = mpsc::channel(1);
         let backend = Arc::clone(&self.backend);
+        let worker = Arc::new(self);
         let join_handle = tokio::spawn(async move {
-            self.run_external_actor_loop(poll_interval, workflows, executor, rx)
+            worker
+                .run_external_actor_loop(poll_interval, workflows, executor, rx)
                 .await
         });
         WorkerHandle {
@@ -505,41 +569,115 @@ where
         }
     }
 
-    /// Actor loop for external executor mode.
-    async fn run_external_actor_loop(
+    /// Reap finished tasks, wait below capacity, then wait for the next
+    /// wakeup signal. Shared verbatim by both actor loops so their
+    /// concurrency/shutdown semantics can't drift.
+    async fn next_loop_event(
         &self,
+        interval: &mut time::Interval,
+        cmd_rx: &mut mpsc::Receiver<WorkerCommand>,
+        inflight: &mut tokio::task::JoinSet<()>,
+        max_inflight: usize,
+        poll_interval: Duration,
+    ) -> LoopEvent {
+        loop {
+            while inflight.try_join_next().is_some() {}
+
+            // At capacity: wait for a slot (or shutdown) instead of polling.
+            if inflight.len() >= max_inflight {
+                tokio::select! {
+                    biased;
+                    _ = cmd_rx.recv() => return LoopEvent::Shutdown,
+                    _ = inflight.join_next() => {}
+                }
+                continue;
+            }
+
+            return tokio::select! {
+                biased;
+
+                cmd = cmd_rx.recv() => {
+                    match cmd {
+                        Some(WorkerCommand::Shutdown) | None => LoopEvent::Shutdown,
+                    }
+                }
+                _ = interval.tick() => {
+                    tracing::trace!(worker_id = %self.worker_id, "fallback poll tick");
+                    LoopEvent::Wake(None)
+                }
+                hint = self.backend.wait_for_wakeup(poll_interval) => {
+                    match hint {
+                        Ok(hint) => {
+                            tracing::debug!(
+                                worker_id = %self.worker_id,
+                                has_hint = hint.is_some(),
+                                "wakeup notification",
+                            );
+                            LoopEvent::Wake(hint)
+                        }
+                        Err(e) => {
+                            tracing::warn!(worker_id = %self.worker_id, error = %e, "wakeup wait failed");
+                            LoopEvent::Wake(None)
+                        }
+                    }
+                }
+            };
+        }
+    }
+
+    /// Fetch up to `limit` dispatchable tasks, logging (not propagating)
+    /// backend errors so a transient DB outage doesn't kill the worker.
+    async fn poll_batch(&self, limit: usize) -> Vec<AvailableTask> {
+        match self
+            .backend
+            .find_available_tasks(
+                &self.worker_id,
+                limit,
+                chrono::Duration::from_std(self.aging_interval).unwrap_or(chrono::Duration::MAX),
+                &self.tags,
+            )
+            .await
+        {
+            Ok(tasks) => tasks,
+            Err(e) => {
+                tracing::warn!(worker_id = %self.worker_id, error = %e, "task poll failed; will retry");
+                Vec::new()
+            }
+        }
+    }
+
+    /// Actor loop for external executor mode.
+    ///
+    /// Up to [`max_concurrent`](Self::max_concurrent) tasks run
+    /// simultaneously, each on its own tokio task with its own claim and
+    /// heartbeat. Task failures (including timeouts) fail or retry that
+    /// workflow only — they never take the worker down. Backend errors on
+    /// the polling path are logged and retried on the next tick, so a
+    /// transient DB outage doesn't kill the fleet either.
+    async fn run_external_actor_loop(
+        self: Arc<Self>,
         poll_interval: Duration,
         workflows: WorkflowIndex,
         executor: ExternalTaskExecutor,
         mut cmd_rx: mpsc::Receiver<WorkerCommand>,
     ) -> Result<(), crate::error::RuntimeError> {
         let mut interval = staggered_poll_interval(&self.worker_id, poll_interval);
+        let max_inflight = self.max_concurrent();
+        let mut inflight = tokio::task::JoinSet::new();
 
         loop {
-            let hint = tokio::select! {
-                biased;
-
-                cmd = cmd_rx.recv() => {
-                    match cmd {
-                        Some(WorkerCommand::Shutdown) | None => {
-                            tracing::info!(worker_id = %self.worker_id, "Worker shutting down");
-                            return Ok(());
-                        }
-                    }
-                }
-                _ = interval.tick() => {
-                    tracing::trace!(worker_id = %self.worker_id, "fallback poll tick");
-                    None
-                }
-                hint = self.backend.wait_for_wakeup(poll_interval) => {
-                    let hint = hint?;
-                    tracing::debug!(
-                        worker_id = %self.worker_id,
-                        has_hint = hint.is_some(),
-                        "wakeup notification",
-                    );
-                    hint
-                }
+            let hint = match self
+                .next_loop_event(
+                    &mut interval,
+                    &mut cmd_rx,
+                    &mut inflight,
+                    max_inflight,
+                    poll_interval,
+                )
+                .await
+            {
+                LoopEvent::Shutdown => return self.drain_inflight(inflight).await,
+                LoopEvent::Wake(hint) => hint,
             };
 
             if let Some(h) = hint.as_ref()
@@ -555,68 +693,73 @@ where
             }
 
             if let Some(h) = hint.as_ref() {
-                match self.try_hinted_execute(h, &workflows, &executor).await {
+                match self
+                    .spawn_hinted_task(h, &workflows, &executor, &mut inflight)
+                    .await
+                {
                     Ok(true) => continue,
                     Ok(false) => {}
-                    Err(ref e) if e.is_timeout() => {
-                        tracing::error!(worker_id = %self.worker_id, error = %e, "Task timed out — worker shutting down");
-                        return Ok(());
+                    Err(e) => {
+                        tracing::warn!(worker_id = %self.worker_id, error = %e, "hinted lookup failed");
                     }
-                    Err(e) => return Err(e),
                 }
             }
 
-            let available_tasks = self
-                .backend
-                .find_available_tasks(
-                    &self.worker_id,
-                    self.batch_size.get(),
-                    chrono::Duration::from_std(self.aging_interval)
-                        .unwrap_or(chrono::Duration::MAX),
-                    &self.tags,
-                )
-                .await?;
-
-            for task in available_tasks {
+            // Fetch up to the free slots — `batch_size` only seeds the
+            // default concurrency; the in-flight cap is the real budget.
+            let limit = max_inflight - inflight.len();
+            for task in self.poll_batch(limit).await {
                 if let Ok(WorkerCommand::Shutdown) | Err(mpsc::error::TryRecvError::Disconnected) =
                     cmd_rx.try_recv()
                 {
-                    tracing::info!(worker_id = %self.worker_id, "Worker shutting down mid-batch");
-                    return Ok(());
+                    return self.drain_inflight(inflight).await;
                 }
 
                 if let Some(ext_wf) = workflows.get(&task.workflow_definition_hash) {
-                    match self
-                        .execute_external_task(
-                            ext_wf,
-                            &task.workflow_definition_hash,
-                            &executor,
-                            &task,
-                        )
-                        .await
-                    {
-                        Err(ref e) if e.is_timeout() => {
-                            tracing::error!(
-                                worker_id = %self.worker_id,
-                                error = %e,
-                                "Task timed out — worker shutting down"
-                            );
-                            return Ok(());
-                        }
-                        Ok(_) => {
-                            tracing::info!(worker_id = %self.worker_id, "completed task");
-                        }
-                        Err(e) => {
-                            tracing::error!(
-                                worker_id = %self.worker_id,
-                                error = %e,
-                                "task execution failed"
-                            );
-                        }
-                    }
+                    self.spawn_external_task(ext_wf.clone(), &executor, task, &mut inflight);
                 }
             }
         }
+    }
+
+    /// Finish all in-flight tasks, then exit. Callers needing a bound
+    /// should wrap [`WorkerHandle::join`] in `tokio::time::timeout`;
+    /// per-task deadlines keep this finite for deadline-bearing tasks.
+    async fn drain_inflight(
+        &self,
+        mut inflight: tokio::task::JoinSet<()>,
+    ) -> Result<(), crate::error::RuntimeError> {
+        tracing::info!(
+            worker_id = %self.worker_id,
+            inflight = inflight.len(),
+            "Worker shutting down; draining in-flight tasks"
+        );
+        while inflight.join_next().await.is_some() {}
+        Ok(())
+    }
+
+    /// Spawn one externally-executed task onto the in-flight set.
+    fn spawn_external_task(
+        self: &Arc<Self>,
+        ext_wf: ExternalWorkflow,
+        executor: &ExternalTaskExecutor,
+        task: AvailableTask,
+        inflight: &mut tokio::task::JoinSet<()>,
+    ) {
+        let worker = Arc::clone(self);
+        let executor = Arc::clone(executor);
+        inflight.spawn(async move {
+            let hash = task.workflow_definition_hash;
+            match worker
+                .execute_external_task(&ext_wf, &hash, &executor, task)
+                .await
+            {
+                Ok(_) => tracing::info!(worker_id = %worker.worker_id, "completed task"),
+                Err(e) => {
+                    tracing::error!(worker_id = %worker.worker_id, error = %e, "task execution failed");
+                }
+            }
+        });
     }
 
     /// True if the worker has the hint's workflow registered and its
@@ -629,14 +772,14 @@ where
         hint.tags.iter().all(|t| self.tags.contains(t))
     }
 
-    /// `Ok(true)` if the hinted task was claimed and executed (or its
-    /// execution failed non-fatally), `Ok(false)` to fall through to the
-    /// full polling scan, `Err(e)` on a fatal task timeout.
-    async fn try_hinted_execute(
-        &self,
+    /// `Ok(true)` if the hinted task resolved and was spawned for
+    /// execution, `Ok(false)` to fall through to the full polling scan.
+    async fn spawn_hinted_task(
+        self: &Arc<Self>,
         hint: &TaskWakeupHint,
         workflows: &WorkflowIndex,
         executor: &ExternalTaskExecutor,
+        inflight: &mut tokio::task::JoinSet<()>,
     ) -> Result<bool, crate::error::RuntimeError> {
         let Some(task) = self.backend.find_hinted_task(hint).await? else {
             return Ok(false);
@@ -644,16 +787,7 @@ where
         let Some(ext_wf) = workflows.get(&task.workflow_definition_hash) else {
             return Ok(false);
         };
-        match self
-            .execute_external_task(ext_wf, &task.workflow_definition_hash, executor, &task)
-            .await
-        {
-            Err(e) if e.is_timeout() => return Err(e),
-            Ok(_) => tracing::info!(worker_id = %self.worker_id, "completed hinted task"),
-            Err(e) => {
-                tracing::error!(worker_id = %self.worker_id, error = %e, "hinted task execution failed");
-            }
-        }
+        self.spawn_external_task(ext_wf.clone(), executor, task, inflight);
         Ok(true)
     }
 
@@ -673,7 +807,7 @@ where
         ext_wf: &ExternalWorkflow,
         definition_hash: &sayiir_core::DefinitionHash,
         executor: &ExternalTaskExecutor,
-        available_task: &AvailableTask,
+        mut available_task: AvailableTask,
     ) -> Result<WorkflowStatus, crate::error::RuntimeError> {
         // Link current span to the workflow's trace context (cross-worker propagation)
         #[cfg(feature = "otel")]
@@ -684,29 +818,30 @@ where
         }
 
         // Workers that lose the claim race drop the `available_task`
-        // (and its `Arc<WorkflowSnapshot>`) cheaply — keep the deep
-        // clone strictly past the claim_task gate.
+        // (and its `Arc<WorkflowSnapshot>`) cheaply — extract the owned
+        // snapshot strictly past the claim_task gate.
         let already_completed = Self::validate_task_preconditions(
             definition_hash,
             &ext_wf.task_index,
-            available_task,
+            &available_task,
             &available_task.snapshot,
         )?;
         if already_completed {
             return Ok(WorkflowStatus::InProgress);
         }
 
-        let Some(claim) = self.claim_task(available_task).await? else {
+        let Some(claim) = self.claim_task(&available_task).await? else {
             return Ok(WorkflowStatus::InProgress);
         };
 
-        if let Some(status) = self.check_post_claim_guards(available_task).await? {
+        if let Some(status) = self.check_post_claim_guards(&available_task).await? {
             claim.release_quietly().await;
             return Ok(status);
         }
 
-        // Past the claim gate — now pay for the deep clone exactly once.
-        let mut snapshot = (*available_task.snapshot).clone();
+        // Past the claim gate — take the snapshot out of its Arc (a move,
+        // not a deep clone: the dispatch Arc is never shared).
+        let mut snapshot = available_task.take_snapshot();
 
         tracing::debug!(
             instance_id = %available_task.instance_id,
@@ -715,14 +850,14 @@ where
         );
 
         let execution_result = self
-            .execute_with_deadline_ext(ext_wf, executor, available_task, &mut snapshot, &claim)
+            .execute_with_deadline_ext(ext_wf, executor, &available_task, &mut snapshot, &claim)
             .await;
 
         self.settle_execution_result_ext(
             execution_result,
             &ext_wf.continuation,
             &ext_wf.task_index,
-            available_task,
+            &available_task,
             &mut snapshot,
             claim,
         )
@@ -784,7 +919,7 @@ where
         snapshot.clear_task_deadline();
 
         match heartbeat_result {
-            Err(timeout_err) => ExecutionOutcome::Timeout(timeout_err),
+            Err(interrupt) => interrupt.into(),
             Ok(Err(panic_payload)) => ExecutionOutcome::Panic(panic_payload),
             Ok(Ok(Err(e))) => ExecutionOutcome::TaskError(e.into()),
             Ok(Ok(Ok(output))) => ExecutionOutcome::Success(output),
@@ -809,89 +944,170 @@ where
         tracing::debug!("settling execution result");
         match outcome {
             ExecutionOutcome::Timeout(err) => {
-                if let Ok(Some(status)) = self
-                    .try_schedule_retry(task_index, available_task, snapshot, &err.to_string())
+                match self
+                    .settle_failure(
+                        task_index,
+                        available_task,
+                        snapshot,
+                        claim,
+                        &err.to_string(),
+                    )
                     .await
                 {
-                    claim.release_quietly().await;
-                    return Ok(status);
+                    Some(status) => Ok(status),
+                    None => Err(err),
                 }
-
-                tracing::warn!(
-                    instance_id = %available_task.instance_id,
-                    task_id = %available_task.task_id,
-                    error = %err,
-                    "Task timed out via heartbeat — marking workflow failed, shutting down"
-                );
-                snapshot.mark_failed(err.to_string());
-                let _ = self.backend.save_snapshot(snapshot).await;
-                claim.release_quietly().await;
-                Err(err)
             }
             ExecutionOutcome::Panic(panic_payload) => {
                 let panic_msg = extract_panic_message(&panic_payload);
-
-                if let Ok(Some(status)) = self
-                    .try_schedule_retry(task_index, available_task, snapshot, &panic_msg)
+                match self
+                    .settle_failure(task_index, available_task, snapshot, claim, &panic_msg)
                     .await
                 {
-                    claim.release_quietly().await;
-                    return Ok(status);
+                    Some(status) => Ok(status),
+                    None => Err(WorkflowError::TaskPanicked(panic_msg).into()),
                 }
-
-                tracing::error!(
-                    instance_id = %available_task.instance_id,
-                    task_id = %available_task.task_id,
-                    panic = %panic_msg,
-                    "Task panicked - releasing claim"
-                );
-                claim.release_quietly().await;
-                Err(WorkflowError::TaskPanicked(panic_msg).into())
             }
             ExecutionOutcome::TaskError(e) => {
-                if let Ok(Some(status)) = self
-                    .try_schedule_retry(task_index, available_task, snapshot, &e.to_string())
+                match self
+                    .settle_failure(task_index, available_task, snapshot, claim, &e.to_string())
                     .await
                 {
-                    claim.release_quietly().await;
-                    return Ok(status);
+                    Some(status) => Ok(status),
+                    None => Err(e),
                 }
-
-                tracing::error!(
-                    instance_id = %available_task.instance_id,
-                    task_id = %available_task.task_id,
-                    error = %e,
-                    "Task execution failed"
-                );
-                claim.release_quietly().await;
-                Err(e)
             }
+            ExecutionOutcome::Cancelled => self.settle_cancelled(available_task, claim).await,
+            ExecutionOutcome::ClaimLost => Ok(Self::settle_claim_lost(available_task)),
             ExecutionOutcome::Success(output) => {
                 snapshot.clear_retry_state(&available_task.task_id);
-                self.commit_task_result(
-                    continuation,
-                    available_task,
-                    snapshot,
-                    output.clone(),
-                    claim,
-                )
-                .await?;
+                if !self
+                    .commit_task_result(
+                        continuation,
+                        available_task,
+                        snapshot,
+                        output.clone(),
+                        claim,
+                    )
+                    .await?
+                {
+                    return Ok(Self::settle_claim_lost(available_task));
+                }
                 self.determine_post_task_status(continuation, available_task, snapshot, output)
                     .await
             }
         }
     }
 
+    /// Retry-or-fail policy shared by every failure outcome: schedule a
+    /// retry if the policy allows (returning the resulting status), else
+    /// fail the workflow and return `None` so the caller surfaces the
+    /// final error.
+    async fn settle_failure(
+        &self,
+        task_index: &sayiir_core::TaskIndex,
+        available_task: &AvailableTask,
+        snapshot: &mut WorkflowSnapshot,
+        claim: ActiveTaskClaim<'_, B>,
+        error_msg: &str,
+    ) -> Option<WorkflowStatus> {
+        if let Ok(Some(status)) = self
+            .try_schedule_retry(task_index, available_task, snapshot, error_msg)
+            .await
+        {
+            claim.release_quietly().await;
+            return Some(status);
+        }
+        self.fail_workflow(available_task, snapshot, claim, error_msg)
+            .await;
+        None
+    }
+
+    /// Terminal-failure path shared by timeout/panic/error settles once
+    /// retries are exhausted (or absent): mark the workflow failed so the
+    /// poison task stops being re-offered at poll speed, persist under the
+    /// claim fence, release.
+    async fn fail_workflow(
+        &self,
+        available_task: &AvailableTask,
+        snapshot: &mut WorkflowSnapshot,
+        claim: ActiveTaskClaim<'_, B>,
+        error_msg: &str,
+    ) {
+        tracing::error!(
+            instance_id = %available_task.instance_id,
+            task_id = %available_task.task_id,
+            error = %error_msg,
+            "Task failed with no retries left — marking workflow failed"
+        );
+        snapshot.mark_failed(error_msg.to_string());
+        match self
+            .backend
+            .save_snapshot_fenced(snapshot, &claim.task_id, &claim.worker_id)
+            .await
+        {
+            Ok(true) => {}
+            Ok(false) => tracing::warn!(
+                instance_id = %available_task.instance_id,
+                "claim lost; failure state not persisted (new claimant owns the task)"
+            ),
+            Err(e) => tracing::warn!(
+                instance_id = %available_task.instance_id,
+                error = %e,
+                "failed to persist failure state"
+            ),
+        }
+        claim.release_quietly().await;
+    }
+
+    /// A cancel signal interrupted the running task: release the claim and
+    /// apply the cancellation (the dropped future did no further work).
+    async fn settle_cancelled(
+        &self,
+        available_task: &AvailableTask,
+        claim: ActiveTaskClaim<'_, B>,
+    ) -> Result<WorkflowStatus, crate::error::RuntimeError> {
+        claim.release_quietly().await;
+        if self
+            .backend
+            .check_and_cancel(&available_task.instance_id, Some(available_task.task_id))
+            .await?
+        {
+            return Ok(self
+                .load_cancelled_status(&available_task.instance_id)
+                .await);
+        }
+        // Signal vanished between detection and here — the task simply
+        // re-dispatches.
+        Ok(WorkflowStatus::InProgress)
+    }
+
+    /// The lease was lost mid-execution: another worker owns the task now.
+    /// Abandon the local result; do NOT release (the claim isn't ours).
+    fn settle_claim_lost(available_task: &AvailableTask) -> WorkflowStatus {
+        tracing::warn!(
+            instance_id = %available_task.instance_id,
+            task_id = %available_task.task_id,
+            "task claim lost mid-execution; abandoning local result"
+        );
+        WorkflowStatus::InProgress
+    }
+
     /// The actor loop: poll for tasks, execute them, respond to shutdown.
     ///
+    /// Same concurrency and resilience model as the external loop: up to
+    /// [`max_concurrent`](Self::max_concurrent) tasks in flight at once,
+    /// task failures fail that workflow only, and polling-path backend
+    /// errors are logged and retried on the next tick.
+    #[allow(clippy::too_many_lines)]
     async fn run_actor_loop<C, Input, M>(
-        &self,
+        self: Arc<Self>,
         poll_interval: Duration,
         workflows: WorkflowRegistry<C, Input, M>,
         mut cmd_rx: mpsc::Receiver<WorkerCommand>,
     ) -> Result<(), crate::error::RuntimeError>
     where
-        Input: Send + 'static,
+        Input: Send + Sync + 'static,
         M: Send + Sync + 'static,
         C: Codec
             + EnvelopeCodec
@@ -900,34 +1116,24 @@ where
             + 'static,
     {
         let mut interval = staggered_poll_interval(&self.worker_id, poll_interval);
+        let max_inflight = self.max_concurrent();
+        let mut inflight = tokio::task::JoinSet::new();
 
         loop {
             // In-process mode only filters irrelevant wakes; the direct-
             // claim shortcut lives on the external-executor path.
-            let hint = tokio::select! {
-                biased;
-
-                cmd = cmd_rx.recv() => {
-                    match cmd {
-                        Some(WorkerCommand::Shutdown) | None => {
-                            tracing::info!(worker_id = %self.worker_id, "Worker shutting down");
-                            return Ok(());
-                        }
-                    }
-                }
-                _ = interval.tick() => {
-                    tracing::trace!(worker_id = %self.worker_id, "fallback poll tick");
-                    None
-                }
-                hint = self.backend.wait_for_wakeup(poll_interval) => {
-                    let hint = hint?;
-                    tracing::debug!(
-                        worker_id = %self.worker_id,
-                        has_hint = hint.is_some(),
-                        "wakeup notification",
-                    );
-                    hint
-                }
+            let hint = match self
+                .next_loop_event(
+                    &mut interval,
+                    &mut cmd_rx,
+                    &mut inflight,
+                    max_inflight,
+                    poll_interval,
+                )
+                .await
+            {
+                LoopEvent::Shutdown => return self.drain_inflight(inflight).await,
+                LoopEvent::Wake(hint) => hint,
             };
 
             if let Some(h) = hint.as_ref()
@@ -942,23 +1148,14 @@ where
                 continue;
             }
 
-            let available_tasks = self
-                .backend
-                .find_available_tasks(
-                    &self.worker_id,
-                    self.batch_size.get(),
-                    chrono::Duration::from_std(self.aging_interval)
-                        .unwrap_or(chrono::Duration::MAX),
-                    &self.tags,
-                )
-                .await?;
-
-            for task in available_tasks {
+            // Fetch up to the free slots — `batch_size` only seeds the
+            // default concurrency; the in-flight cap is the real budget.
+            let limit = max_inflight - inflight.len();
+            for task in self.poll_batch(limit).await {
                 if let Ok(WorkerCommand::Shutdown) | Err(mpsc::error::TryRecvError::Disconnected) =
                     cmd_rx.try_recv()
                 {
-                    tracing::info!(worker_id = %self.worker_id, "Worker shutting down mid-batch");
-                    return Ok(());
+                    return self.drain_inflight(inflight).await;
                 }
 
                 if let Some((_, workflow)) = workflows
@@ -966,26 +1163,22 @@ where
                     .find(|(hash, _)| *hash == task.workflow_definition_hash)
                 // hash and task.workflow_definition_hash are both DefinitionHash
                 {
-                    match self.execute_task(workflow.as_ref(), task).await {
-                        Err(ref e) if e.is_timeout() => {
-                            tracing::error!(
-                                worker_id = %self.worker_id,
-                                error = %e,
-                                "Task timed out — worker shutting down"
-                            );
-                            return Ok(());
+                    let worker = Arc::clone(&self);
+                    let workflow = Arc::clone(workflow);
+                    inflight.spawn(async move {
+                        match worker.execute_task(workflow.as_ref(), task).await {
+                            Ok(_) => {
+                                tracing::info!(worker_id = %worker.worker_id, "completed task");
+                            }
+                            Err(e) => {
+                                tracing::error!(
+                                    worker_id = %worker.worker_id,
+                                    error = %e,
+                                    "task execution failed"
+                                );
+                            }
                         }
-                        Ok(_) => {
-                            tracing::info!(worker_id = %self.worker_id, "completed task");
-                        }
-                        Err(e) => {
-                            tracing::error!(
-                                worker_id = %self.worker_id,
-                                error = %e,
-                                "task execution failed"
-                            );
-                        }
-                    }
+                    });
                 }
             }
         }
@@ -1050,7 +1243,7 @@ where
     pub async fn execute_task<C, Input, M>(
         &self,
         workflow: &Workflow<C, Input, M>,
-        available_task: AvailableTask,
+        mut available_task: AvailableTask,
     ) -> Result<WorkflowStatus, crate::error::RuntimeError>
     where
         Input: Send + 'static,
@@ -1071,7 +1264,7 @@ where
 
         // 1. Use the snapshot the dispatch SELECT already decoded.
         // Lost-race workers drop the `Arc<WorkflowSnapshot>` cheaply —
-        // keep the deep clone strictly past the claim_task gate.
+        // extract the owned snapshot strictly past the claim_task gate.
         let already_completed = Self::validate_task_preconditions(
             workflow.definition_hash(),
             workflow.task_index(),
@@ -1092,8 +1285,9 @@ where
             return Ok(status);
         }
 
-        // Past the claim gate — now pay for the deep clone exactly once.
-        let mut snapshot = (*available_task.snapshot).clone();
+        // Past the claim gate — take the snapshot out of its Arc (a move,
+        // not a deep clone: the dispatch Arc is never shared).
+        let mut snapshot = available_task.take_snapshot();
 
         tracing::debug!(
             instance_id = %available_task.instance_id,
@@ -1227,7 +1421,7 @@ where
         snapshot.clear_task_deadline();
 
         match heartbeat_result {
-            Err(timeout_err) => ExecutionOutcome::Timeout(timeout_err),
+            Err(interrupt) => interrupt.into(),
             Ok(Err(panic_payload)) => ExecutionOutcome::Panic(panic_payload),
             Ok(Ok(Err(e))) => ExecutionOutcome::TaskError(e),
             Ok(Ok(Ok(output))) => ExecutionOutcome::Success(output),
@@ -1262,7 +1456,11 @@ where
             Some(&self.worker_id),
         );
         snapshot.clear_task_deadline();
-        let _ = self.backend.save_snapshot(snapshot).await;
+        // Fenced: if the lease was lost the new claimant owns retry state.
+        let _ = self
+            .backend
+            .save_snapshot_fenced(snapshot, &available_task.task_id, &self.worker_id)
+            .await;
 
         tracing::info!(
             instance_id = %available_task.instance_id,
@@ -1302,83 +1500,67 @@ where
         tracing::debug!("settling execution result");
         match outcome {
             ExecutionOutcome::Timeout(err) => {
-                if let Ok(Some(status)) = self
-                    .try_schedule_retry(
+                match self
+                    .settle_failure(
                         workflow.task_index(),
                         available_task,
                         snapshot,
+                        claim,
                         &err.to_string(),
                     )
                     .await
                 {
-                    claim.release_quietly().await;
-                    return Ok(status);
+                    Some(status) => Ok(status),
+                    None => Err(err),
                 }
-
-                tracing::warn!(
-                    instance_id = %available_task.instance_id,
-                    task_id = %available_task.task_id,
-                    error = %err,
-                    "Task timed out via heartbeat — marking workflow failed, shutting down"
-                );
-                snapshot.mark_failed(err.to_string());
-                let _ = self.backend.save_snapshot(snapshot).await;
-                claim.release_quietly().await;
-                Err(err)
             }
             ExecutionOutcome::Panic(panic_payload) => {
                 let panic_msg = extract_panic_message(&panic_payload);
-
-                if let Ok(Some(status)) = self
-                    .try_schedule_retry(workflow.task_index(), available_task, snapshot, &panic_msg)
-                    .await
-                {
-                    claim.release_quietly().await;
-                    return Ok(status);
-                }
-
-                tracing::error!(
-                    instance_id = %available_task.instance_id,
-                    task_id = %available_task.task_id,
-                    panic = %panic_msg,
-                    "Task panicked - releasing claim"
-                );
-                claim.release_quietly().await;
-                Err(WorkflowError::TaskPanicked(panic_msg).into())
-            }
-            ExecutionOutcome::TaskError(e) => {
-                if let Ok(Some(status)) = self
-                    .try_schedule_retry(
+                match self
+                    .settle_failure(
                         workflow.task_index(),
                         available_task,
                         snapshot,
+                        claim,
+                        &panic_msg,
+                    )
+                    .await
+                {
+                    Some(status) => Ok(status),
+                    None => Err(WorkflowError::TaskPanicked(panic_msg).into()),
+                }
+            }
+            ExecutionOutcome::TaskError(e) => {
+                match self
+                    .settle_failure(
+                        workflow.task_index(),
+                        available_task,
+                        snapshot,
+                        claim,
                         &e.to_string(),
                     )
                     .await
                 {
-                    claim.release_quietly().await;
-                    return Ok(status);
+                    Some(status) => Ok(status),
+                    None => Err(e),
                 }
-
-                tracing::error!(
-                    instance_id = %available_task.instance_id,
-                    task_id = %available_task.task_id,
-                    error = %e,
-                    "Task execution failed"
-                );
-                claim.release_quietly().await;
-                Err(e)
             }
+            ExecutionOutcome::Cancelled => self.settle_cancelled(available_task, claim).await,
+            ExecutionOutcome::ClaimLost => Ok(Self::settle_claim_lost(available_task)),
             ExecutionOutcome::Success(output) => {
                 snapshot.clear_retry_state(&available_task.task_id);
-                self.commit_task_result(
-                    workflow.continuation(),
-                    available_task,
-                    snapshot,
-                    output.clone(),
-                    claim,
-                )
-                .await?;
+                if !self
+                    .commit_task_result(
+                        workflow.continuation(),
+                        available_task,
+                        snapshot,
+                        output.clone(),
+                        claim,
+                    )
+                    .await?
+                {
+                    return Ok(Self::settle_claim_lost(available_task));
+                }
                 // After saving the body task result, resolve any parent loop
                 // nodes so that is_workflow_complete() can detect loop completion.
                 Self::resolve_loop_completions(
@@ -1483,49 +1665,71 @@ where
     /// Returns `Some(status)` if the workflow is cancelled or paused
     /// (caller should release claim and return status).
     /// Returns `None` if execution should proceed.
+    ///
+    /// Uses the combined `check_control_signals`, which backends can
+    /// answer with a single probe in the (overwhelmingly common) case of
+    /// no pending signal.
     async fn check_post_claim_guards(
         &self,
         available_task: &AvailableTask,
     ) -> Result<Option<WorkflowStatus>, crate::error::RuntimeError> {
-        if self
+        match self
             .backend
-            .check_and_cancel(&available_task.instance_id, Some(available_task.task_id))
+            .check_control_signals(&available_task.instance_id, Some(available_task.task_id))
             .await?
         {
-            tracing::info!(
-                instance_id = %available_task.instance_id,
-                task_id = %available_task.task_id,
-                "Workflow was cancelled, releasing claim"
-            );
-            return Ok(Some(
-                self.load_cancelled_status(&available_task.instance_id)
+            Some(signal) => Ok(Some(
+                self.signal_status(signal, available_task, "releasing claim")
                     .await,
-            ));
+            )),
+            None => Ok(None),
         }
+    }
 
-        if self
-            .backend
-            .check_and_pause(&available_task.instance_id)
-            .await?
-        {
-            tracing::info!(
-                instance_id = %available_task.instance_id,
-                task_id = %available_task.task_id,
-                "Workflow was paused, releasing claim"
-            );
-            return Ok(Some(
-                self.load_paused_status(&available_task.instance_id).await,
-            ));
+    /// Resolve an applied control signal into the workflow status to
+    /// report, with a uniform log line (`context` says where it was caught).
+    async fn signal_status(
+        &self,
+        signal: ControlSignal,
+        available_task: &AvailableTask,
+        context: &str,
+    ) -> WorkflowStatus {
+        match signal {
+            ControlSignal::Cancelled => {
+                tracing::info!(
+                    instance_id = %available_task.instance_id,
+                    task_id = %available_task.task_id,
+                    "Workflow was cancelled, {context}"
+                );
+                self.load_cancelled_status(&available_task.instance_id)
+                    .await
+            }
+            ControlSignal::Paused => {
+                tracing::info!(
+                    instance_id = %available_task.instance_id,
+                    task_id = %available_task.task_id,
+                    "Workflow was paused, {context}"
+                );
+                self.load_paused_status(&available_task.instance_id).await
+            }
         }
-
-        Ok(None)
     }
 
     /// Execute a future while periodically extending the task claim.
     ///
-    /// If a `deadline` is provided, the heartbeat tick also checks whether the
-    /// deadline has expired. If it has, the task future is dropped (active
-    /// cancellation) and a `TaskTimedOut` error is returned.
+    /// Heartbeats fire at `claim_ttl / 4`, capped at
+    /// [`HEARTBEAT_MAX_INTERVAL`], so a crashed peer's stall window is
+    /// bounded by the TTL while a live worker renews with margin to spare.
+    /// Each tick also:
+    ///
+    /// - checks the task deadline — if expired, the future is dropped
+    ///   (active cancellation) and `Timeout` is returned;
+    /// - probes for a pending cancel signal — long-running tasks get
+    ///   cancelled cooperatively instead of running to completion;
+    /// - escalates lease loss: a `NotFound`/ownership failure from
+    ///   `extend_task_claim`, or [`HEARTBEAT_FAILURE_LIMIT`] consecutive
+    ///   failures of any kind, aborts the task as `ClaimLost` so a stale
+    ///   worker can't keep computing a result it may no longer commit.
     #[tracing::instrument(
         name = "task",
         skip_all,
@@ -1536,7 +1740,7 @@ where
         claim: &ActiveTaskClaim<'_, B>,
         deadline: Option<&TaskDeadline>,
         future: F,
-    ) -> Result<T, crate::error::RuntimeError>
+    ) -> Result<T, HeartbeatInterrupt>
     where
         F: std::future::Future<Output = T>,
     {
@@ -1548,9 +1752,12 @@ where
             return Ok(future.await);
         };
 
-        let interval_duration = ttl / 2;
+        let interval_duration = (ttl / 4)
+            .min(HEARTBEAT_MAX_INTERVAL)
+            .max(Duration::from_millis(1));
         let mut heartbeat_timer = time::interval(interval_duration);
         heartbeat_timer.tick().await; // skip first immediate tick
+        let mut consecutive_failures: u32 = 0;
 
         tokio::pin!(future);
 
@@ -1567,11 +1774,12 @@ where
                             task_id = %dl.task_id,
                             "Task deadline expired during heartbeat, cancelling"
                         );
-                        return Err(WorkflowError::TaskTimedOut {
-                            task_id: dl.task_id,
-                            timeout: std::time::Duration::from_millis(dl.timeout_ms),
-                        }
-                        .into());
+                        return Err(HeartbeatInterrupt::Timeout(
+                            crate::error::RuntimeError::from(WorkflowError::TaskTimedOut {
+                                task_id: dl.task_id,
+                                timeout: std::time::Duration::from_millis(dl.timeout_ms),
+                            }),
+                        ));
                     }
 
                     tracing::trace!(
@@ -1579,21 +1787,59 @@ where
                         task_id = %claim.task_id,
                         "Extending task claim via heartbeat"
                     );
-                    if let Err(e) = self.backend
-                        .extend_task_claim(
+                    // Cooperative-cancel probe and lease extension are
+                    // independent — run them in one round-trip's latency.
+                    let (cancel, extended) = tokio::join!(
+                        self.backend
+                            .get_signal(&claim.instance_id, SignalKind::Cancel),
+                        self.backend.extend_task_claim(
                             &claim.instance_id,
                             &claim.task_id,
                             &claim.worker_id,
                             chrono_ttl,
-                        )
-                        .await
-                    {
-                        tracing::warn!(
+                        ),
+                    );
+
+                    // Don't let a long task run to completion under a
+                    // cancel that arrived mid-flight.
+                    if let Ok(Some(_)) = cancel {
+                        tracing::info!(
                             instance_id = %claim.instance_id,
                             task_id = %claim.task_id,
-                            error = %e,
-                            "Failed to extend task claim"
+                            "Cancel signal during heartbeat, dropping task future"
                         );
+                        return Err(HeartbeatInterrupt::Cancelled);
+                    }
+
+                    match extended {
+                        Ok(()) => consecutive_failures = 0,
+                        // Claim row gone or re-owned: the lease is
+                        // structurally lost, not flaky — abort now.
+                        Err(
+                            e @ (sayiir_persistence::BackendError::NotFound(_)
+                            | sayiir_persistence::BackendError::ClaimLost(_)),
+                        ) => {
+                            tracing::warn!(
+                                instance_id = %claim.instance_id,
+                                task_id = %claim.task_id,
+                                error = %e,
+                                "Claim no longer held, abandoning task"
+                            );
+                            return Err(HeartbeatInterrupt::ClaimLost);
+                        }
+                        Err(e) => {
+                            consecutive_failures += 1;
+                            tracing::warn!(
+                                instance_id = %claim.instance_id,
+                                task_id = %claim.task_id,
+                                error = %e,
+                                consecutive_failures,
+                                "Failed to extend task claim"
+                            );
+                            if consecutive_failures >= HEARTBEAT_FAILURE_LIMIT {
+                                return Err(HeartbeatInterrupt::ClaimLost);
+                            }
+                        }
                     }
                 }
             }
@@ -1601,6 +1847,10 @@ where
     }
 
     /// Persist task result and release the claim.
+    ///
+    /// Returns `Ok(false)` (without persisting) when the claim fence
+    /// rejects the write — the lease was lost mid-execution and the new
+    /// claimant owns the task's outcome.
     async fn commit_task_result(
         &self,
         continuation: &WorkflowContinuation,
@@ -1608,7 +1858,7 @@ where
         snapshot: &mut WorkflowSnapshot,
         output: Bytes,
         claim: ActiveTaskClaim<'_, B>,
-    ) -> Result<(), crate::error::RuntimeError> {
+    ) -> Result<bool, crate::error::RuntimeError> {
         snapshot.mark_task_completed(available_task.task_id, output);
         tracing::debug!(
             instance_id = %available_task.instance_id,
@@ -1621,7 +1871,13 @@ where
         {
             snapshot.trace_parent = crate::trace_context::current_trace_parent();
         }
-        self.backend.save_snapshot(snapshot).await?;
+        if !self
+            .backend
+            .save_snapshot_fenced(snapshot, &claim.task_id, &claim.worker_id)
+            .await?
+        {
+            return Ok(false);
+        }
 
         // If we just entered AtSignal, drain any event that was
         // buffered while the snapshot was still at AtTask. The
@@ -1638,7 +1894,7 @@ where
             .await?;
 
         claim.release().await?;
-        Ok(())
+        Ok(true)
     }
 
     /// If `snapshot` is parked at `AtSignal { signal_name }` and a
@@ -1693,7 +1949,8 @@ where
 
     /// Determine workflow status after a task completes.
     ///
-    /// Checks cancel/pause guards and workflow completion.
+    /// Checks cancel/pause guards (single combined round-trip in the
+    /// common no-signal case) and workflow completion.
     async fn determine_post_task_status(
         &self,
         continuation: &WorkflowContinuation,
@@ -1701,34 +1958,14 @@ where
         snapshot: &mut WorkflowSnapshot,
         output: Bytes,
     ) -> Result<WorkflowStatus, crate::error::RuntimeError> {
-        // Check for cancellation after task completion
-        if self
+        if let Some(signal) = self
             .backend
-            .check_and_cancel(&available_task.instance_id, None)
+            .check_control_signals(&available_task.instance_id, None)
             .await?
         {
-            tracing::info!(
-                instance_id = %available_task.instance_id,
-                task_id = %available_task.task_id,
-                "Workflow was cancelled after task completion"
-            );
             return Ok(self
-                .load_cancelled_status(&available_task.instance_id)
+                .signal_status(signal, available_task, "after task completion")
                 .await);
-        }
-
-        // Check for pause after task completion
-        if self
-            .backend
-            .check_and_pause(&available_task.instance_id)
-            .await?
-        {
-            tracing::info!(
-                instance_id = %available_task.instance_id,
-                task_id = %available_task.task_id,
-                "Workflow was paused after task completion"
-            );
-            return Ok(self.load_paused_status(&available_task.instance_id).await);
         }
 
         if Self::is_workflow_complete(continuation, snapshot) {
@@ -2190,6 +2427,7 @@ where
             registry,
             claim_ttl: Some(Duration::from_mins(5)),
             batch_size: NonZeroUsize::MIN,
+            max_concurrent_tasks: None,
             aging_interval: Duration::from_mins(5),
             tags: vec![],
         }
@@ -2427,6 +2665,7 @@ pub struct PooledWorkerBuilder<B> {
     registry: TaskRegistry,
     claim_ttl: Option<Duration>,
     batch_size: NonZeroUsize,
+    max_concurrent_tasks: Option<NonZeroUsize>,
     aging_interval: Duration,
     tags: Vec<String>,
 }
@@ -2451,10 +2690,18 @@ where
         self
     }
 
-    /// Set the number of tasks to fetch per poll (default: 1).
+    /// Set the default in-flight task cap (default: 1); see
+    /// [`PooledWorker::with_batch_size`].
     #[must_use]
     pub fn batch_size(mut self, size: NonZeroUsize) -> Self {
         self.batch_size = size;
+        self
+    }
+
+    /// Set the in-flight task cap (default: follows `batch_size`).
+    #[must_use]
+    pub fn max_concurrent_tasks(mut self, max: NonZeroUsize) -> Self {
+        self.max_concurrent_tasks = Some(max);
         self
     }
 
@@ -2493,6 +2740,7 @@ where
             registry: Arc::new(self.registry),
             claim_ttl: self.claim_ttl,
             batch_size: self.batch_size,
+            max_concurrent_tasks: self.max_concurrent_tasks,
             aging_interval: self.aging_interval,
             tags: self.tags,
         }

--- a/sayiir-runtime/src/worker.rs
+++ b/sayiir-runtime/src/worker.rs
@@ -625,6 +625,27 @@ where
         }
     }
 
+    /// Wait until the in-flight set has a free slot, reaping finished
+    /// tasks. `Break` means shutdown was requested while waiting.
+    async fn acquire_slot(
+        &self,
+        inflight: &mut tokio::task::JoinSet<()>,
+        cmd_rx: &mut mpsc::Receiver<WorkerCommand>,
+        max_inflight: usize,
+    ) -> std::ops::ControlFlow<()> {
+        loop {
+            while inflight.try_join_next().is_some() {}
+            if inflight.len() < max_inflight {
+                return std::ops::ControlFlow::Continue(());
+            }
+            tokio::select! {
+                biased;
+                _ = cmd_rx.recv() => return std::ops::ControlFlow::Break(()),
+                _ = inflight.join_next() => {}
+            }
+        }
+    }
+
     /// Fetch up to `limit` dispatchable tasks, logging (not propagating)
     /// backend errors so a transient DB outage doesn't kill the worker.
     async fn poll_batch(&self, limit: usize) -> Vec<AvailableTask> {
@@ -705,10 +726,20 @@ where
                 }
             }
 
-            // Fetch up to the free slots — `batch_size` only seeds the
-            // default concurrency; the in-flight cap is the real budget.
-            let limit = max_inflight - inflight.len();
+            // Prefetch up to `batch_size` candidates (claims resolve any
+            // cross-worker races on them) so one dispatch scan amortises
+            // across many executions, but never fewer than the free
+            // slots so concurrency-only configs still fill up. Spawning
+            // is gated on slot availability below.
+            let limit = self.batch_size.get().max(max_inflight - inflight.len());
             for task in self.poll_batch(limit).await {
+                if self
+                    .acquire_slot(&mut inflight, &mut cmd_rx, max_inflight)
+                    .await
+                    .is_break()
+                {
+                    return self.drain_inflight(inflight).await;
+                }
                 if let Ok(WorkerCommand::Shutdown) | Err(mpsc::error::TryRecvError::Disconnected) =
                     cmd_rx.try_recv()
                 {
@@ -1148,10 +1179,20 @@ where
                 continue;
             }
 
-            // Fetch up to the free slots — `batch_size` only seeds the
-            // default concurrency; the in-flight cap is the real budget.
-            let limit = max_inflight - inflight.len();
+            // Prefetch up to `batch_size` candidates (claims resolve any
+            // cross-worker races on them) so one dispatch scan amortises
+            // across many executions, but never fewer than the free
+            // slots so concurrency-only configs still fill up. Spawning
+            // is gated on slot availability below.
+            let limit = self.batch_size.get().max(max_inflight - inflight.len());
             for task in self.poll_batch(limit).await {
+                if self
+                    .acquire_slot(&mut inflight, &mut cmd_rx, max_inflight)
+                    .await
+                    .is_break()
+                {
+                    return self.drain_inflight(inflight).await;
+                }
                 if let Ok(WorkerCommand::Shutdown) | Err(mpsc::error::TryRecvError::Disconnected) =
                     cmd_rx.try_recv()
                 {


### PR DESCRIPTION
## Summary

Performance and resilience overhaul of the Postgres persistence backend and the distributed worker, driven by a full review of both layers.

### Throughput

- **Per-worker task parallelism**: workers now execute up to `max_concurrent_tasks` tasks concurrently (each with its own claim, heartbeat, and fenced commit) instead of strictly one at a time. New knob on `PooledWorker`, exposed in the Python (`max_concurrent_tasks=`) and Node (`maxConcurrentTasks`) bindings; defaults to `batch_size` so existing configs are unchanged.
- **Index-ordered dispatch query**: `find_available_tasks` replaces the non-SARGable aging `ORDER BY` (full sort of every InProgress row per poll, ~190 ms @ 200k rows) with two `LIMIT`-bounded index-ordered arms (best-priority + oldest-first, migration 010) and exact aging scored in Rust over the small candidate set. Aging is now approximate but starvation-free.
- **Zero-copy dispatch**: the winning worker takes ownership of the dispatch snapshot (`AvailableTask::take_snapshot`) instead of deep-cloning it per task.
- **Fewer round-trips per task**: combined cancel+pause probe (1 PK lookup instead of 2 `FOR UPDATE` transactions in the common no-signal case), `load_task_result` PK fast path on `sayiir_workflow_tasks` (no blob decode), single-statement `delete_snapshot`, JSON branch envelopes spliced via `RawValue` instead of re-parsing.
- **Wakeup hint coalescing** by `(instance, task)` so duplicate NOTIFY hints can't crowd other instances out of the channel; the LISTEN connection is now dedicated (no longer occupies a pool slot when connecting by URL).
- **Pool defaults** raised to 20 max / 2 warm connections.

### Resilience

- **Task failures no longer kill workers**: a task timeout previously shut the whole worker down — one poison workflow could serially drain a fleet. Timeouts/panics/errors now settle that workflow only, and exhausted retries durably mark it `Failed` (fixing a hot-loop where a failing task with spent retries was re-offered at poll speed forever). Transient backend errors on the poll path are logged and retried, not fatal.
- **Fenced commits**: snapshot writes from a worker are gated on still owning the task claim, in one transaction (`save_snapshot_fenced`). A worker whose lease expired mid-execution can no longer overwrite the new claimant's progress.
- **Lease-loss detection**: heartbeats run at `ttl/4` (capped 15 s, was `ttl/2` = 2.5 min) so crashed-worker recovery is fast; a stolen/vanished claim (`BackendError::ClaimLost`) aborts the running task immediately, repeated extension failures abort after 3 strikes.
- **Cooperative cancellation**: heartbeat ticks probe for pending cancel signals and drop the running task future, instead of letting long tasks run to completion under a cancel.
- **Transient-error retry** (serialization failure / deadlock / connection drop) with exponential backoff on `save_task_result`, the hottest read-modify-write transaction.

### Benchmarks

`linear` (5000 workflows × 4 steps, 8 workers): parallelism 4 cut total wall-clock 21% and raised average throughput 26% vs parallelism 1 (66 vs 52 wf/s avg) on a laptop run. Bench workloads now pin worker parallelism to 2 via the new knob.

### Notes

- Migration `010_dispatch_indexes.sql` adds one partial index for the oldest-first dispatch arm.
- `sayiir_workflow_snapshot_history` retention was prototyped and deliberately dropped from this PR (deferred to a later tier); history growth remains unbounded by default, as before.
- Known pre-existing edge left unchanged: `drain_pending_signal` consumes a buffered event before persisting the advanced snapshot; a crash between the two loses that event.